### PR TITLE
fix: undo/redo

### DIFF
--- a/src/ecsScene/scene.ts
+++ b/src/ecsScene/scene.ts
@@ -30,13 +30,13 @@ function handleExternalAction(message: { type: string; payload: Record<string, a
 
       createComponents(components)
       createEntities(entities)
-      // TODO: remove unused components
-      // TODO: remove unused entities
+      removeUnusedComponents(components)
+      removeUnusedEntities(entities)
       break
   }
 }
 
-function createComponents(components: AnyComponent[]) {
+function createComponents(components: Record<string, AnyComponent>) {
   for (let id in components) {
     const { type, data } = components[id]
 
@@ -64,7 +64,7 @@ function createComponents(components: AnyComponent[]) {
   }
 }
 
-function createEntities(entities: EntityDefinition[]) {
+function createEntities(entities: Record<string, EntityDefinition>) {
   for (let id in entities) {
     let entity: Entity = engine.entities[id]
 
@@ -81,6 +81,37 @@ function createEntities(entities: EntityDefinition[]) {
       if (component) {
         entity.set(component)
       }
+    }
+  }
+}
+
+function removeUnusedComponents(components: Record<string, AnyComponent>) {
+  for (const componentId in editorComponents) {
+    const inScene = componentId in components
+    if (!inScene) {
+      const originalComponent = editorComponents[componentId]
+
+      if (componentId in engine.disposableComponents) {
+        engine.disposeComponent(originalComponent)
+      }
+
+      // TODO: Remove component from all entities that have added it (we need the engine to provide a way of doing this)
+      /* pseudo code:
+      for each entity in engine.entities:
+        if entity.has(component)
+          entity.remove(component)
+      */
+
+      delete editorComponents[componentId]
+    }
+  }
+}
+
+function removeUnusedEntities(entities: Record<string, EntityDefinition>) {
+  for (const entityId in engine.entities) {
+    const inScene = entityId in entities
+    if (!inScene) {
+      engine.removeEntity(engine.entities[entityId])
     }
   }
 }

--- a/src/modules/common/store.ts
+++ b/src/modules/common/store.ts
@@ -28,7 +28,7 @@ const loggerMiddleware = createLogger({
 
 const { storageMiddleware, loadStorageMiddleware } = createStorageMiddleware({
   storageKey: env.get('REACT_APP_LOCAL_STORAGE_KEY'),
-  paths: ['project', 'scene'],
+  paths: ['project', ['scene', 'present']] as any,
   actions: [CREATE_PROJECT, CREATE_SCENE, PROVISION_SCENE]
 })
 const middlewares = [historyMiddleware, storageMiddleware, sagasMiddleware, loggerMiddleware]

--- a/src/modules/common/store.ts
+++ b/src/modules/common/store.ts
@@ -10,7 +10,7 @@ import { createStorageMiddleware } from 'decentraland-dapps/dist/modules/storage
 import { createRootReducer } from './reducer'
 import { rootSaga } from './sagas'
 import { scenarioMiddleware, eventEmitter } from 'scenarios/helpers/middleware'
-import { CREATE_SCENE, PROVISION_SCENE } from 'modules/scene/actions'
+import { CREATE_SCENE, PROVISION_SCENE, UPDATE_TRANSFORM } from 'modules/scene/actions'
 import { CREATE_PROJECT } from 'modules/project/actions'
 import { EDITOR_UNDO, EDITOR_REDO } from 'modules/editor/actions'
 
@@ -30,7 +30,7 @@ const loggerMiddleware = createLogger({
 const { storageMiddleware, loadStorageMiddleware } = createStorageMiddleware({
   storageKey: env.get('REACT_APP_LOCAL_STORAGE_KEY'),
   paths: ['project', ['scene', 'present']] as any,
-  actions: [CREATE_PROJECT, CREATE_SCENE, PROVISION_SCENE, EDITOR_UNDO, EDITOR_REDO]
+  actions: [CREATE_PROJECT, CREATE_SCENE, PROVISION_SCENE, EDITOR_UNDO, EDITOR_REDO, UPDATE_TRANSFORM]
 })
 const middlewares = [historyMiddleware, storageMiddleware, sagasMiddleware, loggerMiddleware]
 

--- a/src/modules/common/store.ts
+++ b/src/modules/common/store.ts
@@ -12,6 +12,7 @@ import { rootSaga } from './sagas'
 import { scenarioMiddleware, eventEmitter } from 'scenarios/helpers/middleware'
 import { CREATE_SCENE, PROVISION_SCENE } from 'modules/scene/actions'
 import { CREATE_PROJECT } from 'modules/project/actions'
+import { EDITOR_UNDO, EDITOR_REDO } from 'modules/editor/actions'
 
 // @ts-ignore: Dev tools
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
@@ -29,7 +30,7 @@ const loggerMiddleware = createLogger({
 const { storageMiddleware, loadStorageMiddleware } = createStorageMiddleware({
   storageKey: env.get('REACT_APP_LOCAL_STORAGE_KEY'),
   paths: ['project', ['scene', 'present']] as any,
-  actions: [CREATE_PROJECT, CREATE_SCENE, PROVISION_SCENE]
+  actions: [CREATE_PROJECT, CREATE_SCENE, PROVISION_SCENE, EDITOR_UNDO, EDITOR_REDO]
 })
 const middlewares = [historyMiddleware, storageMiddleware, sagasMiddleware, loggerMiddleware]
 

--- a/src/modules/scene/reducer.ts
+++ b/src/modules/scene/reducer.ts
@@ -10,8 +10,7 @@ import {
   UpdateMetricsAction,
   UPDATE_METRICS,
   UPDATE_TRANSFORM,
-  UpdateComponentAction,
-  ADD_ASSET
+  UpdateComponentAction
 } from 'modules/scene/actions'
 
 export type SceneState = {
@@ -116,10 +115,19 @@ const baseSceneReducer = (state: SceneState = INITIAL_STATE, action: SceneReduce
 
 // This is typed `as any` because undoable uses AnyAction from redux which doesn't account for the payload we use
 // so types don't match
-export const sceneReducer = undoable<SceneState>(baseSceneReducer as any, {
+const undoableReducer = undoable<SceneState>(baseSceneReducer as any, {
   limit: 48,
   undoType: EDITOR_UNDO,
   redoType: EDITOR_REDO,
   clearHistoryType: CLOSE_EDITOR,
-  filter: includeAction([UPDATE_TRANSFORM, PROVISION_SCENE])
+  filter: includeAction([CREATE_SCENE, PROVISION_SCENE, UPDATE_TRANSFORM])
 })
+
+export const sceneReducer = (state: any, action: any) => {
+  const newState = undoableReducer(state, action)
+  // This prevents going back to a broken state after creating a new scene
+  if (action.type === CREATE_SCENE) {
+    newState.past.pop()
+  }
+  return newState
+}

--- a/src/modules/scene/reducer.ts
+++ b/src/modules/scene/reducer.ts
@@ -1,6 +1,6 @@
-import undoable, { StateWithHistory } from 'redux-undo'
+import undoable, { StateWithHistory, includeAction } from 'redux-undo'
 import { loadingReducer, LoadingState } from 'decentraland-dapps/dist/modules/loading/reducer'
-import { EDITOR_UNDO, EDITOR_REDO } from 'modules/editor/actions'
+import { EDITOR_UNDO, EDITOR_REDO, CLOSE_EDITOR } from 'modules/editor/actions'
 import { SceneDefinition } from 'modules/scene/types'
 import {
   CreateSceneAction,
@@ -10,7 +10,8 @@ import {
   UpdateMetricsAction,
   UPDATE_METRICS,
   UPDATE_TRANSFORM,
-  UpdateComponentAction
+  UpdateComponentAction,
+  ADD_ASSET
 } from 'modules/scene/actions'
 
 export type SceneState = {
@@ -118,5 +119,7 @@ const baseSceneReducer = (state: SceneState = INITIAL_STATE, action: SceneReduce
 export const sceneReducer = undoable<SceneState>(baseSceneReducer as any, {
   limit: 48,
   undoType: EDITOR_UNDO,
-  redoType: EDITOR_REDO
+  redoType: EDITOR_REDO,
+  clearHistoryType: CLOSE_EDITOR,
+  filter: includeAction([UPDATE_TRANSFORM, PROVISION_SCENE])
 })

--- a/src/modules/scene/selectors.ts
+++ b/src/modules/scene/selectors.ts
@@ -35,7 +35,7 @@ export const getEntityComponents = (entityId: string) =>
     (entities, components) => {
       let out: Record<string, AnyComponent> = {}
 
-      if (entityId && entities) {
+      if (entityId && entities && entityId in entities) {
         const componentReferences = entities[entityId].components
 
         for (let componentId of componentReferences) {


### PR DESCRIPTION
Closes #90 

- Prevent going to broken states by tracking the right actions and removing broken states from history. I had to remove to track the `CREATE_SCENE` action but also I had to remove it from the past history, otherwise if you undo all the way back you could reach a point where the scene was not created yet, thus this code:

```tsx
export const sceneReducer = (state: any, action: any) => {
  const newState = undoableReducer(state, action)
  // This prevents going back to a broken state after creating a new scene
  if (action.type === CREATE_SCENE) {
    newState.past.pop()
  }
  return newState
}
```

- Remove unused components and entities from scene (before this PR undoing would not remove stuff you added to the scene). The engine still doesn't provide a way to remove the unused components from the entities so I left a TODO there (but for the current use cases it doesn't matter because when we remove a component we also remove the entity all together, so it's okay for now we can add that later).

- Prevent saving past/future history in localstorage (I had to use an `any` there because the types in `decentraland-dapps` are wrong and it doesn't support nested arrays of strings, although the library underneath does support that.

- Fixed race conditions where an entity is already removed from the redux store but it is still in the client's scene and some event is dispatched from that entity before it is removed from the scene.

- Clear history after closing the editor

- Save project to localstorage after doing undo/redo