### PR TITLE
feat: reset/duplicate/delete item

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "7.0.0"
       }
     },
     "@babel/core": {
@@ -17,20 +17,20 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.6.tgz",
       "integrity": "sha512-Hz6PJT6e44iUNpAn8AoyAs6B3bl60g7MJQaI0rZEar6ECzh6+srYO1xlIdssio34mPaUtAb1y+XlkkSJzok3yw==",
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.1.6",
-        "@babel/helpers": "^7.1.5",
-        "@babel/parser": "^7.1.6",
-        "@babel/template": "^7.1.2",
-        "@babel/traverse": "^7.1.6",
-        "@babel/types": "^7.1.6",
-        "convert-source-map": "^1.1.0",
-        "debug": "^4.1.0",
-        "json5": "^2.1.0",
-        "lodash": "^4.17.10",
-        "resolve": "^1.3.2",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
+        "@babel/code-frame": "7.0.0",
+        "@babel/generator": "7.3.0",
+        "@babel/helpers": "7.3.1",
+        "@babel/parser": "7.3.1",
+        "@babel/template": "7.2.2",
+        "@babel/traverse": "7.2.3",
+        "@babel/types": "7.3.0",
+        "convert-source-map": "1.6.0",
+        "debug": "4.1.1",
+        "json5": "2.1.0",
+        "lodash": "4.17.11",
+        "resolve": "1.8.1",
+        "semver": "5.6.0",
+        "source-map": "0.5.7"
       }
     },
     "@babel/generator": {
@@ -38,11 +38,11 @@
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.0.tgz",
       "integrity": "sha512-dZTwMvTgWfhmibq4V9X+LMf6Bgl7zAodRn9PvcPdhlzFMbvUutx74dbEv7Atz3ToeEpevYEJtAwfxq/bDCzHWg==",
       "requires": {
-        "@babel/types": "^7.3.0",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.10",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "@babel/types": "7.3.0",
+        "jsesc": "2.5.2",
+        "lodash": "4.17.11",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       }
     },
     "@babel/helper-annotate-as-pure": {
@@ -50,7 +50,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
       "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -58,8 +58,8 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
       "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
       "requires": {
-        "@babel/helper-explode-assignable-expression": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-explode-assignable-expression": "7.1.0",
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/helper-builder-react-jsx": {
@@ -67,8 +67,8 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz",
       "integrity": "sha512-MjA9KgwCuPEkQd9ncSXvSyJ5y+j2sICHyrI0M3L+6fnS4wMSNDc1ARXsbTfbb2cXHn17VisSnU/sHFTCxVxSMw==",
       "requires": {
-        "@babel/types": "^7.3.0",
-        "esutils": "^2.0.0"
+        "@babel/types": "7.3.0",
+        "esutils": "2.0.2"
       }
     },
     "@babel/helper-call-delegate": {
@@ -76,9 +76,9 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz",
       "integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
       "requires": {
-        "@babel/helper-hoist-variables": "^7.0.0",
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-hoist-variables": "7.0.0",
+        "@babel/traverse": "7.2.3",
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/helper-define-map": {
@@ -86,9 +86,9 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
       "integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/types": "^7.0.0",
-        "lodash": "^4.17.10"
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/types": "7.3.0",
+        "lodash": "4.17.11"
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -96,8 +96,8 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
       "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
       "requires": {
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/traverse": "7.2.3",
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/helper-function-name": {
@@ -105,9 +105,9 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
       "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
       "requires": {
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-get-function-arity": "7.0.0",
+        "@babel/template": "7.2.2",
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -115,7 +115,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/helper-hoist-variables": {
@@ -123,7 +123,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
       "integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -131,7 +131,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
       "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/helper-module-imports": {
@@ -139,7 +139,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/helper-module-transforms": {
@@ -147,12 +147,12 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.2.2.tgz",
       "integrity": "sha512-YRD7I6Wsv+IHuTPkAmAS4HhY0dkPobgLftHp0cRGZSdrRvmZY8rFvae/GVu3bD00qscuvK3WPHB3YdNpBXUqrA==",
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-simple-access": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/template": "^7.2.2",
-        "@babel/types": "^7.2.2",
-        "lodash": "^4.17.10"
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-simple-access": "7.1.0",
+        "@babel/helper-split-export-declaration": "7.0.0",
+        "@babel/template": "7.2.2",
+        "@babel/types": "7.3.0",
+        "lodash": "4.17.11"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -160,7 +160,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
       "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -173,7 +173,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
       "integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -181,11 +181,11 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
       "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-wrap-function": "^7.1.0",
-        "@babel/template": "^7.1.0",
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-wrap-function": "7.2.0",
+        "@babel/template": "7.2.2",
+        "@babel/traverse": "7.2.3",
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/helper-replace-supers": {
@@ -193,10 +193,10 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.2.3.tgz",
       "integrity": "sha512-GyieIznGUfPXPWu0yLS6U55Mz67AZD9cUk0BfirOWlPrXlBcan9Gz+vHGz+cPfuoweZSnPzPIm67VtQM0OWZbA==",
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.0.0",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/traverse": "^7.2.3",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-member-expression-to-functions": "7.0.0",
+        "@babel/helper-optimise-call-expression": "7.0.0",
+        "@babel/traverse": "7.2.3",
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/helper-simple-access": {
@@ -204,8 +204,8 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
       "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
       "requires": {
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/template": "7.2.2",
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -213,7 +213,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
       "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/helper-wrap-function": {
@@ -221,10 +221,10 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
       "integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/template": "^7.1.0",
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.2.0"
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/template": "7.2.2",
+        "@babel/traverse": "7.2.3",
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/helpers": {
@@ -232,9 +232,9 @@
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.3.1.tgz",
       "integrity": "sha512-Q82R3jKsVpUV99mgX50gOPCWwco9Ec5Iln/8Vyu4osNIOQgSrd9RFrQeUvmvddFNoLwMyOUWU+5ckioEKpDoGA==",
       "requires": {
-        "@babel/template": "^7.1.2",
-        "@babel/traverse": "^7.1.5",
-        "@babel/types": "^7.3.0"
+        "@babel/template": "7.2.2",
+        "@babel/traverse": "7.2.3",
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/highlight": {
@@ -242,9 +242,9 @@
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
       "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^4.0.0"
+        "chalk": "2.4.1",
+        "esutils": "2.0.2",
+        "js-tokens": "4.0.0"
       }
     },
     "@babel/parser": {
@@ -257,9 +257,9 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
       "integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-remap-async-to-generator": "^7.1.0",
-        "@babel/plugin-syntax-async-generators": "^7.2.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-remap-async-to-generator": "7.1.0",
+        "@babel/plugin-syntax-async-generators": "7.2.0"
       }
     },
     "@babel/plugin-proposal-class-properties": {
@@ -267,12 +267,12 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz",
       "integrity": "sha512-/PCJWN+CKt5v1xcGn4vnuu13QDoV+P7NcICP44BoonAJoPSGwVkgrXihFIQGiEjjPlUDBIw1cM7wYFLARS2/hw==",
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-member-expression-to-functions": "^7.0.0",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.1.0",
-        "@babel/plugin-syntax-class-properties": "^7.0.0"
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-member-expression-to-functions": "7.0.0",
+        "@babel/helper-optimise-call-expression": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-replace-supers": "7.2.3",
+        "@babel/plugin-syntax-class-properties": "7.2.0"
       }
     },
     "@babel/plugin-proposal-decorators": {
@@ -280,10 +280,10 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.1.6.tgz",
       "integrity": "sha512-U42f8KhUbtlhUDyV/wK4Rq/wWh8vWyttYABckG/v0vVnMPvayOewZC/83CbVdmyP+UhEqI368FEQ7hHMfhBpQA==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/plugin-syntax-decorators": "^7.1.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-replace-supers": "7.2.3",
+        "@babel/helper-split-export-declaration": "7.0.0",
+        "@babel/plugin-syntax-decorators": "7.2.0"
       }
     },
     "@babel/plugin-proposal-json-strings": {
@@ -291,8 +291,8 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
       "integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-json-strings": "^7.2.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-json-strings": "7.2.0"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
@@ -300,8 +300,8 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.1.tgz",
       "integrity": "sha512-Nmmv1+3LqxJu/V5jU9vJmxR/KIRWFk2qLHmbB56yRRRFhlaSuOVXscX3gUmhaKgUhzA3otOHVubbIEVYsZ0eZg==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "7.2.0"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
@@ -309,8 +309,8 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "7.2.0"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
@@ -318,9 +318,9 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.2.0.tgz",
       "integrity": "sha512-LvRVYb7kikuOtIoUeWTkOxQEV1kYvL5B6U3iWEGCzPNRus1MzJweFqORTj+0jkxozkTSYNJozPOddxmqdqsRpw==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
-        "regexpu-core": "^4.2.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.0.0",
+        "regexpu-core": "4.4.0"
       }
     },
     "@babel/plugin-syntax-async-generators": {
@@ -328,7 +328,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
       "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-class-properties": {
@@ -336,7 +336,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.2.0.tgz",
       "integrity": "sha512-UxYaGXYQ7rrKJS/PxIKRkv3exi05oH7rokBAsmCSsCxz1sVPZ7Fu6FzKoGgUvmY+0YgSkYHgUoCh5R5bCNBQlw==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-decorators": {
@@ -344,7 +344,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz",
       "integrity": "sha512-38QdqVoXdHUQfTpZo3rQwqQdWtCn5tMv4uV6r2RMfTqNBuv4ZBhz79SfaQWKTVmxHjeFv/DnXVC/+agHCklYWA==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-dynamic-import": {
@@ -352,7 +352,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0.tgz",
       "integrity": "sha512-Gt9xNyRrCHCiyX/ZxDGOcBnlJl0I3IWicpZRC4CdC0P5a/I07Ya2OAMEBU+J7GmRFVmIetqEYRko6QYRuKOESw==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-flow": {
@@ -360,7 +360,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.2.0.tgz",
       "integrity": "sha512-r6YMuZDWLtLlu0kqIim5o/3TNRAlWb073HwT3e2nKf9I8IIvOggPrnILYPsrrKilmn/mYEMCf/Z07w3yQJF6dg==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-json-strings": {
@@ -368,7 +368,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
       "integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-jsx": {
@@ -376,7 +376,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
       "integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
@@ -384,7 +384,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
       "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-optional-catch-binding": {
@@ -392,7 +392,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-typescript": {
@@ -400,7 +400,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.2.0.tgz",
       "integrity": "sha512-WhKr6yu6yGpGcNMVgIBuI9MkredpVc7Y3YR4UzEZmDztHoL6wV56YBHLhWnjO1EvId1B32HrD3DRFc+zSoKI1g==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
@@ -408,7 +408,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
       "integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
@@ -416,9 +416,9 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.2.0.tgz",
       "integrity": "sha512-CEHzg4g5UraReozI9D4fblBYABs7IM6UerAVG7EJVrTLC5keh00aEuLUT+O40+mJCEzaXkYfTCUKIyeDfMOFFQ==",
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-remap-async-to-generator": "^7.1.0"
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-remap-async-to-generator": "7.1.0"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
@@ -426,7 +426,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
       "integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-block-scoping": {
@@ -434,8 +434,8 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.2.0.tgz",
       "integrity": "sha512-vDTgf19ZEV6mx35yiPJe4fS02mPQUUcBNwWQSZFXSzTSbsJFQvHt7DqyS3LK8oOWALFOsJ+8bbqBgkirZteD5Q==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "lodash": "^4.17.10"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "lodash": "4.17.11"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -443,14 +443,14 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.2.2.tgz",
       "integrity": "sha512-gEZvgTy1VtcDOaQty1l10T3jQmJKlNVxLDCs+3rCVPr6nMkODLELxViq5X9l+rfxbie3XrfrMCYYY6eX3aOcOQ==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-define-map": "^7.1.0",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "globals": "^11.1.0"
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-define-map": "7.1.0",
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-optimise-call-expression": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-replace-supers": "7.2.3",
+        "@babel/helper-split-export-declaration": "7.0.0",
+        "globals": "11.10.0"
       }
     },
     "@babel/plugin-transform-computed-properties": {
@@ -458,7 +458,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
       "integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-destructuring": {
@@ -466,7 +466,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.2.0.tgz",
       "integrity": "sha512-coVO2Ayv7g0qdDbrNiadE4bU7lvCd9H539m2gMknyVjjMdwF/iCOM7R+E8PkntoqLkltO0rk+3axhpp/0v68VQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
@@ -474,9 +474,9 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.2.0.tgz",
       "integrity": "sha512-sKxnyHfizweTgKZf7XsXu/CNupKhzijptfTM+bozonIuyVrLWVUvYjE2bhuSBML8VQeMxq4Mm63Q9qvcvUcciQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
-        "regexpu-core": "^4.1.3"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.0.0",
+        "regexpu-core": "4.4.0"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
@@ -484,7 +484,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.2.0.tgz",
       "integrity": "sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
@@ -492,8 +492,8 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
       "integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.1.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-flow-strip-types": {
@@ -501,8 +501,8 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.1.6.tgz",
       "integrity": "sha512-0tyFAAjJmnRlr8MVJV39ASn1hv+PbdVP71hf7aAseqLfQ0o9QXk9htbMbq7/ZYXnUIp6gDw0lUUP0+PQMbbtmg==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-flow": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-flow": "7.2.0"
       }
     },
     "@babel/plugin-transform-for-of": {
@@ -510,7 +510,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.2.0.tgz",
       "integrity": "sha512-Kz7Mt0SsV2tQk6jG5bBv5phVbkd0gd27SgYD4hH1aLMJRchM0dzHaXvrWhVZ+WxAlDoAKZ7Uy3jVTW2mKXQ1WQ==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-function-name": {
@@ -518,8 +518,8 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.2.0.tgz",
       "integrity": "sha512-kWgksow9lHdvBC2Z4mxTsvc7YdY7w/V6B2vy9cTIPtLEE9NhwoWivaxdNM/S37elu5bqlLP/qOY906LukO9lkQ==",
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-literals": {
@@ -527,7 +527,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
       "integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-modules-amd": {
@@ -535,8 +535,8 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
       "integrity": "sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==",
       "requires": {
-        "@babel/helper-module-transforms": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-module-transforms": "7.2.2",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
@@ -544,9 +544,9 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz",
       "integrity": "sha512-V6y0uaUQrQPXUrmj+hgnks8va2L0zcZymeU7TtWEgdRLNkceafKXEduv7QzgQAE4lT+suwooG9dC7LFhdRAbVQ==",
       "requires": {
-        "@babel/helper-module-transforms": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-simple-access": "^7.1.0"
+        "@babel/helper-module-transforms": "7.2.2",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-simple-access": "7.1.0"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
@@ -554,8 +554,8 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.2.0.tgz",
       "integrity": "sha512-aYJwpAhoK9a+1+O625WIjvMY11wkB/ok0WClVwmeo3mCjcNRjt+/8gHWrB5i+00mUju0gWsBkQnPpdvQ7PImmQ==",
       "requires": {
-        "@babel/helper-hoist-variables": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-hoist-variables": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-modules-umd": {
@@ -563,8 +563,8 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
       "integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
       "requires": {
-        "@babel/helper-module-transforms": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-module-transforms": "7.2.2",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
@@ -572,7 +572,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.3.0.tgz",
       "integrity": "sha512-NxIoNVhk9ZxS+9lSoAQ/LM0V2UEvARLttEHUrRDGKFaAxOYQcrkN/nLRE+BbbicCAvZPl7wMP0X60HsHE5DtQw==",
       "requires": {
-        "regexp-tree": "^0.1.0"
+        "regexp-tree": "0.1.1"
       }
     },
     "@babel/plugin-transform-new-target": {
@@ -580,7 +580,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz",
       "integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-object-super": {
@@ -588,8 +588,8 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
       "integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.1.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-replace-supers": "7.2.3"
       }
     },
     "@babel/plugin-transform-parameters": {
@@ -597,9 +597,9 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.2.0.tgz",
       "integrity": "sha512-kB9+hhUidIgUoBQ0MsxMewhzr8i60nMa2KgeJKQWYrqQpqcBYtnpR+JgkadZVZoaEZ/eKu9mclFaVwhRpLNSzA==",
       "requires": {
-        "@babel/helper-call-delegate": "^7.1.0",
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-call-delegate": "7.1.0",
+        "@babel/helper-get-function-arity": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-react-constant-elements": {
@@ -607,8 +607,8 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.2.0.tgz",
       "integrity": "sha512-YYQFg6giRFMsZPKUM9v+VcHOdfSQdz9jHCx3akAi3UYgyjndmdYGSXylQ/V+HswQt4fL8IklchD9HTsaOCrWQQ==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-react-display-name": {
@@ -616,7 +616,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
       "integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-react-jsx": {
@@ -624,9 +624,9 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz",
       "integrity": "sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==",
       "requires": {
-        "@babel/helper-builder-react-jsx": "^7.3.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-jsx": "^7.2.0"
+        "@babel/helper-builder-react-jsx": "7.3.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-jsx": "7.2.0"
       }
     },
     "@babel/plugin-transform-react-jsx-self": {
@@ -634,8 +634,8 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz",
       "integrity": "sha512-v6S5L/myicZEy+jr6ielB0OR8h+EH/1QFx/YJ7c7Ua+7lqsjj/vW6fD5FR9hB/6y7mGbfT4vAURn3xqBxsUcdg==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-jsx": "^7.2.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-jsx": "7.2.0"
       }
     },
     "@babel/plugin-transform-react-jsx-source": {
@@ -643,8 +643,8 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.2.0.tgz",
       "integrity": "sha512-A32OkKTp4i5U6aE88GwwcuV4HAprUgHcTq0sSafLxjr6AW0QahrCRCjxogkbbcdtpbXkuTOlgpjophCxb6sh5g==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-jsx": "^7.2.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-jsx": "7.2.0"
       }
     },
     "@babel/plugin-transform-regenerator": {
@@ -652,7 +652,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
       "integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
       "requires": {
-        "regenerator-transform": "^0.13.3"
+        "regenerator-transform": "0.13.3"
       }
     },
     "@babel/plugin-transform-runtime": {
@@ -660,10 +660,10 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.1.0.tgz",
       "integrity": "sha512-WFLMgzu5DLQEah0lKTJzYb14vd6UiES7PTnXcvrPZ1VrwFeJ+mTbvr65fFAsXYMt2bIoOoC0jk76zY1S7HZjUg==",
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "resolve": "^1.8.1",
-        "semver": "^5.5.1"
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "resolve": "1.8.1",
+        "semver": "5.6.0"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
@@ -671,7 +671,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
       "integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-spread": {
@@ -679,7 +679,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
       "integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
@@ -687,8 +687,8 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
       "integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.0.0"
       }
     },
     "@babel/plugin-transform-template-literals": {
@@ -696,8 +696,8 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.2.0.tgz",
       "integrity": "sha512-FkPix00J9A/XWXv4VoKJBMeSkyY9x/TqIh76wzcdfl57RJJcf8CehQ08uwfhCDNtRQYtHQKBTwKZDEyjE13Lwg==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
@@ -705,7 +705,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
       "integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-typescript": {
@@ -713,8 +713,8 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.2.0.tgz",
       "integrity": "sha512-EnI7i2/gJ7ZNr2MuyvN2Hu+BHJENlxWte5XygPvfj/MbvtOkWor9zcnHpMMQL2YYaaCcqtIvJUyJ7QVfoGs7ew==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-typescript": "^7.2.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-typescript": "7.2.0"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
@@ -722,9 +722,9 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.2.0.tgz",
       "integrity": "sha512-m48Y0lMhrbXEJnVUaYly29jRXbQ3ksxPrS1Tg8t+MHqzXhtBYAvI51euOBaoAlZLPHsieY9XPVMf80a5x0cPcA==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
-        "regexpu-core": "^4.1.3"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.0.0",
+        "regexpu-core": "4.4.0"
       }
     },
     "@babel/preset-env": {
@@ -732,49 +732,49 @@
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.1.tgz",
       "integrity": "sha512-FHKrD6Dxf30e8xgHQO0zJZpUPfVZg+Xwgz5/RdSWCbza9QLNk4Qbp40ctRoqDxml3O8RMzB1DU55SXeDG6PqHQ==",
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-        "@babel/plugin-proposal-json-strings": "^7.2.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.3.1",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.2.0",
-        "@babel/plugin-syntax-async-generators": "^7.2.0",
-        "@babel/plugin-syntax-json-strings": "^7.2.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
-        "@babel/plugin-transform-arrow-functions": "^7.2.0",
-        "@babel/plugin-transform-async-to-generator": "^7.2.0",
-        "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-        "@babel/plugin-transform-block-scoping": "^7.2.0",
-        "@babel/plugin-transform-classes": "^7.2.0",
-        "@babel/plugin-transform-computed-properties": "^7.2.0",
-        "@babel/plugin-transform-destructuring": "^7.2.0",
-        "@babel/plugin-transform-dotall-regex": "^7.2.0",
-        "@babel/plugin-transform-duplicate-keys": "^7.2.0",
-        "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-        "@babel/plugin-transform-for-of": "^7.2.0",
-        "@babel/plugin-transform-function-name": "^7.2.0",
-        "@babel/plugin-transform-literals": "^7.2.0",
-        "@babel/plugin-transform-modules-amd": "^7.2.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.2.0",
-        "@babel/plugin-transform-modules-systemjs": "^7.2.0",
-        "@babel/plugin-transform-modules-umd": "^7.2.0",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.3.0",
-        "@babel/plugin-transform-new-target": "^7.0.0",
-        "@babel/plugin-transform-object-super": "^7.2.0",
-        "@babel/plugin-transform-parameters": "^7.2.0",
-        "@babel/plugin-transform-regenerator": "^7.0.0",
-        "@babel/plugin-transform-shorthand-properties": "^7.2.0",
-        "@babel/plugin-transform-spread": "^7.2.0",
-        "@babel/plugin-transform-sticky-regex": "^7.2.0",
-        "@babel/plugin-transform-template-literals": "^7.2.0",
-        "@babel/plugin-transform-typeof-symbol": "^7.2.0",
-        "@babel/plugin-transform-unicode-regex": "^7.2.0",
-        "browserslist": "^4.3.4",
-        "invariant": "^2.2.2",
-        "js-levenshtein": "^1.1.3",
-        "semver": "^5.3.0"
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-proposal-async-generator-functions": "7.2.0",
+        "@babel/plugin-proposal-json-strings": "7.2.0",
+        "@babel/plugin-proposal-object-rest-spread": "7.3.1",
+        "@babel/plugin-proposal-optional-catch-binding": "7.2.0",
+        "@babel/plugin-proposal-unicode-property-regex": "7.2.0",
+        "@babel/plugin-syntax-async-generators": "7.2.0",
+        "@babel/plugin-syntax-json-strings": "7.2.0",
+        "@babel/plugin-syntax-object-rest-spread": "7.2.0",
+        "@babel/plugin-syntax-optional-catch-binding": "7.2.0",
+        "@babel/plugin-transform-arrow-functions": "7.2.0",
+        "@babel/plugin-transform-async-to-generator": "7.2.0",
+        "@babel/plugin-transform-block-scoped-functions": "7.2.0",
+        "@babel/plugin-transform-block-scoping": "7.2.0",
+        "@babel/plugin-transform-classes": "7.2.2",
+        "@babel/plugin-transform-computed-properties": "7.2.0",
+        "@babel/plugin-transform-destructuring": "7.2.0",
+        "@babel/plugin-transform-dotall-regex": "7.2.0",
+        "@babel/plugin-transform-duplicate-keys": "7.2.0",
+        "@babel/plugin-transform-exponentiation-operator": "7.2.0",
+        "@babel/plugin-transform-for-of": "7.2.0",
+        "@babel/plugin-transform-function-name": "7.2.0",
+        "@babel/plugin-transform-literals": "7.2.0",
+        "@babel/plugin-transform-modules-amd": "7.2.0",
+        "@babel/plugin-transform-modules-commonjs": "7.2.0",
+        "@babel/plugin-transform-modules-systemjs": "7.2.0",
+        "@babel/plugin-transform-modules-umd": "7.2.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "7.3.0",
+        "@babel/plugin-transform-new-target": "7.0.0",
+        "@babel/plugin-transform-object-super": "7.2.0",
+        "@babel/plugin-transform-parameters": "7.2.0",
+        "@babel/plugin-transform-regenerator": "7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "7.2.0",
+        "@babel/plugin-transform-spread": "7.2.2",
+        "@babel/plugin-transform-sticky-regex": "7.2.0",
+        "@babel/plugin-transform-template-literals": "7.2.0",
+        "@babel/plugin-transform-typeof-symbol": "7.2.0",
+        "@babel/plugin-transform-unicode-regex": "7.2.0",
+        "browserslist": "4.4.1",
+        "invariant": "2.2.4",
+        "js-levenshtein": "1.1.6",
+        "semver": "5.6.0"
       }
     },
     "@babel/preset-react": {
@@ -782,11 +782,11 @@
       "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0.tgz",
       "integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-transform-react-display-name": "^7.0.0",
-        "@babel/plugin-transform-react-jsx": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-source": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-transform-react-display-name": "7.2.0",
+        "@babel/plugin-transform-react-jsx": "7.3.0",
+        "@babel/plugin-transform-react-jsx-self": "7.2.0",
+        "@babel/plugin-transform-react-jsx-source": "7.2.0"
       }
     },
     "@babel/preset-typescript": {
@@ -794,8 +794,8 @@
       "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.1.0.tgz",
       "integrity": "sha512-LYveByuF9AOM8WrsNne5+N79k1YxjNB6gmpCQsnuSBAcV8QUeB+ZUxQzL7Rz7HksPbahymKkq2qBR+o36ggFZA==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-transform-typescript": "^7.1.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-transform-typescript": "7.2.0"
       }
     },
     "@babel/runtime": {
@@ -803,7 +803,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
       "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
       "requires": {
-        "regenerator-runtime": "^0.12.0"
+        "regenerator-runtime": "0.12.1"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -818,9 +818,9 @@
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
       "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.2.2",
-        "@babel/types": "^7.2.2"
+        "@babel/code-frame": "7.0.0",
+        "@babel/parser": "7.3.1",
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/traverse": {
@@ -828,15 +828,15 @@
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
       "integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.2.2",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/parser": "^7.2.3",
-        "@babel/types": "^7.2.2",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.10"
+        "@babel/code-frame": "7.0.0",
+        "@babel/generator": "7.3.0",
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-split-export-declaration": "7.0.0",
+        "@babel/parser": "7.3.1",
+        "@babel/types": "7.3.0",
+        "debug": "4.1.1",
+        "globals": "11.10.0",
+        "lodash": "4.17.11"
       }
     },
     "@babel/types": {
@@ -844,9 +844,9 @@
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.0.tgz",
       "integrity": "sha512-QkFPw68QqWU1/RVPyBe8SO7lXbPfjtqAxRYQKpFpaB8yMq7X2qAqfwK5LKoQufEkSmO5NQ70O6Kc3Afk03RwXw==",
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.10",
-        "to-fast-properties": "^2.0.0"
+        "esutils": "2.0.2",
+        "lodash": "4.17.11",
+        "to-fast-properties": "2.0.0"
       }
     },
     "@csstools/convert-colors": {
@@ -859,7 +859,7 @@
       "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-4.35.0.tgz",
       "integrity": "sha512-MSDr8+CaoXhtm64ELuI/8wpcfmrMUjzGJgASY6bnjc82vAW+6sHNZlTU0zWRTZxqQUuZ8WpuJP159cf92MWq3g==",
       "requires": {
-        "@ledgerhq/hw-transport": "^4.35.0"
+        "@ledgerhq/hw-transport": "4.35.0"
       }
     },
     "@ledgerhq/hw-transport": {
@@ -867,7 +867,7 @@
       "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-4.35.0.tgz",
       "integrity": "sha512-o8ekdoCkHMvOByIKDmAMNDjm8Q5cu+sbqmebPtGrHAPbgIZBUbNA5UupY/Om+xypdxXYnuBw+MF8FyIVOjnIsg==",
       "requires": {
-        "events": "^3.0.0"
+        "events": "3.0.0"
       }
     },
     "@ledgerhq/hw-transport-u2f": {
@@ -875,7 +875,7 @@
       "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-4.35.0.tgz",
       "integrity": "sha512-cVPH0SNRrIKVZz9zHvulHGPSdDQiV1hCK634KZa2M2+fMVhQxUi4YRBQz7QpI88CwRyEy+sBfTfSahPWjQUN2Q==",
       "requires": {
-        "@ledgerhq/hw-transport": "^4.35.0",
+        "@ledgerhq/hw-transport": "4.35.0",
         "u2f-api": "0.2.7"
       }
     },
@@ -884,12 +884,12 @@
       "resolved": "https://registry.npmjs.org/@ledgerhq/web3-subprovider/-/web3-subprovider-4.35.0.tgz",
       "integrity": "sha512-7aX1wGmWaXlZYLAfqKs5wg+IuupMKpI8CLGPPqUUiML6+QvV4PigzotXlXCOnaJ5WYzPPumGLgtol1ID+73jSw==",
       "requires": {
-        "@ledgerhq/hw-app-eth": "^4.35.0",
-        "@ledgerhq/hw-transport": "^4.35.0",
-        "@ledgerhq/hw-transport-u2f": "^4.35.0",
-        "ethereumjs-tx": "^1.3.7",
-        "strip-hex-prefix": "^1.0.0",
-        "web3-provider-engine": "^14.0.2"
+        "@ledgerhq/hw-app-eth": "4.35.0",
+        "@ledgerhq/hw-transport": "4.35.0",
+        "@ledgerhq/hw-transport-u2f": "4.35.0",
+        "ethereumjs-tx": "1.3.7",
+        "strip-hex-prefix": "1.0.0",
+        "web3-provider-engine": "14.1.0"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -897,8 +897,8 @@
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "requires": {
-        "call-me-maybe": "^1.0.1",
-        "glob-to-regexp": "^0.3.0"
+        "call-me-maybe": "1.0.1",
+        "glob-to-regexp": "0.3.0"
       }
     },
     "@nodelib/fs.stat": {
@@ -911,8 +911,8 @@
       "resolved": "https://registry.npmjs.org/@semantic-ui-react/event-stack/-/event-stack-3.0.1.tgz",
       "integrity": "sha512-9YNRr0z9GEvk/yvIzAzv0sbYa/FPrtWTYibu+chJ0CEMQjYDjUdRSqtxXOvP0eM6kZjD1G/Oy1LhPiHG7DRHsg==",
       "requires": {
-        "exenv": "^1.2.2",
-        "prop-types": "^15.6.2"
+        "exenv": "1.2.2",
+        "prop-types": "15.6.2"
       }
     },
     "@svgr/core": {
@@ -920,13 +920,13 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-2.4.1.tgz",
       "integrity": "sha512-2i1cUbjpKt1KcIP05e10vkmu9Aedp32EFqVcSQ08onbB8lVxJqMPci3Hr54aI14S9cLg4JdcpO0D35HHUtT8oQ==",
       "requires": {
-        "camelcase": "^5.0.0",
-        "cosmiconfig": "^5.0.6",
-        "h2x-core": "^1.1.0",
-        "h2x-plugin-jsx": "^1.1.0",
-        "merge-deep": "^3.0.2",
-        "prettier": "^1.14.2",
-        "svgo": "^1.0.5"
+        "camelcase": "5.0.0",
+        "cosmiconfig": "5.0.7",
+        "h2x-core": "1.1.1",
+        "h2x-plugin-jsx": "1.2.0",
+        "merge-deep": "3.0.2",
+        "prettier": "1.16.4",
+        "svgo": "1.1.1"
       }
     },
     "@svgr/webpack": {
@@ -934,12 +934,12 @@
       "resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-2.4.1.tgz",
       "integrity": "sha512-sMHYq0zbMtSHcc9kVfkYI2zrl88u4mKGyQLgKt7r+ul5nITcncm/EPBhzEUrJY5izdlaU6EvyH8zOhZnfaSmOA==",
       "requires": {
-        "@babel/core": "^7.0.1",
-        "@babel/plugin-transform-react-constant-elements": "^7.0.0",
-        "@babel/preset-env": "^7.0.0",
-        "@babel/preset-react": "^7.0.0",
-        "@svgr/core": "^2.4.1",
-        "loader-utils": "^1.1.0"
+        "@babel/core": "7.1.6",
+        "@babel/plugin-transform-react-constant-elements": "7.2.0",
+        "@babel/preset-env": "7.3.1",
+        "@babel/preset-react": "7.0.0",
+        "@svgr/core": "2.4.1",
+        "loader-utils": "1.2.3"
       }
     },
     "@types/flat": {
@@ -996,8 +996,8 @@
       "integrity": "sha512-Tx4uu3ppK53/iHk6VpamMP3f3ahfDLEVt3ZQc8TFm30a1H3v9lMsCntBREswZIW/SKrvJjkb3Hq8UwO6GREBng==",
       "dev": true,
       "requires": {
-        "@types/prop-types": "*",
-        "csstype": "^2.2.0"
+        "@types/prop-types": "15.5.8",
+        "csstype": "2.6.2"
       }
     },
     "@types/react-dom": {
@@ -1006,7 +1006,7 @@
       "integrity": "sha512-x6zUx9/42B5Kl2Vl9HlopV8JF64wLpX3c+Pst9kc1HgzrsH+mkehe/zmHMQTplIrR48H2gpU7ZqurQolYu8XBA==",
       "dev": true,
       "requires": {
-        "@types/react": "*"
+        "@types/react": "16.7.18"
       }
     },
     "@types/react-intl": {
@@ -1019,8 +1019,8 @@
       "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-6.0.13.tgz",
       "integrity": "sha512-69lPYT69CSvzQ75Ut4MfT+oQU9TAjCycdL6BQOrPztqbzdhzSe1d4Qj8vrMkTOm454Xz151zh+YT6S4t2OBopw==",
       "requires": {
-        "@types/react": "*",
-        "redux": "^4.0.0"
+        "@types/react": "16.8.1",
+        "redux": "4.0.1"
       },
       "dependencies": {
         "@types/react": {
@@ -1028,8 +1028,8 @@
           "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.1.tgz",
           "integrity": "sha512-tD1ETKJcuhANOejRc/p7OgQ16DKnbGi0M3LccelKlPnUCDp2a5koVxZFoRN9HN+A+m84HB5VGN7I+r3nNhS3PA==",
           "requires": {
-            "@types/prop-types": "*",
-            "csstype": "^2.2.0"
+            "@types/prop-types": "15.5.8",
+            "csstype": "2.6.2"
           }
         }
       }
@@ -1039,8 +1039,8 @@
       "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-4.4.3.tgz",
       "integrity": "sha512-8GmjakEBFNCLJbpg9jtDp1EDvFP0VkIPPKBpVwmB3Q+9whFoHu8rluMUXUE5SoGkEQvVOtgJzWmUsJojNpFMQQ==",
       "requires": {
-        "@types/history": "*",
-        "@types/react": "*"
+        "@types/history": "4.7.2",
+        "@types/react": "16.8.1"
       },
       "dependencies": {
         "@types/react": {
@@ -1048,8 +1048,8 @@
           "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.1.tgz",
           "integrity": "sha512-tD1ETKJcuhANOejRc/p7OgQ16DKnbGi0M3LccelKlPnUCDp2a5koVxZFoRN9HN+A+m84HB5VGN7I+r3nNhS3PA==",
           "requires": {
-            "@types/prop-types": "*",
-            "csstype": "^2.2.0"
+            "@types/prop-types": "15.5.8",
+            "csstype": "2.6.2"
           }
         }
       }
@@ -1060,9 +1060,9 @@
       "integrity": "sha512-GbztJAScOmQ/7RsQfO4cd55RuH1W4g6V1gDW3j4riLlt+8yxYLqqsiMzmyuXBLzdFmDtX/uU2Bpcm0cmudv44A==",
       "dev": true,
       "requires": {
-        "@types/history": "*",
-        "@types/react": "*",
-        "@types/react-router": "*"
+        "@types/history": "4.7.2",
+        "@types/react": "16.7.18",
+        "@types/react-router": "4.4.3"
       }
     },
     "@types/react-router-redux": {
@@ -1070,10 +1070,10 @@
       "resolved": "https://registry.npmjs.org/@types/react-router-redux/-/react-router-redux-5.0.17.tgz",
       "integrity": "sha512-BSh7O1s5QBbV4tUOby8UcIdvEHOePXT9CCdwBtAIKw/lLRghKgWUA4modmWaXGx5o/rLk03UuVxx04BXFgHu5A==",
       "requires": {
-        "@types/history": "*",
-        "@types/react": "*",
-        "@types/react-router": "*",
-        "redux": ">= 3.7.2"
+        "@types/history": "4.7.2",
+        "@types/react": "16.8.1",
+        "@types/react-router": "4.4.3",
+        "redux": "4.0.1"
       },
       "dependencies": {
         "@types/react": {
@@ -1081,8 +1081,8 @@
           "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.1.tgz",
           "integrity": "sha512-tD1ETKJcuhANOejRc/p7OgQ16DKnbGi0M3LccelKlPnUCDp2a5koVxZFoRN9HN+A+m84HB5VGN7I+r3nNhS3PA==",
           "requires": {
-            "@types/prop-types": "*",
-            "csstype": "^2.2.0"
+            "@types/prop-types": "15.5.8",
+            "csstype": "2.6.2"
           }
         }
       }
@@ -1092,7 +1092,7 @@
       "resolved": "https://registry.npmjs.org/@types/redux-logger/-/redux-logger-3.0.6.tgz",
       "integrity": "sha512-HXVJnbyuTcVtQ+qiwDcbLEMoOgNjKnNYVKx29P4NhV+FIgVVRCFILEPzjgSxlmMLc6aBVaEew7PfE3421DZ6Jw==",
       "requires": {
-        "redux": "^3.6.0"
+        "redux": "3.7.2"
       },
       "dependencies": {
         "redux": {
@@ -1100,10 +1100,10 @@
           "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
           "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
           "requires": {
-            "lodash": "^4.2.1",
-            "lodash-es": "^4.2.1",
-            "loose-envify": "^1.1.0",
-            "symbol-observable": "^1.0.3"
+            "lodash": "4.17.11",
+            "lodash-es": "4.17.11",
+            "loose-envify": "1.4.0",
+            "symbol-observable": "1.2.0"
           }
         }
       }
@@ -1113,7 +1113,7 @@
       "resolved": "https://registry.npmjs.org/@types/redux-storage/-/redux-storage-4.0.11.tgz",
       "integrity": "sha512-J3eP8zFunjLamkM5ENYdDK0aqNzt90l2LtdglQJitCOzrVpnZKLSTBh2xgJsEbFkWfekLcHPMR2KySeS4lyg0g==",
       "requires": {
-        "redux": "^3.6.0"
+        "redux": "3.7.2"
       },
       "dependencies": {
         "redux": {
@@ -1121,10 +1121,10 @@
           "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
           "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
           "requires": {
-            "lodash": "^4.2.1",
-            "lodash-es": "^4.2.1",
-            "loose-envify": "^1.1.0",
-            "symbol-observable": "^1.0.3"
+            "lodash": "4.17.11",
+            "lodash-es": "4.17.11",
+            "loose-envify": "1.4.0",
+            "symbol-observable": "1.2.0"
           }
         }
       }
@@ -1134,7 +1134,7 @@
       "resolved": "https://registry.npmjs.org/@types/redux-storage-engine-localstorage/-/redux-storage-engine-localstorage-1.1.0.tgz",
       "integrity": "sha512-jhj4bD38BXsQx9qekmv28GftUhGGpnufBCq5zeJ16JvOb1z2IbLquhBCYjs69x8xKksvaq7I9L3bV2B73XVd1w==",
       "requires": {
-        "@types/redux-storage": "*"
+        "@types/redux-storage": "4.0.11"
       }
     },
     "@types/reselect": {
@@ -1142,7 +1142,7 @@
       "resolved": "https://registry.npmjs.org/@types/reselect/-/reselect-2.2.0.tgz",
       "integrity": "sha1-xmcgbP3DgZDh03m6vgiGWyKIV18=",
       "requires": {
-        "reselect": "*"
+        "reselect": "4.0.0"
       }
     },
     "@types/segment-analytics": {
@@ -1160,7 +1160,7 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.4.tgz",
       "integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
       "requires": {
-        "@types/node": "*"
+        "@types/node": "10.12.21"
       },
       "dependencies": {
         "@types/node": {
@@ -1178,7 +1178,7 @@
         "@webassemblyjs/helper-module-context": "1.7.6",
         "@webassemblyjs/helper-wasm-bytecode": "1.7.6",
         "@webassemblyjs/wast-parser": "1.7.6",
-        "mamacro": "^0.0.3"
+        "mamacro": "0.0.3"
       }
     },
     "@webassemblyjs/floating-point-hex-parser": {
@@ -1214,7 +1214,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.6.tgz",
       "integrity": "sha512-e8/6GbY7OjLM+6OsN7f2krC2qYVNaSr0B0oe4lWdmq5sL++8dYDD1TFbD1TdAdWMRTYNr/Qq7ovXWzia2EbSjw==",
       "requires": {
-        "mamacro": "^0.0.3"
+        "mamacro": "0.0.3"
       }
     },
     "@webassemblyjs/helper-wasm-bytecode": {
@@ -1238,7 +1238,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.6.tgz",
       "integrity": "sha512-V4cIp0ruyw+hawUHwQLn6o2mFEw4t50tk530oKsYXQhEzKR+xNGDxs/SFFuyTO7X3NzEu4usA3w5jzhl2RYyzQ==",
       "requires": {
-        "@xtuc/ieee754": "^1.2.0"
+        "@xtuc/ieee754": "1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
@@ -1316,7 +1316,7 @@
         "@webassemblyjs/helper-code-frame": "1.7.6",
         "@webassemblyjs/helper-fsm": "1.7.6",
         "@xtuc/long": "4.2.1",
-        "mamacro": "^0.0.3"
+        "mamacro": "0.0.3"
       }
     },
     "@webassemblyjs/wast-printer": {
@@ -1349,7 +1349,7 @@
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
       "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
       "requires": {
-        "xtend": "~4.0.0"
+        "xtend": "4.0.1"
       }
     },
     "accepts": {
@@ -1357,7 +1357,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "~2.1.18",
+        "mime-types": "2.1.21",
         "negotiator": "0.6.1"
       }
     },
@@ -1371,7 +1371,7 @@
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
       "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
       "requires": {
-        "acorn": "^5.0.0"
+        "acorn": "5.7.3"
       },
       "dependencies": {
         "acorn": {
@@ -1386,8 +1386,8 @@
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
       "integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
       "requires": {
-        "acorn": "^6.0.1",
-        "acorn-walk": "^6.0.1"
+        "acorn": "6.0.7",
+        "acorn-walk": "6.1.1"
       }
     },
     "acorn-jsx": {
@@ -1410,10 +1410,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.8.1.tgz",
       "integrity": "sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
       }
     },
     "ajv-errors": {
@@ -1456,7 +1456,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.3"
       }
     },
     "anymatch": {
@@ -1464,8 +1464,8 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "requires": {
-        "micromatch": "^3.1.4",
-        "normalize-path": "^2.1.1"
+        "micromatch": "3.1.10",
+        "normalize-path": "2.1.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -1483,16 +1483,16 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.3",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -1500,7 +1500,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -1518,13 +1518,13 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -1532,7 +1532,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -1540,7 +1540,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -1548,7 +1548,7 @@
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -1556,7 +1556,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -1566,7 +1566,7 @@
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -1574,7 +1574,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -1584,9 +1584,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -1601,14 +1601,14 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -1616,7 +1616,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -1624,7 +1624,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -1634,10 +1634,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -1645,7 +1645,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -1655,7 +1655,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -1663,7 +1663,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -1671,9 +1671,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-number": {
@@ -1681,7 +1681,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -1689,7 +1689,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -1704,19 +1704,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "ms": {
@@ -1731,7 +1731,7 @@
       "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
       "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
       "requires": {
-        "default-require-extensions": "^1.0.0"
+        "default-require-extensions": "1.0.0"
       }
     },
     "aproba": {
@@ -1744,7 +1744,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "aria-query": {
@@ -1753,7 +1753,7 @@
       "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
       "requires": {
         "ast-types-flow": "0.0.7",
-        "commander": "^2.11.0"
+        "commander": "2.19.0"
       }
     },
     "arr-diff": {
@@ -1761,7 +1761,7 @@
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "requires": {
-        "arr-flatten": "^1.0.1"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-flatten": {
@@ -1794,8 +1794,8 @@
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.13.0"
       }
     },
     "array-map": {
@@ -1813,7 +1813,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -1841,7 +1841,7 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
-        "safer-buffer": "~2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "asn1.js": {
@@ -1849,9 +1849,9 @@
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "bn.js": "4.11.8",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "assert": {
@@ -1912,7 +1912,7 @@
       "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
       "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
       "requires": {
-        "async": "^2.4.0"
+        "async": "2.6.1"
       },
       "dependencies": {
         "async": {
@@ -1920,7 +1920,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
-            "lodash": "^4.17.10"
+            "lodash": "4.17.11"
           }
         }
       }
@@ -1945,12 +1945,12 @@
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.7.tgz",
       "integrity": "sha512-qS5wW6aXHkm53Y4z73tFGsUhmZu4aMPV9iHXYlF0c/wxjknXNHuj/1cIQb+6YH692DbJGGWcckAXX+VxKvahMA==",
       "requires": {
-        "browserslist": "^4.4.1",
-        "caniuse-lite": "^1.0.30000932",
-        "normalize-range": "^0.1.2",
-        "num2fraction": "^1.2.2",
-        "postcss": "^7.0.14",
-        "postcss-value-parser": "^3.3.1"
+        "browserslist": "4.4.1",
+        "caniuse-lite": "1.0.30000934",
+        "normalize-range": "0.1.2",
+        "num2fraction": "1.2.2",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.1"
       },
       "dependencies": {
         "chalk": {
@@ -1958,9 +1958,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -1968,7 +1968,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -1978,9 +1978,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -1993,7 +1993,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -2013,8 +2013,8 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
       "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
       "requires": {
-        "follow-redirects": "^1.2.5",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.6.1",
+        "is-buffer": "1.1.6"
       }
     },
     "axobject-query": {
@@ -2030,9 +2030,9 @@
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2050,11 +2050,11 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "js-tokens": {
@@ -2067,7 +2067,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {
@@ -2087,12 +2087,12 @@
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-9.0.0.tgz",
       "integrity": "sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==",
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
+        "@babel/code-frame": "7.0.0",
+        "@babel/parser": "7.3.1",
+        "@babel/traverse": "7.2.3",
+        "@babel/types": "7.3.0",
         "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-visitor-keys": "1.0.0"
       }
     },
     "babel-extract-comments": {
@@ -2100,7 +2100,7 @@
       "resolved": "https://registry.npmjs.org/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz",
       "integrity": "sha512-qWWzi4TlddohA91bFwgt6zO/J0X+io7Qp184Fw0m2JYRSTZnJbFR8+07KmzudHCZgOiKRCrjhylwv9Xd8gfhVQ==",
       "requires": {
-        "babylon": "^6.18.0"
+        "babylon": "6.18.0"
       }
     },
     "babel-generator": {
@@ -2108,14 +2108,14 @@
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.11",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "jsesc": {
@@ -2130,9 +2130,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "requires": {
-        "babel-helper-explode-assignable-expression": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-call-delegate": {
@@ -2140,10 +2140,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-define-map": {
@@ -2151,10 +2151,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.11"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -2162,9 +2162,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-function-name": {
@@ -2172,11 +2172,11 @@
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "requires": {
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-get-function-arity": {
@@ -2184,8 +2184,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-hoist-variables": {
@@ -2193,8 +2193,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -2202,8 +2202,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-regex": {
@@ -2211,9 +2211,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.11"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -2221,11 +2221,11 @@
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-replace-supers": {
@@ -2233,12 +2233,12 @@
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "requires": {
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helpers": {
@@ -2246,8 +2246,8 @@
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-jest": {
@@ -2255,8 +2255,8 @@
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.6.0.tgz",
       "integrity": "sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==",
       "requires": {
-        "babel-plugin-istanbul": "^4.1.6",
-        "babel-preset-jest": "^23.2.0"
+        "babel-plugin-istanbul": "4.1.6",
+        "babel-preset-jest": "23.2.0"
       }
     },
     "babel-loader": {
@@ -2264,10 +2264,10 @@
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.4.tgz",
       "integrity": "sha512-fhBhNkUToJcW9nV46v8w87AJOwAJDz84c1CL57n3Stj73FANM/b9TbCUK4YhdOwEyZ+OxhYpdeZDNzSI29Firw==",
       "requires": {
-        "find-cache-dir": "^1.0.0",
-        "loader-utils": "^1.0.2",
-        "mkdirp": "^0.5.1",
-        "util.promisify": "^1.0.0"
+        "find-cache-dir": "1.0.0",
+        "loader-utils": "1.2.3",
+        "mkdirp": "0.5.1",
+        "util.promisify": "1.0.0"
       }
     },
     "babel-messages": {
@@ -2275,7 +2275,7 @@
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -2283,7 +2283,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-dynamic-import-node": {
@@ -2291,7 +2291,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.2.0.tgz",
       "integrity": "sha512-fP899ELUnTaBcIzmrW7nniyqqdYWrWuJUyPWHxFa/c7r7hS6KC8FscNfLlBNIoPSc55kYMGEEKjPjJGCLbE1qA==",
       "requires": {
-        "object.assign": "^4.1.0"
+        "object.assign": "4.1.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -2299,10 +2299,10 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
       "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "^6.13.0",
-        "find-up": "^2.1.0",
-        "istanbul-lib-instrument": "^1.10.1",
-        "test-exclude": "^4.2.1"
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "find-up": "2.1.0",
+        "istanbul-lib-instrument": "1.10.2",
+        "test-exclude": "4.2.3"
       },
       "dependencies": {
         "find-up": {
@@ -2310,7 +2310,7 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "locate-path": {
@@ -2318,8 +2318,8 @@
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -2327,7 +2327,7 @@
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
@@ -2335,7 +2335,7 @@
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.3.0"
           }
         },
         "p-try": {
@@ -2355,8 +2355,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.4.2.tgz",
       "integrity": "sha512-NBVpEWN4OQ/bHnu1fyDaAaTPAjnhXCEPqr1RwqxrU7b6tZ2hypp+zX4hlNfmVGfClD5c3Sl6Hfj5TJNF5VG5aA==",
       "requires": {
-        "cosmiconfig": "^5.0.5",
-        "resolve": "^1.8.1"
+        "cosmiconfig": "5.0.7",
+        "resolve": "1.8.1"
       }
     },
     "babel-plugin-named-asset-import": {
@@ -2389,9 +2389,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-functions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -2399,7 +2399,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -2407,7 +2407,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -2415,11 +2415,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.11"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -2427,15 +2427,15 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "requires": {
-        "babel-helper-define-map": "^6.24.1",
-        "babel-helper-function-name": "^6.24.1",
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-define-map": "6.26.0",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -2443,8 +2443,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -2452,7 +2452,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -2460,8 +2460,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -2469,7 +2469,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -2477,9 +2477,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -2487,7 +2487,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -2495,9 +2495,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -2505,10 +2505,10 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "requires": {
-        "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-types": "^6.26.0"
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -2516,9 +2516,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -2526,9 +2526,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -2536,8 +2536,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "requires": {
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -2545,12 +2545,12 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "requires": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -2558,8 +2558,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -2567,7 +2567,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -2575,9 +2575,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -2585,7 +2585,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -2593,7 +2593,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -2601,9 +2601,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "regexpu-core": "^2.0.0"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "regexpu-core": "2.0.0"
       },
       "dependencies": {
         "jsesc": {
@@ -2616,9 +2616,9 @@
           "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
           "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
           "requires": {
-            "regenerate": "^1.2.1",
-            "regjsgen": "^0.2.0",
-            "regjsparser": "^0.1.4"
+            "regenerate": "1.4.0",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
           }
         },
         "regjsgen": {
@@ -2631,7 +2631,7 @@
           "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
           "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
           "requires": {
-            "jsesc": "~0.5.0"
+            "jsesc": "0.5.0"
           }
         }
       }
@@ -2641,9 +2641,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -2651,8 +2651,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
-        "babel-runtime": "^6.26.0"
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-react-remove-prop-types": {
@@ -2665,7 +2665,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "requires": {
-        "regenerator-transform": "^0.10.0"
+        "regenerator-transform": "0.10.1"
       },
       "dependencies": {
         "regenerator-transform": {
@@ -2673,9 +2673,9 @@
           "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
           "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
           "requires": {
-            "babel-runtime": "^6.18.0",
-            "babel-types": "^6.19.0",
-            "private": "^0.1.6"
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "private": "0.1.8"
           }
         }
       }
@@ -2685,8 +2685,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-preset-env": {
@@ -2694,36 +2694,36 @@
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
       "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-to-generator": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-        "babel-plugin-transform-es2015-classes": "^6.23.0",
-        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-        "babel-plugin-transform-es2015-for-of": "^6.23.0",
-        "babel-plugin-transform-es2015-function-name": "^6.22.0",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-        "babel-plugin-transform-es2015-object-super": "^6.22.0",
-        "babel-plugin-transform-es2015-parameters": "^6.23.0",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
-        "babel-plugin-transform-regenerator": "^6.22.0",
-        "browserslist": "^3.2.6",
-        "invariant": "^2.2.2",
-        "semver": "^5.3.0"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "3.2.8",
+        "invariant": "2.2.4",
+        "semver": "5.6.0"
       },
       "dependencies": {
         "browserslist": {
@@ -2731,8 +2731,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
           "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
           "requires": {
-            "caniuse-lite": "^1.0.30000844",
-            "electron-to-chromium": "^1.3.47"
+            "caniuse-lite": "1.0.30000934",
+            "electron-to-chromium": "1.3.113"
           }
         }
       }
@@ -2742,8 +2742,8 @@
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
       "integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
       "requires": {
-        "babel-plugin-jest-hoist": "^23.2.0",
-        "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+        "babel-plugin-jest-hoist": "23.2.0",
+        "babel-plugin-syntax-object-rest-spread": "6.13.0"
       }
     },
     "babel-preset-react-app": {
@@ -2777,8 +2777,8 @@
           "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz",
           "integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/plugin-syntax-object-rest-spread": "^7.0.0"
+            "@babel/helper-plugin-utils": "7.0.0",
+            "@babel/plugin-syntax-object-rest-spread": "7.2.0"
           }
         },
         "@babel/plugin-transform-classes": {
@@ -2786,14 +2786,14 @@
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.1.0.tgz",
           "integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
           "requires": {
-            "@babel/helper-annotate-as-pure": "^7.0.0",
-            "@babel/helper-define-map": "^7.1.0",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-optimise-call-expression": "^7.0.0",
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/helper-replace-supers": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.0.0",
-            "globals": "^11.1.0"
+            "@babel/helper-annotate-as-pure": "7.0.0",
+            "@babel/helper-define-map": "7.1.0",
+            "@babel/helper-function-name": "7.1.0",
+            "@babel/helper-optimise-call-expression": "7.0.0",
+            "@babel/helper-plugin-utils": "7.0.0",
+            "@babel/helper-replace-supers": "7.2.3",
+            "@babel/helper-split-export-declaration": "7.0.0",
+            "globals": "11.10.0"
           }
         },
         "@babel/plugin-transform-destructuring": {
@@ -2801,7 +2801,7 @@
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.1.3.tgz",
           "integrity": "sha512-Mb9M4DGIOspH1ExHOUnn2UUXFOyVTiX84fXCd+6B5iWrQg/QMeeRmSwpZ9lnjYLSXtZwiw80ytVMr3zue0ucYw==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
+            "@babel/helper-plugin-utils": "7.0.0"
           }
         },
         "@babel/plugin-transform-react-constant-elements": {
@@ -2809,8 +2809,8 @@
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.0.0.tgz",
           "integrity": "sha512-z8yrW4KCVcqPYr0r9dHXe7fu3daLzn0r6TQEFoGbXahdrzEwT1d1ux+/EnFcqIHv9uPilUlnRnPIUf7GMO0ehg==",
           "requires": {
-            "@babel/helper-annotate-as-pure": "^7.0.0",
-            "@babel/helper-plugin-utils": "^7.0.0"
+            "@babel/helper-annotate-as-pure": "7.0.0",
+            "@babel/helper-plugin-utils": "7.0.0"
           }
         },
         "@babel/plugin-transform-react-display-name": {
@@ -2818,7 +2818,7 @@
           "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.0.0.tgz",
           "integrity": "sha512-BX8xKuQTO0HzINxT6j/GiCwoJB0AOMs0HmLbEnAvcte8U8rSkNa/eSCAY+l1OA4JnCVq2jw2p6U8QQryy2fTPg==",
           "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0"
+            "@babel/helper-plugin-utils": "7.0.0"
           }
         },
         "@babel/preset-env": {
@@ -2826,47 +2826,47 @@
           "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.6.tgz",
           "integrity": "sha512-YIBfpJNQMBkb6MCkjz/A9J76SNCSuGVamOVBgoUkLzpJD/z8ghHi9I42LQ4pulVX68N/MmImz6ZTixt7Azgexw==",
           "requires": {
-            "@babel/helper-module-imports": "^7.0.0",
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/plugin-proposal-async-generator-functions": "^7.1.0",
-            "@babel/plugin-proposal-json-strings": "^7.0.0",
-            "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-            "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-            "@babel/plugin-proposal-unicode-property-regex": "^7.0.0",
-            "@babel/plugin-syntax-async-generators": "^7.0.0",
-            "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-            "@babel/plugin-syntax-optional-catch-binding": "^7.0.0",
-            "@babel/plugin-transform-arrow-functions": "^7.0.0",
-            "@babel/plugin-transform-async-to-generator": "^7.1.0",
-            "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
-            "@babel/plugin-transform-block-scoping": "^7.1.5",
-            "@babel/plugin-transform-classes": "^7.1.0",
-            "@babel/plugin-transform-computed-properties": "^7.0.0",
-            "@babel/plugin-transform-destructuring": "^7.0.0",
-            "@babel/plugin-transform-dotall-regex": "^7.0.0",
-            "@babel/plugin-transform-duplicate-keys": "^7.0.0",
-            "@babel/plugin-transform-exponentiation-operator": "^7.1.0",
-            "@babel/plugin-transform-for-of": "^7.0.0",
-            "@babel/plugin-transform-function-name": "^7.1.0",
-            "@babel/plugin-transform-literals": "^7.0.0",
-            "@babel/plugin-transform-modules-amd": "^7.1.0",
-            "@babel/plugin-transform-modules-commonjs": "^7.1.0",
-            "@babel/plugin-transform-modules-systemjs": "^7.0.0",
-            "@babel/plugin-transform-modules-umd": "^7.1.0",
-            "@babel/plugin-transform-new-target": "^7.0.0",
-            "@babel/plugin-transform-object-super": "^7.1.0",
-            "@babel/plugin-transform-parameters": "^7.1.0",
-            "@babel/plugin-transform-regenerator": "^7.0.0",
-            "@babel/plugin-transform-shorthand-properties": "^7.0.0",
-            "@babel/plugin-transform-spread": "^7.0.0",
-            "@babel/plugin-transform-sticky-regex": "^7.0.0",
-            "@babel/plugin-transform-template-literals": "^7.0.0",
-            "@babel/plugin-transform-typeof-symbol": "^7.0.0",
-            "@babel/plugin-transform-unicode-regex": "^7.0.0",
-            "browserslist": "^4.1.0",
-            "invariant": "^2.2.2",
-            "js-levenshtein": "^1.1.3",
-            "semver": "^5.3.0"
+            "@babel/helper-module-imports": "7.0.0",
+            "@babel/helper-plugin-utils": "7.0.0",
+            "@babel/plugin-proposal-async-generator-functions": "7.2.0",
+            "@babel/plugin-proposal-json-strings": "7.2.0",
+            "@babel/plugin-proposal-object-rest-spread": "7.0.0",
+            "@babel/plugin-proposal-optional-catch-binding": "7.2.0",
+            "@babel/plugin-proposal-unicode-property-regex": "7.2.0",
+            "@babel/plugin-syntax-async-generators": "7.2.0",
+            "@babel/plugin-syntax-object-rest-spread": "7.2.0",
+            "@babel/plugin-syntax-optional-catch-binding": "7.2.0",
+            "@babel/plugin-transform-arrow-functions": "7.2.0",
+            "@babel/plugin-transform-async-to-generator": "7.2.0",
+            "@babel/plugin-transform-block-scoped-functions": "7.2.0",
+            "@babel/plugin-transform-block-scoping": "7.2.0",
+            "@babel/plugin-transform-classes": "7.1.0",
+            "@babel/plugin-transform-computed-properties": "7.2.0",
+            "@babel/plugin-transform-destructuring": "7.1.3",
+            "@babel/plugin-transform-dotall-regex": "7.2.0",
+            "@babel/plugin-transform-duplicate-keys": "7.2.0",
+            "@babel/plugin-transform-exponentiation-operator": "7.2.0",
+            "@babel/plugin-transform-for-of": "7.2.0",
+            "@babel/plugin-transform-function-name": "7.2.0",
+            "@babel/plugin-transform-literals": "7.2.0",
+            "@babel/plugin-transform-modules-amd": "7.2.0",
+            "@babel/plugin-transform-modules-commonjs": "7.2.0",
+            "@babel/plugin-transform-modules-systemjs": "7.2.0",
+            "@babel/plugin-transform-modules-umd": "7.2.0",
+            "@babel/plugin-transform-new-target": "7.0.0",
+            "@babel/plugin-transform-object-super": "7.2.0",
+            "@babel/plugin-transform-parameters": "7.2.0",
+            "@babel/plugin-transform-regenerator": "7.0.0",
+            "@babel/plugin-transform-shorthand-properties": "7.2.0",
+            "@babel/plugin-transform-spread": "7.2.2",
+            "@babel/plugin-transform-sticky-regex": "7.2.0",
+            "@babel/plugin-transform-template-literals": "7.2.0",
+            "@babel/plugin-transform-typeof-symbol": "7.2.0",
+            "@babel/plugin-transform-unicode-regex": "7.2.0",
+            "browserslist": "4.4.1",
+            "invariant": "2.2.4",
+            "js-levenshtein": "1.1.6",
+            "semver": "5.6.0"
           }
         }
       }
@@ -2876,13 +2876,13 @@
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
+        "babel-core": "6.26.3",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.6.3",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.11",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
       },
       "dependencies": {
         "babel-core": {
@@ -2890,25 +2890,25 @@
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
           "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
           "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-generator": "^6.26.0",
-            "babel-helpers": "^6.24.1",
-            "babel-messages": "^6.23.0",
-            "babel-register": "^6.26.0",
-            "babel-runtime": "^6.26.0",
-            "babel-template": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "convert-source-map": "^1.5.1",
-            "debug": "^2.6.9",
-            "json5": "^0.5.1",
-            "lodash": "^4.17.4",
-            "minimatch": "^3.0.4",
-            "path-is-absolute": "^1.0.1",
-            "private": "^0.1.8",
-            "slash": "^1.0.0",
-            "source-map": "^0.5.7"
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.1",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.6.0",
+            "debug": "2.6.9",
+            "json5": "0.5.1",
+            "lodash": "4.17.11",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
+            "slash": "1.0.0",
+            "source-map": "0.5.7"
           }
         },
         "debug": {
@@ -2936,8 +2936,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.6.3",
+        "regenerator-runtime": "0.11.1"
       }
     },
     "babel-template": {
@@ -2945,11 +2945,11 @@
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.11"
       }
     },
     "babel-traverse": {
@@ -2957,15 +2957,15 @@
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.11"
       },
       "dependencies": {
         "debug": {
@@ -2993,10 +2993,10 @@
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.11",
+        "to-fast-properties": "1.0.3"
       },
       "dependencies": {
         "to-fast-properties": {
@@ -3011,8 +3011,8 @@
       "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
       "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
       "requires": {
-        "babel-core": "^6.0.14",
-        "object-assign": "^4.0.0"
+        "babel-core": "6.26.3",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "babel-core": {
@@ -3020,25 +3020,25 @@
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
           "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
           "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-generator": "^6.26.0",
-            "babel-helpers": "^6.24.1",
-            "babel-messages": "^6.23.0",
-            "babel-register": "^6.26.0",
-            "babel-runtime": "^6.26.0",
-            "babel-template": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "convert-source-map": "^1.5.1",
-            "debug": "^2.6.9",
-            "json5": "^0.5.1",
-            "lodash": "^4.17.4",
-            "minimatch": "^3.0.4",
-            "path-is-absolute": "^1.0.1",
-            "private": "^0.1.8",
-            "slash": "^1.0.0",
-            "source-map": "^0.5.7"
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.1",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.6.0",
+            "debug": "2.6.9",
+            "json5": "0.5.1",
+            "lodash": "4.17.11",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
+            "slash": "1.0.0",
+            "source-map": "0.5.7"
           }
         },
         "debug": {
@@ -3071,7 +3071,7 @@
       "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
       "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
       "requires": {
-        "precond": "0.2"
+        "precond": "0.2.3"
       }
     },
     "balanced-match": {
@@ -3089,13 +3089,13 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -3103,7 +3103,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -3111,7 +3111,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -3119,7 +3119,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -3127,9 +3127,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "kind-of": {
@@ -3154,7 +3154,7 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "bfj": {
@@ -3162,10 +3162,10 @@
       "resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.1.tgz",
       "integrity": "sha512-+GUNvzHR4nRyGybQc2WpNJL4MJazMuvf92ueIyA0bIkPRwhhQu3IfZQ2PSoVPpCBJfmoSdOxu5rnotfFLlvYRQ==",
       "requires": {
-        "bluebird": "^3.5.1",
-        "check-types": "^7.3.0",
-        "hoopy": "^0.1.2",
-        "tryer": "^1.0.0"
+        "bluebird": "3.5.3",
+        "check-types": "7.4.0",
+        "hoopy": "0.1.4",
+        "tryer": "1.0.1"
       }
     },
     "big.js": {
@@ -3174,8 +3174,7 @@
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "bignumber.js": {
-      "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-      "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+      "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
     },
     "binary-extensions": {
       "version": "1.13.0",
@@ -3195,7 +3194,7 @@
       "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
       "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "bluebird": {
@@ -3214,15 +3213,15 @@
       "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "~1.6.3",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
         "iconv-lite": "0.4.23",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.3.0",
         "qs": "6.5.2",
         "raw-body": "2.3.3",
-        "type-is": "~1.6.16"
+        "type-is": "1.6.16"
       },
       "dependencies": {
         "debug": {
@@ -3238,7 +3237,7 @@
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         },
         "ms": {
@@ -3253,12 +3252,12 @@
       "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "requires": {
-        "array-flatten": "^2.1.0",
-        "deep-equal": "^1.0.1",
-        "dns-equal": "^1.0.0",
-        "dns-txt": "^2.0.2",
-        "multicast-dns": "^6.0.1",
-        "multicast-dns-service-types": "^1.1.0"
+        "array-flatten": "2.1.2",
+        "deep-equal": "1.0.1",
+        "dns-equal": "1.0.0",
+        "dns-txt": "2.0.2",
+        "multicast-dns": "6.2.3",
+        "multicast-dns-service-types": "1.1.0"
       }
     },
     "boolbase": {
@@ -3271,7 +3270,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -3280,9 +3279,9 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.3"
       }
     },
     "brorand": {
@@ -3315,12 +3314,12 @@
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "browserify-cipher": {
@@ -3328,9 +3327,9 @@
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "requires": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
+        "browserify-aes": "1.2.0",
+        "browserify-des": "1.0.2",
+        "evp_bytestokey": "1.0.3"
       }
     },
     "browserify-des": {
@@ -3338,10 +3337,10 @@
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "requires": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "browserify-rsa": {
@@ -3349,8 +3348,8 @@
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
-        "bn.js": "^4.1.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "randombytes": "2.0.6"
       }
     },
     "browserify-sign": {
@@ -3358,13 +3357,13 @@
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "elliptic": "6.4.1",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.3"
       }
     },
     "browserify-zlib": {
@@ -3372,7 +3371,7 @@
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "requires": {
-        "pako": "~1.0.5"
+        "pako": "1.0.8"
       }
     },
     "browserslist": {
@@ -3380,9 +3379,9 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.1.tgz",
       "integrity": "sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==",
       "requires": {
-        "caniuse-lite": "^1.0.30000929",
-        "electron-to-chromium": "^1.3.103",
-        "node-releases": "^1.1.3"
+        "caniuse-lite": "1.0.30000934",
+        "electron-to-chromium": "1.3.113",
+        "node-releases": "1.1.7"
       }
     },
     "bser": {
@@ -3390,7 +3389,7 @@
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
       "requires": {
-        "node-int64": "^0.4.0"
+        "node-int64": "0.4.0"
       }
     },
     "buffer": {
@@ -3398,9 +3397,9 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "base64-js": "1.3.0",
+        "ieee754": "1.1.12",
+        "isarray": "1.0.0"
       }
     },
     "buffer-from": {
@@ -3438,20 +3437,20 @@
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
       "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
       "requires": {
-        "bluebird": "^3.5.3",
-        "chownr": "^1.1.1",
-        "figgy-pudding": "^3.5.1",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.1.15",
-        "lru-cache": "^5.1.1",
-        "mississippi": "^3.0.0",
-        "mkdirp": "^0.5.1",
-        "move-concurrently": "^1.0.1",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.2",
-        "ssri": "^6.0.1",
-        "unique-filename": "^1.1.1",
-        "y18n": "^4.0.0"
+        "bluebird": "3.5.3",
+        "chownr": "1.1.1",
+        "figgy-pudding": "3.5.1",
+        "glob": "7.1.3",
+        "graceful-fs": "4.1.15",
+        "lru-cache": "5.1.1",
+        "mississippi": "3.0.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "promise-inflight": "1.0.1",
+        "rimraf": "2.6.3",
+        "ssri": "6.0.1",
+        "unique-filename": "1.1.1",
+        "y18n": "4.0.0"
       },
       "dependencies": {
         "lru-cache": {
@@ -3459,7 +3458,7 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
           "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "requires": {
-            "yallist": "^3.0.2"
+            "yallist": "3.0.3"
           }
         },
         "yallist": {
@@ -3474,15 +3473,15 @@
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       }
     },
     "call-me-maybe": {
@@ -3495,7 +3494,7 @@
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "requires": {
-        "callsites": "^2.0.0"
+        "callsites": "2.0.0"
       }
     },
     "caller-path": {
@@ -3503,7 +3502,7 @@
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "requires": {
-        "caller-callsite": "^2.0.0"
+        "caller-callsite": "2.0.0"
       }
     },
     "callsites": {
@@ -3516,8 +3515,8 @@
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
       }
     },
     "camelcase": {
@@ -3530,10 +3529,10 @@
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
       "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
       "requires": {
-        "browserslist": "^4.0.0",
-        "caniuse-lite": "^1.0.0",
-        "lodash.memoize": "^4.1.2",
-        "lodash.uniq": "^4.5.0"
+        "browserslist": "4.4.1",
+        "caniuse-lite": "1.0.30000934",
+        "lodash.memoize": "4.1.2",
+        "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-lite": {
@@ -3546,7 +3545,7 @@
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
       "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
       "requires": {
-        "rsvp": "^3.3.3"
+        "rsvp": "3.6.2"
       }
     },
     "case-sensitive-paths-webpack-plugin": {
@@ -3564,9 +3563,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.5.0"
       }
     },
     "chardet": {
@@ -3584,7 +3583,7 @@
       "resolved": "https://registry.npmjs.org/checkpoint-store/-/checkpoint-store-1.1.0.tgz",
       "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
       "requires": {
-        "functional-red-black-tree": "^1.0.1"
+        "functional-red-black-tree": "1.0.1"
       }
     },
     "chokidar": {
@@ -3592,19 +3591,19 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
       "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
       "requires": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.0",
-        "braces": "^2.3.0",
-        "fsevents": "^1.2.2",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "lodash.debounce": "^4.0.8",
-        "normalize-path": "^2.1.1",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0",
-        "upath": "^1.0.5"
+        "anymatch": "2.0.0",
+        "async-each": "1.0.1",
+        "braces": "2.3.2",
+        "fsevents": "1.2.7",
+        "glob-parent": "3.1.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "4.0.0",
+        "lodash.debounce": "4.0.8",
+        "normalize-path": "2.1.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.2.1",
+        "upath": "1.1.0"
       },
       "dependencies": {
         "array-unique": {
@@ -3617,16 +3616,16 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.3",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           }
         },
         "extend-shallow": {
@@ -3634,7 +3633,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "fill-range": {
@@ -3642,10 +3641,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           }
         },
         "glob-parent": {
@@ -3653,8 +3652,8 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           },
           "dependencies": {
             "is-glob": {
@@ -3662,7 +3661,7 @@
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
               }
             }
           }
@@ -3677,7 +3676,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -3685,7 +3684,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         }
       }
@@ -3700,7 +3699,7 @@
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
       "integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.3"
       }
     },
     "ci-info": {
@@ -3713,8 +3712,8 @@
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "circular-json": {
@@ -3727,10 +3726,10 @@
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -3738,7 +3737,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -3753,7 +3752,7 @@
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
       "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
       "requires": {
-        "source-map": "~0.6.0"
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -3768,7 +3767,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-table3": {
@@ -3776,9 +3775,9 @@
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
       "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
       "requires": {
-        "colors": "^1.1.2",
-        "object-assign": "^4.1.0",
-        "string-width": "^2.1.1"
+        "colors": "1.3.3",
+        "object-assign": "4.1.1",
+        "string-width": "2.1.1"
       }
     },
     "cli-width": {
@@ -3791,9 +3790,9 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
       "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "wrap-ansi": "2.1.0"
       }
     },
     "clone": {
@@ -3806,11 +3805,11 @@
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
       "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
       "requires": {
-        "for-own": "^0.1.3",
-        "is-plain-object": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "lazy-cache": "^1.0.3",
-        "shallow-clone": "^0.1.2"
+        "for-own": "0.1.5",
+        "is-plain-object": "2.0.4",
+        "kind-of": "3.2.2",
+        "lazy-cache": "1.0.4",
+        "shallow-clone": "0.1.2"
       }
     },
     "co": {
@@ -3823,9 +3822,9 @@
       "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
       "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
       "requires": {
-        "@types/q": "^1.5.1",
-        "chalk": "^2.4.1",
-        "q": "^1.1.2"
+        "@types/q": "1.5.1",
+        "chalk": "2.4.1",
+        "q": "1.5.1"
       }
     },
     "code-point-at": {
@@ -3838,8 +3837,8 @@
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color": {
@@ -3847,8 +3846,8 @@
       "resolved": "https://registry.npmjs.org/color/-/color-3.1.0.tgz",
       "integrity": "sha512-CwyopLkuRYO5ei2EpzpIh6LqJMt6Mt+jZhO5VI5f/wJLZriXQE32/SSqzmrh+QB+AZT81Cj8yv+7zwToW8ahZg==",
       "requires": {
-        "color-convert": "^1.9.1",
-        "color-string": "^1.5.2"
+        "color-convert": "1.9.3",
+        "color-string": "1.5.3"
       }
     },
     "color-convert": {
@@ -3869,8 +3868,8 @@
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
       "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
       "requires": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
+        "color-name": "1.1.3",
+        "simple-swizzle": "0.2.2"
       }
     },
     "colors": {
@@ -3883,7 +3882,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "comma-separated-values": {
@@ -3916,7 +3915,7 @@
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.15.tgz",
       "integrity": "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==",
       "requires": {
-        "mime-db": ">= 1.36.0 < 2"
+        "mime-db": "1.37.0"
       }
     },
     "compression": {
@@ -3924,13 +3923,13 @@
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
       "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "1.3.5",
         "bytes": "3.0.0",
-        "compressible": "~2.0.14",
+        "compressible": "2.0.15",
         "debug": "2.6.9",
-        "on-headers": "~1.0.1",
+        "on-headers": "1.0.1",
         "safe-buffer": "5.1.2",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       },
       "dependencies": {
         "debug": {
@@ -3958,10 +3957,10 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       }
     },
     "concurrently": {
@@ -3970,15 +3969,15 @@
       "integrity": "sha512-pwzXCE7qtOB346LyO9eFWpkFJVO3JQZ/qU/feGeaAHiX1M3Rw3zgXKc5cZ8vSH5DGygkjzLFDzA/pwoQDkRNGg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
-        "date-fns": "^1.23.0",
-        "lodash": "^4.17.10",
-        "read-pkg": "^4.0.1",
-        "rxjs": "^6.3.3",
-        "spawn-command": "^0.0.2-1",
-        "supports-color": "^4.5.0",
-        "tree-kill": "^1.1.0",
-        "yargs": "^12.0.1"
+        "chalk": "2.4.1",
+        "date-fns": "1.30.1",
+        "lodash": "4.17.11",
+        "read-pkg": "4.0.1",
+        "rxjs": "6.4.0",
+        "spawn-command": "0.0.2-1",
+        "supports-color": "4.5.0",
+        "tree-kill": "1.2.1",
+        "yargs": "12.0.5"
       },
       "dependencies": {
         "has-flag": {
@@ -3999,9 +3998,9 @@
           "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
           "dev": true,
           "requires": {
-            "normalize-package-data": "^2.3.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0"
+            "normalize-package-data": "2.4.2",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0"
           }
         },
         "supports-color": {
@@ -4010,7 +4009,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -4030,8 +4029,8 @@
       "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.2.2.tgz",
       "integrity": "sha512-tPI3s7yYtnTt/XLoQFsQqIEQxdQCrsZltEdozjG7LPkOTNglJJ7WqUqnlnh9thC6ebavfaJoTtPa9G2EibuJbg==",
       "requires": {
-        "immutable": "^3.8.1",
-        "seamless-immutable": "^7.1.3"
+        "immutable": "3.8.2",
+        "seamless-immutable": "7.1.4"
       }
     },
     "console-browserify": {
@@ -4039,7 +4038,7 @@
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "requires": {
-        "date-now": "^0.1.4"
+        "date-now": "0.1.4"
       }
     },
     "console-polyfill": {
@@ -4072,7 +4071,7 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
       "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
       "requires": {
-        "safe-buffer": "~5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "cookie": {
@@ -4095,12 +4094,12 @@
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "requires": {
-        "aproba": "^1.1.1",
-        "fs-write-stream-atomic": "^1.0.8",
-        "iferr": "^0.1.5",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.0"
+        "aproba": "1.2.0",
+        "fs-write-stream-atomic": "1.0.10",
+        "iferr": "0.1.5",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.3",
+        "run-queue": "1.0.3"
       }
     },
     "copy-descriptor": {
@@ -4123,10 +4122,10 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.7.tgz",
       "integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
       "requires": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.9.0",
-        "parse-json": "^4.0.0"
+        "import-fresh": "2.0.0",
+        "is-directory": "0.3.1",
+        "js-yaml": "3.12.1",
+        "parse-json": "4.0.0"
       }
     },
     "create-ecdh": {
@@ -4134,8 +4133,8 @@
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "requires": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
+        "bn.js": "4.11.8",
+        "elliptic": "6.4.1"
       }
     },
     "create-hash": {
@@ -4143,11 +4142,11 @@
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "md5.js": "1.3.5",
+        "ripemd160": "2.0.2",
+        "sha.js": "2.4.11"
       }
     },
     "create-hmac": {
@@ -4155,12 +4154,12 @@
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
+        "sha.js": "2.4.11"
       }
     },
     "cross-fetch": {
@@ -4177,11 +4176,11 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "nice-try": "1.0.5",
+        "path-key": "2.0.1",
+        "semver": "5.6.0",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "crypto-browserify": {
@@ -4189,17 +4188,17 @@
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "requires": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
+        "browserify-cipher": "1.0.1",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.3",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "diffie-hellman": "5.0.3",
+        "inherits": "2.0.3",
+        "pbkdf2": "3.0.17",
+        "public-encrypt": "4.0.3",
+        "randombytes": "2.0.6",
+        "randomfill": "1.0.4"
       }
     },
     "crypto-js": {
@@ -4217,8 +4216,8 @@
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
       "integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
       "requires": {
-        "postcss": "^7.0.1",
-        "timsort": "^0.3.0"
+        "postcss": "7.0.14",
+        "timsort": "0.3.0"
       },
       "dependencies": {
         "chalk": {
@@ -4226,9 +4225,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -4236,7 +4235,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -4246,9 +4245,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -4261,7 +4260,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -4271,18 +4270,18 @@
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.0.tgz",
       "integrity": "sha512-tMXlTYf3mIMt3b0dDCOQFJiVvxbocJ5Ho577WiGPYPZcqVEO218L2iU22pDXzkTZCLDE+9AmGSUkWxeh/nZReA==",
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "css-selector-tokenizer": "^0.7.0",
-        "icss-utils": "^2.1.0",
-        "loader-utils": "^1.0.2",
-        "lodash.camelcase": "^4.3.0",
-        "postcss": "^6.0.23",
-        "postcss-modules-extract-imports": "^1.2.0",
-        "postcss-modules-local-by-default": "^1.2.0",
-        "postcss-modules-scope": "^1.1.0",
-        "postcss-modules-values": "^1.3.0",
-        "postcss-value-parser": "^3.3.0",
-        "source-list-map": "^2.0.0"
+        "babel-code-frame": "6.26.0",
+        "css-selector-tokenizer": "0.7.1",
+        "icss-utils": "2.1.0",
+        "loader-utils": "1.2.3",
+        "lodash.camelcase": "4.3.0",
+        "postcss": "6.0.23",
+        "postcss-modules-extract-imports": "1.2.1",
+        "postcss-modules-local-by-default": "1.2.0",
+        "postcss-modules-scope": "1.1.0",
+        "postcss-modules-values": "1.3.0",
+        "postcss-value-parser": "3.3.1",
+        "source-list-map": "2.0.1"
       }
     },
     "css-select": {
@@ -4290,10 +4289,10 @@
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
       "integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
       "requires": {
-        "boolbase": "^1.0.0",
-        "css-what": "^2.1.2",
-        "domutils": "^1.7.0",
-        "nth-check": "^1.0.2"
+        "boolbase": "1.0.0",
+        "css-what": "2.1.2",
+        "domutils": "1.7.0",
+        "nth-check": "1.0.2"
       }
     },
     "css-select-base-adapter": {
@@ -4306,9 +4305,9 @@
       "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
       "integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
       "requires": {
-        "cssesc": "^0.1.0",
-        "fastparse": "^1.1.1",
-        "regexpu-core": "^1.0.0"
+        "cssesc": "0.1.0",
+        "fastparse": "1.1.2",
+        "regexpu-core": "1.0.0"
       },
       "dependencies": {
         "jsesc": {
@@ -4321,9 +4320,9 @@
           "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
           "requires": {
-            "regenerate": "^1.2.1",
-            "regjsgen": "^0.2.0",
-            "regjsparser": "^0.1.4"
+            "regenerate": "1.4.0",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
           }
         },
         "regjsgen": {
@@ -4336,7 +4335,7 @@
           "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
           "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
           "requires": {
-            "jsesc": "~0.5.0"
+            "jsesc": "0.5.0"
           }
         }
       }
@@ -4346,8 +4345,8 @@
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
       "integrity": "sha512-joNNW1gCp3qFFzj4St6zk+Wh/NBv0vM5YbEreZk0SD4S23S+1xBKb6cLDg2uj4P4k/GUMlIm6cKIDqIG+vdt0w==",
       "requires": {
-        "mdn-data": "~1.1.0",
-        "source-map": "^0.5.3"
+        "mdn-data": "1.1.4",
+        "source-map": "0.5.7"
       }
     },
     "css-unit-converter": {
@@ -4380,10 +4379,10 @@
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.8.tgz",
       "integrity": "sha512-5GIY0VzAHORpbKiL3rMXp4w4M1Ki+XlXgEXyuWXVd3h6hlASb+9Vo76dNP56/elLMVBBsUfusCo1q56uW0UWig==",
       "requires": {
-        "cosmiconfig": "^5.0.0",
-        "cssnano-preset-default": "^4.0.6",
-        "is-resolvable": "^1.0.0",
-        "postcss": "^7.0.0"
+        "cosmiconfig": "5.0.7",
+        "cssnano-preset-default": "4.0.6",
+        "is-resolvable": "1.1.0",
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -4391,9 +4390,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -4401,7 +4400,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -4411,9 +4410,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -4426,7 +4425,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -4436,36 +4435,36 @@
       "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.6.tgz",
       "integrity": "sha512-UPboYbFaJFtDUhJ4fqctThWbbyF4q01/7UhsZbLzp35l+nUxtzh1SifoVlEfyLM3n3Z0htd8B1YlCxy9i+bQvg==",
       "requires": {
-        "css-declaration-sorter": "^4.0.1",
-        "cssnano-util-raw-cache": "^4.0.1",
-        "postcss": "^7.0.0",
-        "postcss-calc": "^7.0.0",
-        "postcss-colormin": "^4.0.2",
-        "postcss-convert-values": "^4.0.1",
-        "postcss-discard-comments": "^4.0.1",
-        "postcss-discard-duplicates": "^4.0.2",
-        "postcss-discard-empty": "^4.0.1",
-        "postcss-discard-overridden": "^4.0.1",
-        "postcss-merge-longhand": "^4.0.10",
-        "postcss-merge-rules": "^4.0.2",
-        "postcss-minify-font-values": "^4.0.2",
-        "postcss-minify-gradients": "^4.0.1",
-        "postcss-minify-params": "^4.0.1",
-        "postcss-minify-selectors": "^4.0.1",
-        "postcss-normalize-charset": "^4.0.1",
-        "postcss-normalize-display-values": "^4.0.1",
-        "postcss-normalize-positions": "^4.0.1",
-        "postcss-normalize-repeat-style": "^4.0.1",
-        "postcss-normalize-string": "^4.0.1",
-        "postcss-normalize-timing-functions": "^4.0.1",
-        "postcss-normalize-unicode": "^4.0.1",
-        "postcss-normalize-url": "^4.0.1",
-        "postcss-normalize-whitespace": "^4.0.1",
-        "postcss-ordered-values": "^4.1.1",
-        "postcss-reduce-initial": "^4.0.2",
-        "postcss-reduce-transforms": "^4.0.1",
-        "postcss-svgo": "^4.0.1",
-        "postcss-unique-selectors": "^4.0.1"
+        "css-declaration-sorter": "4.0.1",
+        "cssnano-util-raw-cache": "4.0.1",
+        "postcss": "7.0.14",
+        "postcss-calc": "7.0.1",
+        "postcss-colormin": "4.0.2",
+        "postcss-convert-values": "4.0.1",
+        "postcss-discard-comments": "4.0.1",
+        "postcss-discard-duplicates": "4.0.2",
+        "postcss-discard-empty": "4.0.1",
+        "postcss-discard-overridden": "4.0.1",
+        "postcss-merge-longhand": "4.0.10",
+        "postcss-merge-rules": "4.0.2",
+        "postcss-minify-font-values": "4.0.2",
+        "postcss-minify-gradients": "4.0.1",
+        "postcss-minify-params": "4.0.1",
+        "postcss-minify-selectors": "4.0.1",
+        "postcss-normalize-charset": "4.0.1",
+        "postcss-normalize-display-values": "4.0.1",
+        "postcss-normalize-positions": "4.0.1",
+        "postcss-normalize-repeat-style": "4.0.1",
+        "postcss-normalize-string": "4.0.1",
+        "postcss-normalize-timing-functions": "4.0.1",
+        "postcss-normalize-unicode": "4.0.1",
+        "postcss-normalize-url": "4.0.1",
+        "postcss-normalize-whitespace": "4.0.1",
+        "postcss-ordered-values": "4.1.1",
+        "postcss-reduce-initial": "4.0.2",
+        "postcss-reduce-transforms": "4.0.1",
+        "postcss-svgo": "4.0.1",
+        "postcss-unique-selectors": "4.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -4473,9 +4472,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -4483,7 +4482,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -4493,9 +4492,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -4508,7 +4507,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -4528,7 +4527,7 @@
       "resolved": "https://registry.npmjs.org/cssnano-util-raw-cache/-/cssnano-util-raw-cache-4.0.1.tgz",
       "integrity": "sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==",
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -4536,9 +4535,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -4546,7 +4545,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -4556,9 +4555,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -4571,7 +4570,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -4594,8 +4593,8 @@
           "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
           "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
           "requires": {
-            "mdn-data": "~1.1.0",
-            "source-map": "^0.5.3"
+            "mdn-data": "1.1.4",
+            "source-map": "0.5.7"
           }
         }
       }
@@ -4610,7 +4609,7 @@
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
       "integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
       "requires": {
-        "cssom": "0.3.x"
+        "cssom": "0.3.4"
       }
     },
     "csstype": {
@@ -4633,7 +4632,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "data-urls": {
@@ -4641,9 +4640,9 @@
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
       "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
       "requires": {
-        "abab": "^2.0.0",
-        "whatwg-mimetype": "^2.2.0",
-        "whatwg-url": "^7.0.0"
+        "abab": "2.0.0",
+        "whatwg-mimetype": "2.3.0",
+        "whatwg-url": "7.0.0"
       }
     },
     "date-fns": {
@@ -4662,9 +4661,9 @@
       "integrity": "sha512-oVCmIbPI+uQ861ObWWvsF8p2OSuBkU2fR2sAVlhMll4p7p6Ks7IbXYtXXN916VQfIfpH/CmOzSlc0TxRva+9Fw==",
       "dev": true,
       "requires": {
-        "tslint-clean-code": "^0.2.5",
-        "tslint-eslint-rules": "^5.1.0",
-        "tslint-no-circular-imports": "^0.2.1"
+        "tslint-clean-code": "0.2.9",
+        "tslint-eslint-rules": "5.4.0",
+        "tslint-no-circular-imports": "0.2.1"
       }
     },
     "debug": {
@@ -4672,7 +4671,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.1"
       }
     },
     "decache": {
@@ -4681,7 +4680,7 @@
       "integrity": "sha1-T1A2+9ZYH8yXI3rDlUokS5U2wto=",
       "optional": true,
       "requires": {
-        "find": "^0.2.4"
+        "find": "0.2.9"
       }
     },
     "decamelize": {
@@ -4694,7 +4693,7 @@
       "resolved": "https://registry.npmjs.org/decentraland-commons/-/decentraland-commons-5.1.0.tgz",
       "integrity": "sha1-U/vuRFq4Tynuj0whO85qN2+RAOw=",
       "requires": {
-        "rollbar": "^2.3.9"
+        "rollbar": "2.5.2"
       }
     },
     "decentraland-dapps": {
@@ -4703,25 +4702,25 @@
       "integrity": "sha512-FQm4Jt5jv4oXRI44bJqzEkyooijmqAJeFpO7Ke0EFt41rGKTtK250nZXC4mTPjBIqC0epI2bMTP7Jsk1yVxukw==",
       "requires": {
         "@types/flat": "0.0.28",
-        "@types/node": "^10.1.2",
-        "@types/react": "^16.4.7",
-        "@types/react-intl": "^2.3.8",
-        "@types/react-redux": "^6.0.4",
-        "@types/react-router-redux": "^5.0.14",
-        "@types/redux-storage": "^4.0.11",
-        "@types/redux-storage-engine-localstorage": "^1.1.0",
+        "@types/node": "10.12.21",
+        "@types/react": "16.8.1",
+        "@types/react-intl": "2.3.15",
+        "@types/react-redux": "6.0.13",
+        "@types/react-router-redux": "5.0.17",
+        "@types/redux-storage": "4.0.11",
+        "@types/redux-storage-engine-localstorage": "1.1.0",
         "@types/segment-analytics": "0.0.28",
-        "@types/uuid": "^3.4.3",
-        "axios": "^0.17.0",
-        "date-fns": "^1.29.0",
-        "flat": "^4.1.0",
-        "react-intl": "^2.4.0",
-        "redux-storage": "^4.1.2",
-        "redux-storage-decorator-filter": "^1.1.8",
-        "redux-storage-engine-localstorage": "^1.1.4",
-        "tslint": "^5.7.0",
-        "tslint-config-prettier": "^1.10.0",
-        "typesafe-actions": "^2.0.3"
+        "@types/uuid": "3.4.4",
+        "axios": "0.17.1",
+        "date-fns": "1.30.1",
+        "flat": "4.1.0",
+        "react-intl": "2.8.0",
+        "redux-storage": "4.1.2",
+        "redux-storage-decorator-filter": "1.1.8",
+        "redux-storage-engine-localstorage": "1.1.4",
+        "tslint": "5.12.1",
+        "tslint-config-prettier": "1.18.0",
+        "typesafe-actions": "2.2.0"
       },
       "dependencies": {
         "@types/node": {
@@ -4734,8 +4733,8 @@
           "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.1.tgz",
           "integrity": "sha512-tD1ETKJcuhANOejRc/p7OgQ16DKnbGi0M3LccelKlPnUCDp2a5koVxZFoRN9HN+A+m84HB5VGN7I+r3nNhS3PA==",
           "requires": {
-            "@types/prop-types": "*",
-            "csstype": "^2.2.0"
+            "@types/prop-types": "15.5.8",
+            "csstype": "2.6.2"
           }
         },
         "typesafe-actions": {
@@ -4751,8 +4750,8 @@
       "integrity": "sha512-O8Iyk6inlMZ2dlcdd2OHkEPrmCUO2+Mt1hx2Jr9Lh7O+IW6nQhCxKBEQUJyG93baIRqZ8/oVZld/Z0bZ/v2xNQ==",
       "dev": true,
       "requires": {
-        "typescript": "^3.2.2",
-        "uglify-js": "^3.4.9"
+        "typescript": "3.2.2",
+        "uglify-js": "3.4.9"
       }
     },
     "decentraland-eth": {
@@ -4760,14 +4759,14 @@
       "resolved": "https://registry.npmjs.org/decentraland-eth/-/decentraland-eth-8.7.0.tgz",
       "integrity": "sha512-0OX2fFE8sn1EmUJANyYA1A6ZrA+tTEZDz5CRbXWSRvVt2+4hDgp8Uy2sH9hDMZIhn/2ffwFkIvKMC8wcDt8HcA==",
       "requires": {
-        "@ledgerhq/hw-app-eth": "^4.21.0",
-        "@ledgerhq/hw-transport-u2f": "^4.21.0",
-        "@ledgerhq/web3-subprovider": "^4.21.0",
-        "comma-separated-values": "^3.6.4",
-        "ethereumjs-util": "^5.1.5",
-        "npx": "^10.2.0",
-        "web3": "^0.20.7",
-        "web3-provider-engine": "^14.0.6"
+        "@ledgerhq/hw-app-eth": "4.35.0",
+        "@ledgerhq/hw-transport-u2f": "4.35.0",
+        "@ledgerhq/web3-subprovider": "4.35.0",
+        "comma-separated-values": "3.6.4",
+        "ethereumjs-util": "5.2.0",
+        "npx": "10.2.0",
+        "web3": "0.20.7",
+        "web3-provider-engine": "14.1.0"
       }
     },
     "decentraland-rpc": {
@@ -4776,17 +4775,17 @@
       "integrity": "sha512-irgcOmPceTnW3QfgZOru19j8YmMYlTOaaIyekt8stpo5ZneWQbsFxr77Ru0X146IFIZfdJkvBLe0zkJbC6m/hw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
-        "glob": "^7.1.3",
-        "istanbul-instrumenter-loader": "^3.0.1",
-        "progress": "^2.0.1",
-        "raw-loader": "^0.5.1",
-        "rimraf": "^2.6.2",
-        "ts-loader": "^5.3.1",
-        "tsconfig-paths-webpack-plugin": "^3.2.0",
-        "typescript": "^3.2.2",
-        "url-loader": "^1.1.2",
-        "webpack": "^4.27.1"
+        "chalk": "2.4.1",
+        "glob": "7.1.3",
+        "istanbul-instrumenter-loader": "3.0.1",
+        "progress": "2.0.3",
+        "raw-loader": "0.5.1",
+        "rimraf": "2.6.3",
+        "ts-loader": "5.3.3",
+        "tsconfig-paths-webpack-plugin": "3.2.0",
+        "typescript": "3.2.2",
+        "url-loader": "1.1.2",
+        "webpack": "4.29.1"
       },
       "dependencies": {
         "@webassemblyjs/ast": {
@@ -4863,7 +4862,7 @@
           "integrity": "sha512-Mmqx/cS68K1tSrvRLtaV/Lp3NZWzXtOHUW2IvDvl2sihAwJh4ACE0eL6A8FvMyDG9abes3saB6dMimLOs+HMoQ==",
           "dev": true,
           "requires": {
-            "@xtuc/ieee754": "^1.2.0"
+            "@xtuc/ieee754": "1.2.0"
           }
         },
         "@webassemblyjs/leb128": {
@@ -4985,16 +4984,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.3",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -5003,7 +5002,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -5023,8 +5022,8 @@
           "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
           "dev": true,
           "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
+            "esrecurse": "4.2.1",
+            "estraverse": "4.2.0"
           }
         },
         "expand-brackets": {
@@ -5033,13 +5032,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -5048,7 +5047,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -5057,7 +5056,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -5066,7 +5065,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -5075,7 +5074,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -5086,7 +5085,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -5095,7 +5094,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -5106,9 +5105,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -5125,14 +5124,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -5141,7 +5140,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -5150,7 +5149,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -5161,10 +5160,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -5173,7 +5172,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -5184,7 +5183,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -5193,7 +5192,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -5202,9 +5201,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-number": {
@@ -5213,7 +5212,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5222,7 +5221,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -5239,19 +5238,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "ms": {
@@ -5272,9 +5271,9 @@
           "integrity": "sha512-dXHkKmw8FhPqu8asTc1puBfe3TehOCo2+RmOOev5suNCIYBcT626kxiWg1NBVkwc4rO8BGa7gP70W7VXuqHrjg==",
           "dev": true,
           "requires": {
-            "loader-utils": "^1.1.0",
-            "mime": "^2.0.3",
-            "schema-utils": "^1.0.0"
+            "loader-utils": "1.2.3",
+            "mime": "2.4.0",
+            "schema-utils": "1.0.0"
           }
         },
         "webpack": {
@@ -5287,26 +5286,26 @@
             "@webassemblyjs/helper-module-context": "1.7.11",
             "@webassemblyjs/wasm-edit": "1.7.11",
             "@webassemblyjs/wasm-parser": "1.7.11",
-            "acorn": "^6.0.5",
-            "acorn-dynamic-import": "^4.0.0",
-            "ajv": "^6.1.0",
-            "ajv-keywords": "^3.1.0",
-            "chrome-trace-event": "^1.0.0",
-            "enhanced-resolve": "^4.1.0",
-            "eslint-scope": "^4.0.0",
-            "json-parse-better-errors": "^1.0.2",
-            "loader-runner": "^2.3.0",
-            "loader-utils": "^1.1.0",
-            "memory-fs": "~0.4.1",
-            "micromatch": "^3.1.8",
-            "mkdirp": "~0.5.0",
-            "neo-async": "^2.5.0",
-            "node-libs-browser": "^2.0.0",
-            "schema-utils": "^0.4.4",
-            "tapable": "^1.1.0",
-            "terser-webpack-plugin": "^1.1.0",
-            "watchpack": "^1.5.0",
-            "webpack-sources": "^1.3.0"
+            "acorn": "6.0.7",
+            "acorn-dynamic-import": "4.0.0",
+            "ajv": "6.8.1",
+            "ajv-keywords": "3.3.0",
+            "chrome-trace-event": "1.0.0",
+            "enhanced-resolve": "4.1.0",
+            "eslint-scope": "4.0.0",
+            "json-parse-better-errors": "1.0.2",
+            "loader-runner": "2.4.0",
+            "loader-utils": "1.2.3",
+            "memory-fs": "0.4.1",
+            "micromatch": "3.1.10",
+            "mkdirp": "0.5.1",
+            "neo-async": "2.6.0",
+            "node-libs-browser": "2.2.0",
+            "schema-utils": "0.4.7",
+            "tapable": "1.1.1",
+            "terser-webpack-plugin": "1.1.0",
+            "watchpack": "1.6.0",
+            "webpack-sources": "1.3.0"
           },
           "dependencies": {
             "schema-utils": {
@@ -5315,8 +5314,8 @@
               "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
               "dev": true,
               "requires": {
-                "ajv": "^6.1.0",
-                "ajv-keywords": "^3.1.0"
+                "ajv": "6.8.1",
+                "ajv-keywords": "3.3.0"
               }
             }
           }
@@ -5328,11 +5327,11 @@
       "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-1.17.0.tgz",
       "integrity": "sha512-V6sVYFO8pSlRgYz0Z40Ver2BFyw/1LZ/3lMnmhCKKmrCNSM6XTjq7P4I0C4eNIXNktGx6V2BsxO6nZzLMOkemQ==",
       "requires": {
-        "balloon-css": "^0.5.0",
-        "ethereum-blockies": "^0.1.1",
-        "parallax-js": "^3.1.0",
-        "semantic-ui-css": "^2.3.2",
-        "semantic-ui-react": "^0.84.0"
+        "balloon-css": "0.5.0",
+        "ethereum-blockies": "0.1.1",
+        "parallax-js": "3.1.0",
+        "semantic-ui-css": "2.4.1",
+        "semantic-ui-react": "0.84.0"
       }
     },
     "decode-uri-component": {
@@ -5366,8 +5365,8 @@
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.2.tgz",
       "integrity": "sha512-lAc4i9QJR0YHSDFdzeBQKfZ1SRDG3hsJNEkrpcZa8QhBfidLAilT60BDEIVUUGqosFp425KOgB3uYqcnQrWafQ==",
       "requires": {
-        "execa": "^0.10.0",
-        "ip-regex": "^2.1.0"
+        "execa": "0.10.0",
+        "ip-regex": "2.1.0"
       },
       "dependencies": {
         "execa": {
@@ -5375,13 +5374,13 @@
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
           "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
           "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "6.0.5",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "get-stream": {
@@ -5396,7 +5395,7 @@
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
       "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
       "requires": {
-        "strip-bom": "^2.0.0"
+        "strip-bom": "2.0.0"
       }
     },
     "deferred-leveldown": {
@@ -5404,7 +5403,7 @@
       "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
       "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
       "requires": {
-        "abstract-leveldown": "~2.6.0"
+        "abstract-leveldown": "2.6.3"
       }
     },
     "define-properties": {
@@ -5412,7 +5411,7 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "requires": {
-        "object-keys": "^1.0.12"
+        "object-keys": "1.0.12"
       }
     },
     "define-property": {
@@ -5420,8 +5419,8 @@
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -5429,7 +5428,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -5437,7 +5436,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -5445,9 +5444,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "kind-of": {
@@ -5467,12 +5466,12 @@
       "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
       "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "requires": {
-        "globby": "^6.1.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "p-map": "^1.1.1",
-        "pify": "^3.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "6.1.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "p-map": "1.2.0",
+        "pify": "3.0.0",
+        "rimraf": "2.6.3"
       },
       "dependencies": {
         "globby": {
@@ -5480,11 +5479,11 @@
           "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "requires": {
-            "array-union": "^1.0.1",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "array-union": "1.0.2",
+            "glob": "7.1.3",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           },
           "dependencies": {
             "pify": {
@@ -5516,8 +5515,8 @@
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "requires": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "destroy": {
@@ -5530,7 +5529,7 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "detect-newline": {
@@ -5548,8 +5547,8 @@
       "resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
       "integrity": "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==",
       "requires": {
-        "address": "^1.0.1",
-        "debug": "^2.6.0"
+        "address": "1.0.3",
+        "debug": "2.6.9"
       },
       "dependencies": {
         "debug": {
@@ -5577,9 +5576,9 @@
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
+        "bn.js": "4.11.8",
+        "miller-rabin": "4.0.1",
+        "randombytes": "2.0.6"
       }
     },
     "dir-glob": {
@@ -5587,7 +5586,7 @@
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
       "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
       "requires": {
-        "path-type": "^3.0.0"
+        "path-type": "3.0.0"
       },
       "dependencies": {
         "path-type": {
@@ -5595,7 +5594,7 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "pify": {
@@ -5615,8 +5614,8 @@
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
       "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
       "requires": {
-        "ip": "^1.1.0",
-        "safe-buffer": "^5.0.1"
+        "ip": "1.1.5",
+        "safe-buffer": "5.1.2"
       }
     },
     "dns-txt": {
@@ -5624,7 +5623,7 @@
       "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "requires": {
-        "buffer-indexof": "^1.0.0"
+        "buffer-indexof": "1.1.1"
       }
     },
     "doctrine": {
@@ -5632,7 +5631,7 @@
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "requires": {
-        "esutils": "^2.0.2"
+        "esutils": "2.0.2"
       }
     },
     "dom-converter": {
@@ -5640,7 +5639,7 @@
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "requires": {
-        "utila": "~0.4"
+        "utila": "0.4.0"
       }
     },
     "dom-serializer": {
@@ -5648,8 +5647,8 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "1.1.3",
+        "entities": "1.1.2"
       },
       "dependencies": {
         "domelementtype": {
@@ -5679,7 +5678,7 @@
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
       "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
       "requires": {
-        "webidl-conversions": "^4.0.2"
+        "webidl-conversions": "4.0.2"
       }
     },
     "domhandler": {
@@ -5687,7 +5686,7 @@
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
       "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "1.3.1"
       }
     },
     "domutils": {
@@ -5695,8 +5694,8 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.1"
       }
     },
     "dot-prop": {
@@ -5704,7 +5703,7 @@
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "dotenv": {
@@ -5722,9 +5721,9 @@
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
       "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
       "requires": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
+        "browserify-aes": "1.2.0",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7"
       }
     },
     "duplexer": {
@@ -5737,10 +5736,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "stream-shift": "1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -5748,8 +5747,8 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "ee-first": {
@@ -5767,13 +5766,13 @@
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
       "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.7",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "emoji-regex": {
@@ -5796,7 +5795,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "0.4.24"
       }
     },
     "end-of-stream": {
@@ -5804,7 +5803,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "enhanced-resolve": {
@@ -5812,9 +5811,9 @@
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
       "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.4.0",
-        "tapable": "^1.0.0"
+        "graceful-fs": "4.1.15",
+        "memory-fs": "0.4.1",
+        "tapable": "1.1.1"
       }
     },
     "entities": {
@@ -5827,7 +5826,7 @@
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
-        "prr": "~1.0.1"
+        "prr": "1.0.1"
       }
     },
     "error-ex": {
@@ -5835,7 +5834,7 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "error-stack-parser": {
@@ -5843,7 +5842,7 @@
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.3.tgz",
       "integrity": "sha1-+tpuOpzSsOCA5tb8dRQYZJc081w=",
       "requires": {
-        "stackframe": "^0.3.1"
+        "stackframe": "0.3.1"
       }
     },
     "es-abstract": {
@@ -5851,12 +5850,12 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
       "requires": {
-        "es-to-primitive": "^1.2.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
+        "es-to-primitive": "1.2.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "is-callable": "1.1.4",
+        "is-regex": "1.0.4",
+        "object-keys": "1.0.12"
       }
     },
     "es-to-primitive": {
@@ -5864,9 +5863,9 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
+        "is-callable": "1.1.4",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.2"
       }
     },
     "escape-html": {
@@ -5884,11 +5883,11 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
       "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
       "requires": {
-        "esprima": "^3.1.3",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -5909,44 +5908,44 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.6.0.tgz",
       "integrity": "sha512-/eVYs9VVVboX286mBK7bbKnO1yamUy2UCRjiY6MryhQL2PaaXCExsCQ2aO83OeYRhU2eCU/FMFP+tVMoOrzNrA==",
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "ajv": "^6.5.3",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
-        "debug": "^3.1.0",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^4.0.0",
-        "eslint-utils": "^1.3.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^4.0.0",
-        "esquery": "^1.0.1",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
-        "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.7.0",
-        "ignore": "^4.0.6",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^6.1.0",
-        "is-resolvable": "^1.1.0",
-        "js-yaml": "^3.12.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.5",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
-        "progress": "^2.0.0",
-        "regexpp": "^2.0.0",
-        "require-uncached": "^1.0.3",
-        "semver": "^5.5.1",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "^2.0.1",
-        "table": "^4.0.3",
-        "text-table": "^0.2.0"
+        "@babel/code-frame": "7.0.0",
+        "ajv": "6.8.1",
+        "chalk": "2.4.1",
+        "cross-spawn": "6.0.5",
+        "debug": "3.2.6",
+        "doctrine": "2.1.0",
+        "eslint-scope": "4.0.0",
+        "eslint-utils": "1.3.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "4.1.0",
+        "esquery": "1.0.1",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.3",
+        "globals": "11.10.0",
+        "ignore": "4.0.6",
+        "imurmurhash": "0.1.4",
+        "inquirer": "6.2.2",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.12.1",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.11",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.3",
+        "regexpp": "2.0.1",
+        "require-uncached": "1.0.3",
+        "semver": "5.6.0",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "4.0.3",
+        "text-table": "0.2.0"
       },
       "dependencies": {
         "debug": {
@@ -5954,7 +5953,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "eslint-scope": {
@@ -5962,8 +5961,8 @@
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
           "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
           "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
+            "esrecurse": "4.2.1",
+            "estraverse": "4.2.0"
           }
         }
       }
@@ -5973,7 +5972,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-3.0.6.tgz",
       "integrity": "sha512-VL5rA1EBZv7f9toc9x71or7nr4jRmwCH4V9JKB9DFVaTLOLI9+vjWLgQLjMu3xR9iUT80dty86RbCfNaKyrFFg==",
       "requires": {
-        "confusing-browser-globals": "^1.0.5"
+        "confusing-browser-globals": "1.0.5"
       }
     },
     "eslint-import-resolver-node": {
@@ -5981,8 +5980,8 @@
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
       "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "requires": {
-        "debug": "^2.6.9",
-        "resolve": "^1.5.0"
+        "debug": "2.6.9",
+        "resolve": "1.8.1"
       },
       "dependencies": {
         "debug": {
@@ -6005,11 +6004,11 @@
       "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-2.1.1.tgz",
       "integrity": "sha512-1GrJFfSevQdYpoDzx8mEE2TDWsb/zmFuY09l6hURg1AeFIKQOvZ+vH0UPjzmd1CZIbfTV5HUkMeBmFiDBkgIsQ==",
       "requires": {
-        "loader-fs-cache": "^1.0.0",
-        "loader-utils": "^1.0.2",
-        "object-assign": "^4.0.1",
-        "object-hash": "^1.1.4",
-        "rimraf": "^2.6.1"
+        "loader-fs-cache": "1.0.1",
+        "loader-utils": "1.2.3",
+        "object-assign": "4.1.1",
+        "object-hash": "1.3.1",
+        "rimraf": "2.6.3"
       }
     },
     "eslint-module-utils": {
@@ -6017,8 +6016,8 @@
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
       "integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
       "requires": {
-        "debug": "^2.6.8",
-        "pkg-dir": "^2.0.0"
+        "debug": "2.6.9",
+        "pkg-dir": "2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -6041,7 +6040,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.50.1.tgz",
       "integrity": "sha512-9kRxF9hfM/O6WGZcZPszOVPd2W0TLHBtceulLTsGfwMPtiCCLnCW0ssRiOOiXyqrCA20pm1iXdXm7gQeN306zQ==",
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "eslint-plugin-import": {
@@ -6049,16 +6048,16 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
       "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
       "requires": {
-        "contains-path": "^0.1.0",
-        "debug": "^2.6.8",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.1",
-        "eslint-module-utils": "^2.2.0",
-        "has": "^1.0.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.3",
-        "read-pkg-up": "^2.0.0",
-        "resolve": "^1.6.0"
+        "eslint-import-resolver-node": "0.3.2",
+        "eslint-module-utils": "2.3.0",
+        "has": "1.0.3",
+        "lodash": "4.17.11",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "2.0.0",
+        "resolve": "1.8.1"
       },
       "dependencies": {
         "debug": {
@@ -6074,8 +6073,8 @@
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
           }
         },
         "find-up": {
@@ -6083,7 +6082,7 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "load-json-file": {
@@ -6091,10 +6090,10 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.15",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
           }
         },
         "locate-path": {
@@ -6102,8 +6101,8 @@
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "ms": {
@@ -6116,7 +6115,7 @@
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
@@ -6124,7 +6123,7 @@
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.3.0"
           }
         },
         "p-try": {
@@ -6137,7 +6136,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.2"
           }
         },
         "path-type": {
@@ -6145,7 +6144,7 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "requires": {
-            "pify": "^2.0.0"
+            "pify": "2.3.0"
           }
         },
         "read-pkg": {
@@ -6153,9 +6152,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "requires": {
-            "load-json-file": "^2.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.2",
+            "path-type": "2.0.0"
           }
         },
         "read-pkg-up": {
@@ -6163,8 +6162,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
           }
         },
         "strip-bom": {
@@ -6179,14 +6178,14 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.1.2.tgz",
       "integrity": "sha512-7gSSmwb3A+fQwtw0arguwMdOdzmKUgnUcbSNlo+GjKLAQFuC2EZxWqG9XHRI8VscBJD5a8raz3RuxQNFW+XJbw==",
       "requires": {
-        "aria-query": "^3.0.0",
-        "array-includes": "^3.0.3",
-        "ast-types-flow": "^0.0.7",
-        "axobject-query": "^2.0.1",
-        "damerau-levenshtein": "^1.0.4",
-        "emoji-regex": "^6.5.1",
-        "has": "^1.0.3",
-        "jsx-ast-utils": "^2.0.1"
+        "aria-query": "3.0.0",
+        "array-includes": "3.0.3",
+        "ast-types-flow": "0.0.7",
+        "axobject-query": "2.0.2",
+        "damerau-levenshtein": "1.0.4",
+        "emoji-regex": "6.5.1",
+        "has": "1.0.3",
+        "jsx-ast-utils": "2.0.1"
       }
     },
     "eslint-plugin-prettier": {
@@ -6195,8 +6194,8 @@
       "integrity": "sha512-CStQYJgALoQBw3FsBzH0VOVDRnJ/ZimUlpLm226U8qgqYJfPOY/CPK6wyRInMxh73HSKg5wyRwdS4BVYYHwokA==",
       "dev": true,
       "requires": {
-        "fast-diff": "^1.1.1",
-        "jest-docblock": "^21.0.0"
+        "fast-diff": "1.2.0",
+        "jest-docblock": "21.2.0"
       },
       "dependencies": {
         "jest-docblock": {
@@ -6212,11 +6211,11 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz",
       "integrity": "sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==",
       "requires": {
-        "array-includes": "^3.0.3",
-        "doctrine": "^2.1.0",
-        "has": "^1.0.3",
-        "jsx-ast-utils": "^2.0.1",
-        "prop-types": "^15.6.2"
+        "array-includes": "3.0.3",
+        "doctrine": "2.1.0",
+        "has": "1.0.3",
+        "jsx-ast-utils": "2.0.1",
+        "prop-types": "15.6.2"
       }
     },
     "eslint-scope": {
@@ -6224,8 +6223,8 @@
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
       }
     },
     "eslint-utils": {
@@ -6243,9 +6242,9 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
       "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
       "requires": {
-        "acorn": "^6.0.2",
-        "acorn-jsx": "^5.0.0",
-        "eslint-visitor-keys": "^1.0.0"
+        "acorn": "6.0.7",
+        "acorn-jsx": "5.0.1",
+        "eslint-visitor-keys": "1.0.0"
       }
     },
     "esprima": {
@@ -6258,7 +6257,7 @@
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "4.2.0"
       }
     },
     "esrecurse": {
@@ -6266,7 +6265,7 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "4.2.0"
       }
     },
     "estraverse": {
@@ -6289,13 +6288,13 @@
       "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-3.0.1.tgz",
       "integrity": "sha512-WUVxWLuhMmsfenfZvFO5sbl1qFY2IqUlw/FPVmjjdElpqLsZtSG+wPe9Dz7W/sB6e80HgFKknOmKk2eNlznHug==",
       "requires": {
-        "eth-query": "^2.1.0",
-        "ethereumjs-tx": "^1.3.3",
-        "ethereumjs-util": "^5.1.3",
-        "ethjs-util": "^0.1.3",
-        "json-rpc-engine": "^3.6.0",
-        "pify": "^2.3.0",
-        "tape": "^4.6.3"
+        "eth-query": "2.1.2",
+        "ethereumjs-tx": "1.3.7",
+        "ethereumjs-util": "5.2.0",
+        "ethjs-util": "0.1.6",
+        "json-rpc-engine": "3.8.0",
+        "pify": "2.3.0",
+        "tape": "4.9.2"
       }
     },
     "eth-json-rpc-infura": {
@@ -6303,11 +6302,11 @@
       "resolved": "https://registry.npmjs.org/eth-json-rpc-infura/-/eth-json-rpc-infura-3.2.0.tgz",
       "integrity": "sha512-FLcpdxPRVBCUc7yoE+wHGvyYg2lATedP+/q7PsKvaSzQpJbgTG4ZjLnyrLanxDr6M1k/dSNa6V5QnILwjUKJcw==",
       "requires": {
-        "cross-fetch": "^2.1.1",
-        "eth-json-rpc-middleware": "^1.5.0",
-        "json-rpc-engine": "^3.4.0",
-        "json-rpc-error": "^2.0.0",
-        "tape": "^4.8.0"
+        "cross-fetch": "2.2.3",
+        "eth-json-rpc-middleware": "1.6.0",
+        "json-rpc-engine": "3.8.0",
+        "json-rpc-error": "2.0.0",
+        "tape": "4.9.2"
       }
     },
     "eth-json-rpc-middleware": {
@@ -6315,19 +6314,19 @@
       "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-1.6.0.tgz",
       "integrity": "sha512-tDVCTlrUvdqHKqivYMjtFZsdD7TtpNLBCfKAcOpaVs7orBMS/A8HWro6dIzNtTZIR05FAbJ3bioFOnZpuCew9Q==",
       "requires": {
-        "async": "^2.5.0",
-        "eth-query": "^2.1.2",
-        "eth-tx-summary": "^3.1.2",
-        "ethereumjs-block": "^1.6.0",
-        "ethereumjs-tx": "^1.3.3",
-        "ethereumjs-util": "^5.1.2",
-        "ethereumjs-vm": "^2.1.0",
-        "fetch-ponyfill": "^4.0.0",
-        "json-rpc-engine": "^3.6.0",
-        "json-rpc-error": "^2.0.0",
-        "json-stable-stringify": "^1.0.1",
-        "promise-to-callback": "^1.0.0",
-        "tape": "^4.6.3"
+        "async": "2.6.1",
+        "eth-query": "2.1.2",
+        "eth-tx-summary": "3.2.3",
+        "ethereumjs-block": "1.7.1",
+        "ethereumjs-tx": "1.3.7",
+        "ethereumjs-util": "5.2.0",
+        "ethereumjs-vm": "2.5.1",
+        "fetch-ponyfill": "4.1.0",
+        "json-rpc-engine": "3.8.0",
+        "json-rpc-error": "2.0.0",
+        "json-stable-stringify": "1.0.1",
+        "promise-to-callback": "1.0.0",
+        "tape": "4.9.2"
       },
       "dependencies": {
         "async": {
@@ -6335,7 +6334,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
-            "lodash": "^4.17.10"
+            "lodash": "4.17.11"
           }
         }
       }
@@ -6345,8 +6344,8 @@
       "resolved": "https://registry.npmjs.org/eth-query/-/eth-query-2.1.2.tgz",
       "integrity": "sha1-1nQdkAAQa1FRDHLbktY2VFam2l4=",
       "requires": {
-        "json-rpc-random-id": "^1.0.0",
-        "xtend": "^4.0.1"
+        "json-rpc-random-id": "1.0.1",
+        "xtend": "4.0.1"
       }
     },
     "eth-sig-util": {
@@ -6355,7 +6354,7 @@
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
         "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
-        "ethereumjs-util": "^5.1.1"
+        "ethereumjs-util": "5.2.0"
       }
     },
     "eth-tx-summary": {
@@ -6363,19 +6362,19 @@
       "resolved": "https://registry.npmjs.org/eth-tx-summary/-/eth-tx-summary-3.2.3.tgz",
       "integrity": "sha512-1gZpA5fKarJOVSb5OUlPnhDQuIazqAkI61zlVvf5LdG47nEgw+/qhyZnuj3CUdE/TLTKuRzPLeyXLjaB4qWTRQ==",
       "requires": {
-        "async": "^2.1.2",
-        "bn.js": "^4.11.8",
-        "clone": "^2.0.0",
-        "concat-stream": "^1.5.1",
-        "end-of-stream": "^1.1.0",
-        "eth-query": "^2.0.2",
-        "ethereumjs-block": "^1.4.1",
-        "ethereumjs-tx": "^1.1.1",
-        "ethereumjs-util": "^5.0.1",
+        "async": "2.6.1",
+        "bn.js": "4.11.8",
+        "clone": "2.1.2",
+        "concat-stream": "1.6.2",
+        "end-of-stream": "1.4.1",
+        "eth-query": "2.1.2",
+        "ethereumjs-block": "1.7.1",
+        "ethereumjs-tx": "1.3.7",
+        "ethereumjs-util": "5.2.0",
         "ethereumjs-vm": "2.3.4",
-        "through2": "^2.0.3",
-        "treeify": "^1.0.1",
-        "web3-provider-engine": "^13.3.2"
+        "through2": "2.0.5",
+        "treeify": "1.1.0",
+        "web3-provider-engine": "13.8.0"
       },
       "dependencies": {
         "async": {
@@ -6383,7 +6382,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
-            "lodash": "^4.17.10"
+            "lodash": "4.17.11"
           }
         },
         "eth-block-tracker": {
@@ -6392,20 +6391,19 @@
           "integrity": "sha512-NamWuMBIl8kmkJFVj8WzGatySTzQPQag4Xr677yFxdVtIxACFbL/dQowk0MzEqIKk93U1TwY3MjVU6mOcwZnKA==",
           "requires": {
             "async-eventemitter": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
-            "eth-query": "^2.1.0",
-            "ethereumjs-tx": "^1.3.3",
-            "ethereumjs-util": "^5.1.3",
-            "ethjs-util": "^0.1.3",
-            "json-rpc-engine": "^3.6.0",
-            "pify": "^2.3.0",
-            "tape": "^4.6.3"
+            "eth-query": "2.1.2",
+            "ethereumjs-tx": "1.3.7",
+            "ethereumjs-util": "5.2.0",
+            "ethjs-util": "0.1.6",
+            "json-rpc-engine": "3.8.0",
+            "pify": "2.3.0",
+            "tape": "4.9.2"
           },
           "dependencies": {
             "async-eventemitter": {
               "version": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
-              "from": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
               "requires": {
-                "async": "^2.4.0"
+                "async": "2.6.1"
               }
             }
           }
@@ -6420,17 +6418,17 @@
           "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.4.tgz",
           "integrity": "sha512-Y4SlzNDqxrCO58jhp98HdnZVdjOqB+HC0hoU+N/DEp1aU+hFkRX/nru5F7/HkQRPIlA6aJlQp/xIA6xZs1kspw==",
           "requires": {
-            "async": "^2.1.2",
-            "async-eventemitter": "^0.2.2",
+            "async": "2.6.1",
+            "async-eventemitter": "0.2.4",
             "ethereum-common": "0.2.0",
-            "ethereumjs-account": "^2.0.3",
-            "ethereumjs-block": "~1.7.0",
-            "ethereumjs-util": "^5.1.3",
-            "fake-merkle-patricia-tree": "^1.0.1",
-            "functional-red-black-tree": "^1.0.1",
-            "merkle-patricia-tree": "^2.1.2",
-            "rustbn.js": "~0.1.1",
-            "safe-buffer": "^5.1.1"
+            "ethereumjs-account": "2.0.5",
+            "ethereumjs-block": "1.7.1",
+            "ethereumjs-util": "5.2.0",
+            "fake-merkle-patricia-tree": "1.0.1",
+            "functional-red-black-tree": "1.0.1",
+            "merkle-patricia-tree": "2.3.2",
+            "rustbn.js": "0.1.2",
+            "safe-buffer": "5.1.2"
           }
         },
         "web3-provider-engine": {
@@ -6438,25 +6436,25 @@
           "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-13.8.0.tgz",
           "integrity": "sha512-fZXhX5VWwWpoFfrfocslyg6P7cN3YWPG/ASaevNfeO80R+nzgoPUBXcWQekSGSsNDkeRTis4aMmpmofYf1TNtQ==",
           "requires": {
-            "async": "^2.5.0",
-            "clone": "^2.0.0",
-            "eth-block-tracker": "^2.2.2",
-            "eth-sig-util": "^1.4.2",
-            "ethereumjs-block": "^1.2.2",
-            "ethereumjs-tx": "^1.2.0",
-            "ethereumjs-util": "^5.1.1",
-            "ethereumjs-vm": "^2.0.2",
-            "fetch-ponyfill": "^4.0.0",
-            "json-rpc-error": "^2.0.0",
-            "json-stable-stringify": "^1.0.1",
-            "promise-to-callback": "^1.0.0",
-            "readable-stream": "^2.2.9",
-            "request": "^2.67.0",
-            "semaphore": "^1.0.3",
-            "solc": "^0.4.2",
-            "tape": "^4.4.0",
-            "xhr": "^2.2.0",
-            "xtend": "^4.0.1"
+            "async": "2.6.1",
+            "clone": "2.1.2",
+            "eth-block-tracker": "2.3.1",
+            "eth-sig-util": "1.4.2",
+            "ethereumjs-block": "1.7.1",
+            "ethereumjs-tx": "1.3.7",
+            "ethereumjs-util": "5.2.0",
+            "ethereumjs-vm": "2.3.4",
+            "fetch-ponyfill": "4.1.0",
+            "json-rpc-error": "2.0.0",
+            "json-stable-stringify": "1.0.1",
+            "promise-to-callback": "1.0.0",
+            "readable-stream": "2.3.6",
+            "request": "2.88.0",
+            "semaphore": "1.1.0",
+            "solc": "0.4.25",
+            "tape": "4.9.2",
+            "xhr": "2.5.0",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -6473,10 +6471,9 @@
     },
     "ethereumjs-abi": {
       "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
-      "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
       "requires": {
-        "bn.js": "^4.10.0",
-        "ethereumjs-util": "^5.0.0"
+        "bn.js": "4.11.8",
+        "ethereumjs-util": "5.2.0"
       }
     },
     "ethereumjs-account": {
@@ -6484,9 +6481,9 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
       "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
       "requires": {
-        "ethereumjs-util": "^5.0.0",
-        "rlp": "^2.0.0",
-        "safe-buffer": "^5.1.1"
+        "ethereumjs-util": "5.2.0",
+        "rlp": "2.2.2",
+        "safe-buffer": "5.1.2"
       }
     },
     "ethereumjs-block": {
@@ -6494,11 +6491,11 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
       "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
       "requires": {
-        "async": "^2.0.1",
+        "async": "2.6.1",
         "ethereum-common": "0.2.0",
-        "ethereumjs-tx": "^1.2.2",
-        "ethereumjs-util": "^5.0.0",
-        "merkle-patricia-tree": "^2.1.2"
+        "ethereumjs-tx": "1.3.7",
+        "ethereumjs-util": "5.2.0",
+        "merkle-patricia-tree": "2.3.2"
       },
       "dependencies": {
         "async": {
@@ -6506,7 +6503,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
-            "lodash": "^4.17.10"
+            "lodash": "4.17.11"
           }
         },
         "ethereum-common": {
@@ -6526,8 +6523,8 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
       "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
       "requires": {
-        "ethereum-common": "^0.0.18",
-        "ethereumjs-util": "^5.0.0"
+        "ethereum-common": "0.0.18",
+        "ethereumjs-util": "5.2.0"
       }
     },
     "ethereumjs-util": {
@@ -6535,13 +6532,13 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
       "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
       "requires": {
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "ethjs-util": "^0.1.3",
-        "keccak": "^1.0.2",
-        "rlp": "^2.0.0",
-        "safe-buffer": "^5.1.1",
-        "secp256k1": "^3.0.1"
+        "bn.js": "4.11.8",
+        "create-hash": "1.2.0",
+        "ethjs-util": "0.1.6",
+        "keccak": "1.4.0",
+        "rlp": "2.2.2",
+        "safe-buffer": "5.1.2",
+        "secp256k1": "3.6.2"
       }
     },
     "ethereumjs-vm": {
@@ -6549,17 +6546,17 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.5.1.tgz",
       "integrity": "sha512-YLxPfJLHIS6caKJb2WEY+atN8N9DsXzixZfZORCKQBx6nEe1ar6rQBHBNQBBhM7Vbk/bFCOYZpU5gHShvXN1Vw==",
       "requires": {
-        "async": "^2.1.2",
-        "async-eventemitter": "^0.2.2",
-        "ethereumjs-account": "^2.0.3",
-        "ethereumjs-block": "~2.1.0",
-        "ethereumjs-common": "^0.6.0",
-        "ethereumjs-util": "^6.0.0",
-        "fake-merkle-patricia-tree": "^1.0.1",
-        "functional-red-black-tree": "^1.0.1",
-        "merkle-patricia-tree": "^2.3.2",
-        "rustbn.js": "~0.2.0",
-        "safe-buffer": "^5.1.1"
+        "async": "2.6.1",
+        "async-eventemitter": "0.2.4",
+        "ethereumjs-account": "2.0.5",
+        "ethereumjs-block": "2.1.0",
+        "ethereumjs-common": "0.6.1",
+        "ethereumjs-util": "6.0.0",
+        "fake-merkle-patricia-tree": "1.0.1",
+        "functional-red-black-tree": "1.0.1",
+        "merkle-patricia-tree": "2.3.2",
+        "rustbn.js": "0.2.0",
+        "safe-buffer": "5.1.2"
       },
       "dependencies": {
         "async": {
@@ -6567,7 +6564,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
-            "lodash": "^4.17.10"
+            "lodash": "4.17.11"
           }
         },
         "ethereumjs-block": {
@@ -6575,11 +6572,11 @@
           "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.1.0.tgz",
           "integrity": "sha512-ip+x4/7hUInX+TQfhEKsQh9MJK1Dbjp4AuPjf1UdX3udAV4beYD4EMCNIPzBLCsGS8WQZYXLpo83tVTISYNpow==",
           "requires": {
-            "async": "^2.0.1",
-            "ethereumjs-common": "^0.6.0",
-            "ethereumjs-tx": "^1.2.2",
-            "ethereumjs-util": "^5.0.0",
-            "merkle-patricia-tree": "^2.1.2"
+            "async": "2.6.1",
+            "ethereumjs-common": "0.6.1",
+            "ethereumjs-tx": "1.3.7",
+            "ethereumjs-util": "5.2.0",
+            "merkle-patricia-tree": "2.3.2"
           },
           "dependencies": {
             "ethereumjs-util": {
@@ -6587,13 +6584,13 @@
               "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
               "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
               "requires": {
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "ethjs-util": "^0.1.3",
-                "keccak": "^1.0.2",
-                "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1",
-                "secp256k1": "^3.0.1"
+                "bn.js": "4.11.8",
+                "create-hash": "1.2.0",
+                "ethjs-util": "0.1.6",
+                "keccak": "1.4.0",
+                "rlp": "2.2.2",
+                "safe-buffer": "5.1.2",
+                "secp256k1": "3.6.2"
               }
             }
           }
@@ -6603,13 +6600,13 @@
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.0.0.tgz",
           "integrity": "sha512-E3yKUyl0Fs95nvTFQZe/ZSNcofhDzUsDlA5y2uoRmf1+Ec7gpGhNCsgKkZBRh7Br5op8mJcYF/jFbmjj909+nQ==",
           "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "ethjs-util": "^0.1.6",
-            "keccak": "^1.0.2",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1",
-            "secp256k1": "^3.0.1"
+            "bn.js": "4.11.8",
+            "create-hash": "1.2.0",
+            "ethjs-util": "0.1.6",
+            "keccak": "1.4.0",
+            "rlp": "2.2.2",
+            "safe-buffer": "5.1.2",
+            "secp256k1": "3.6.2"
           }
         },
         "rustbn.js": {
@@ -6643,7 +6640,7 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
       "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
       "requires": {
-        "original": ">=0.0.5"
+        "original": "1.0.2"
       }
     },
     "evp_bytestokey": {
@@ -6651,8 +6648,8 @@
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
+        "md5.js": "1.3.5",
+        "safe-buffer": "5.1.2"
       }
     },
     "exec-sh": {
@@ -6660,7 +6657,7 @@
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
       "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
       "requires": {
-        "merge": "^1.2.0"
+        "merge": "1.2.1"
       }
     },
     "execa": {
@@ -6668,13 +6665,13 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "requires": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "6.0.5",
+        "get-stream": "4.1.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "exenv": {
@@ -6692,7 +6689,7 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "requires": {
-        "is-posix-bracket": "^0.1.0"
+        "is-posix-bracket": "0.1.1"
       }
     },
     "expand-range": {
@@ -6700,7 +6697,7 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.4"
       }
     },
     "expand-tilde": {
@@ -6708,7 +6705,7 @@
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.1"
       }
     },
     "expect": {
@@ -6716,12 +6713,12 @@
       "resolved": "https://registry.npmjs.org/expect/-/expect-23.6.0.tgz",
       "integrity": "sha512-dgSoOHgmtn/aDGRVFWclQyPDKl2CQRq0hmIEoUAuQs/2rn2NcvCWcSCovm6BLeuB/7EZuLGu2QfnR+qRt5OM4w==",
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "jest-diff": "^23.6.0",
-        "jest-get-type": "^22.1.0",
-        "jest-matcher-utils": "^23.6.0",
-        "jest-message-util": "^23.4.0",
-        "jest-regex-util": "^23.3.0"
+        "ansi-styles": "3.2.1",
+        "jest-diff": "23.6.0",
+        "jest-get-type": "22.4.3",
+        "jest-matcher-utils": "23.6.0",
+        "jest-message-util": "23.4.0",
+        "jest-regex-util": "23.3.0"
       }
     },
     "express": {
@@ -6729,36 +6726,36 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
       "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.3",
         "content-disposition": "0.5.2",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.4",
+        "proxy-addr": "2.0.4",
         "qs": "6.5.2",
-        "range-parser": "~1.2.0",
+        "range-parser": "1.2.0",
         "safe-buffer": "5.1.2",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
+        "statuses": "1.4.0",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       },
       "dependencies": {
         "array-flatten": {
@@ -6796,8 +6793,8 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -6805,7 +6802,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -6815,9 +6812,9 @@
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
       "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
       "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
+        "chardet": "0.7.0",
+        "iconv-lite": "0.4.24",
+        "tmp": "0.0.33"
       }
     },
     "extglob": {
@@ -6825,7 +6822,7 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "extsprintf": {
@@ -6838,7 +6835,7 @@
       "resolved": "https://registry.npmjs.org/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz",
       "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
       "requires": {
-        "checkpoint-store": "^1.1.0"
+        "checkpoint-store": "1.1.0"
       }
     },
     "fast-deep-equal": {
@@ -6857,12 +6854,12 @@
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.6.tgz",
       "integrity": "sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==",
       "requires": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "@nodelib/fs.stat": "^1.1.2",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.3",
-        "micromatch": "^3.1.10"
+        "@mrmlnc/readdir-enhanced": "2.2.1",
+        "@nodelib/fs.stat": "1.1.3",
+        "glob-parent": "3.1.0",
+        "is-glob": "4.0.0",
+        "merge2": "1.2.3",
+        "micromatch": "3.1.10"
       },
       "dependencies": {
         "arr-diff": {
@@ -6880,16 +6877,16 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.3",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -6897,7 +6894,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -6915,13 +6912,13 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -6929,7 +6926,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -6937,7 +6934,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -6945,7 +6942,7 @@
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -6953,7 +6950,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -6963,7 +6960,7 @@
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -6971,7 +6968,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -6981,9 +6978,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -6998,14 +6995,14 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -7013,7 +7010,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -7021,7 +7018,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -7031,10 +7028,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -7042,7 +7039,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -7052,8 +7049,8 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           },
           "dependencies": {
             "is-glob": {
@@ -7061,7 +7058,7 @@
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
               }
             }
           }
@@ -7071,7 +7068,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -7079,7 +7076,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -7087,9 +7084,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-extglob": {
@@ -7102,7 +7099,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -7110,7 +7107,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -7118,7 +7115,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -7133,19 +7130,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "ms": {
@@ -7175,7 +7172,7 @@
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
       "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
       "requires": {
-        "websocket-driver": ">=0.5.1"
+        "websocket-driver": "0.7.0"
       }
     },
     "fb-watchman": {
@@ -7183,7 +7180,7 @@
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "requires": {
-        "bser": "^2.0.0"
+        "bser": "2.0.0"
       }
     },
     "fetch-ponyfill": {
@@ -7191,7 +7188,7 @@
       "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz",
       "integrity": "sha1-rjzl9zLGReq4fkroeTQUcJsjmJM=",
       "requires": {
-        "node-fetch": "~1.7.1"
+        "node-fetch": "1.7.3"
       },
       "dependencies": {
         "node-fetch": {
@@ -7199,8 +7196,8 @@
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
           "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
           "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
+            "encoding": "0.1.12",
+            "is-stream": "1.1.0"
           }
         }
       }
@@ -7215,7 +7212,7 @@
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-entry-cache": {
@@ -7223,8 +7220,8 @@
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.4",
+        "object-assign": "4.1.1"
       }
     },
     "file-loader": {
@@ -7232,8 +7229,8 @@
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-2.0.0.tgz",
       "integrity": "sha512-YCsBfd1ZGCyonOKLxPiKPdu+8ld9HAaMEvJewzz+b2eTF7uL5Zm/HdBF6FjCrpCMRq25Mi0U1gl4pwn2TlH7hQ==",
       "requires": {
-        "loader-utils": "^1.0.2",
-        "schema-utils": "^1.0.0"
+        "loader-utils": "1.2.3",
+        "schema-utils": "1.0.0"
       }
     },
     "file-uri-to-path": {
@@ -7251,8 +7248,8 @@
       "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
       "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
       "requires": {
-        "glob": "^7.0.3",
-        "minimatch": "^3.0.3"
+        "glob": "7.1.3",
+        "minimatch": "3.0.4"
       }
     },
     "filesize": {
@@ -7265,11 +7262,11 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
       "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^3.0.0",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "3.1.1",
+        "repeat-element": "1.1.3",
+        "repeat-string": "1.6.1"
       },
       "dependencies": {
         "isobject": {
@@ -7288,12 +7285,12 @@
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.4.0",
+        "unpipe": "1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -7317,7 +7314,7 @@
       "integrity": "sha1-S3Px/55WrZG3bnFkB/5f/mVUu4w=",
       "optional": true,
       "requires": {
-        "traverse-chain": "~0.1.0"
+        "traverse-chain": "0.1.0"
       }
     },
     "find-cache-dir": {
@@ -7325,9 +7322,9 @@
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
       "requires": {
-        "commondir": "^1.0.1",
-        "make-dir": "^1.0.0",
-        "pkg-dir": "^2.0.0"
+        "commondir": "1.0.1",
+        "make-dir": "1.3.0",
+        "pkg-dir": "2.0.0"
       }
     },
     "find-up": {
@@ -7335,7 +7332,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "requires": {
-        "locate-path": "^3.0.0"
+        "locate-path": "3.0.0"
       }
     },
     "flat": {
@@ -7343,7 +7340,7 @@
       "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
       "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
       "requires": {
-        "is-buffer": "~2.0.3"
+        "is-buffer": "2.0.3"
       },
       "dependencies": {
         "is-buffer": {
@@ -7358,10 +7355,10 @@
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
       "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "requires": {
-        "circular-json": "^0.3.1",
-        "graceful-fs": "^4.1.2",
-        "rimraf": "~2.6.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "graceful-fs": "4.1.15",
+        "rimraf": "2.6.3",
+        "write": "0.2.1"
       }
     },
     "flatten": {
@@ -7374,8 +7371,8 @@
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.0.tgz",
       "integrity": "sha512-6MHED/cmsyux1G4/Cek2Z776y9t7WCNd3h2h/HW91vFeU7pzMhA8XvAlDhHcanG5IWuIh/xcC7JASY4WQpG6xg==",
       "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
+        "inherits": "2.0.3",
+        "readable-stream": "3.1.1"
       },
       "dependencies": {
         "readable-stream": {
@@ -7383,9 +7380,9 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
           "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
           "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
+            "inherits": "2.0.3",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         }
       }
@@ -7395,7 +7392,7 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
       "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
       "requires": {
-        "debug": "=3.1.0"
+        "debug": "3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -7418,7 +7415,7 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "requires": {
-        "is-callable": "^1.1.3"
+        "is-callable": "1.1.4"
       }
     },
     "for-in": {
@@ -7431,7 +7428,7 @@
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "forever-agent": {
@@ -7444,14 +7441,14 @@
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin-alt/-/fork-ts-checker-webpack-plugin-alt-0.4.14.tgz",
       "integrity": "sha512-s0wjOBuPdylMRBzZ4yO8LSJuzem3g0MYZFxsjRXrFDQyL5KJBVSq30+GoHM/t/r2CRU4tI6zi04sq6OXK0UYnw==",
       "requires": {
-        "babel-code-frame": "^6.22.0",
-        "chalk": "^2.4.1",
-        "chokidar": "^2.0.4",
-        "lodash": "^4.17.11",
-        "micromatch": "^3.1.10",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.5.0",
-        "tapable": "^1.0.0"
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.4.1",
+        "chokidar": "2.0.4",
+        "lodash": "4.17.11",
+        "micromatch": "3.1.10",
+        "minimatch": "3.0.4",
+        "resolve": "1.8.1",
+        "tapable": "1.1.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -7469,16 +7466,16 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.3",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -7486,7 +7483,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -7504,13 +7501,13 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -7518,7 +7515,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -7526,7 +7523,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -7534,7 +7531,7 @@
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -7542,7 +7539,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -7552,7 +7549,7 @@
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -7560,7 +7557,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -7570,9 +7567,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -7587,14 +7584,14 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -7602,7 +7599,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -7610,7 +7607,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -7620,10 +7617,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -7631,7 +7628,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -7641,7 +7638,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -7649,7 +7646,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -7657,9 +7654,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-number": {
@@ -7667,7 +7664,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -7675,7 +7672,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -7690,19 +7687,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "ms": {
@@ -7717,9 +7714,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.7",
+        "mime-types": "2.1.21"
       }
     },
     "forwarded": {
@@ -7732,7 +7729,7 @@
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "fresh": {
@@ -7745,8 +7742,8 @@
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "fs-extra": {
@@ -7754,9 +7751,9 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
       "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "4.1.15",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.2"
       },
       "dependencies": {
         "jsonfile": {
@@ -7764,7 +7761,7 @@
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.1.15"
           }
         }
       }
@@ -7774,10 +7771,10 @@
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "iferr": "^0.1.5",
-        "imurmurhash": "^0.1.4",
-        "readable-stream": "1 || 2"
+        "graceful-fs": "4.1.15",
+        "iferr": "0.1.5",
+        "imurmurhash": "0.1.4",
+        "readable-stream": "2.3.6"
       }
     },
     "fs.realpath": {
@@ -7791,8 +7788,8 @@
       "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "2.12.1",
+        "node-pre-gyp": "0.10.3"
       },
       "dependencies": {
         "abbrev": {
@@ -7814,8 +7811,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
@@ -7826,7 +7823,7 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -7880,7 +7877,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.5"
           }
         },
         "fs.realpath": {
@@ -7893,14 +7890,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.3"
           }
         },
         "glob": {
@@ -7908,12 +7905,12 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -7926,7 +7923,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -7934,7 +7931,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -7942,8 +7939,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -7959,7 +7956,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -7971,7 +7968,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -7982,8 +7979,8 @@
           "version": "2.3.5",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.3"
           }
         },
         "minizlib": {
@@ -7991,7 +7988,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.3.5"
           }
         },
         "mkdirp": {
@@ -8011,9 +8008,9 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.24",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -8021,16 +8018,16 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.4",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.2.0",
+            "npmlog": "4.1.2",
+            "rc": "1.2.8",
+            "rimraf": "2.6.3",
+            "semver": "5.6.0",
+            "tar": "4.4.8"
           }
         },
         "nopt": {
@@ -8038,8 +8035,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -8052,8 +8049,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.5"
           }
         },
         "npmlog": {
@@ -8061,10 +8058,10 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.5",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -8080,7 +8077,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -8098,8 +8095,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -8117,10 +8114,10 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.6.0",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -8135,13 +8132,13 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -8149,7 +8146,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.3"
           }
         },
         "safe-buffer": {
@@ -8185,9 +8182,9 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -8195,14 +8192,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -8215,13 +8212,13 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "chownr": "1.1.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.3.5",
+            "minizlib": "1.2.1",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.0.3"
           }
         },
         "util-deprecate": {
@@ -8234,7 +8231,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2 || 2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -8272,7 +8269,7 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "requires": {
-        "pump": "^3.0.0"
+        "pump": "3.0.0"
       }
     },
     "get-value": {
@@ -8285,7 +8282,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "glob": {
@@ -8293,12 +8290,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-base": {
@@ -8306,8 +8303,8 @@
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "glob-parent": {
@@ -8315,7 +8312,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "2.0.1"
       }
     },
     "glob-to-regexp": {
@@ -8328,8 +8325,8 @@
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "requires": {
-        "min-document": "^2.19.0",
-        "process": "~0.5.1"
+        "min-document": "2.19.0",
+        "process": "0.5.2"
       }
     },
     "global-modules": {
@@ -8337,9 +8334,9 @@
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.2",
+        "resolve-dir": "1.0.1"
       }
     },
     "global-prefix": {
@@ -8347,11 +8344,11 @@
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.3.1"
       }
     },
     "globals": {
@@ -8364,13 +8361,13 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
       "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
       "requires": {
-        "array-union": "^1.0.1",
-        "dir-glob": "^2.0.0",
-        "fast-glob": "^2.0.2",
-        "glob": "^7.1.2",
-        "ignore": "^3.3.5",
-        "pify": "^3.0.0",
-        "slash": "^1.0.0"
+        "array-union": "1.0.2",
+        "dir-glob": "2.2.2",
+        "fast-glob": "2.2.6",
+        "glob": "7.1.3",
+        "ignore": "3.3.10",
+        "pify": "3.0.0",
+        "slash": "1.0.0"
       },
       "dependencies": {
         "ignore": {
@@ -8400,8 +8397,8 @@
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.0.0.tgz",
       "integrity": "sha512-5iI7omclyqrnWw4XbXAmGhPsABkSIDQonv2K0h61lybgofWa6iZyvrI3r2zsJH4P8Nb64fFVzlvfhs0g7BBxAA==",
       "requires": {
-        "duplexer": "^0.1.1",
-        "pify": "^3.0.0"
+        "duplexer": "0.1.1",
+        "pify": "3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -8416,9 +8413,9 @@
       "resolved": "https://registry.npmjs.org/h2x-core/-/h2x-core-1.1.1.tgz",
       "integrity": "sha512-LdXe4Irs731knLtHgLyFrnJCumfiqXXQwKN1IMUhi37li29PLfLbMDvfK7Rk4wmgHLKP+sIITT1mcJV4QsC3nw==",
       "requires": {
-        "h2x-generate": "^1.1.0",
-        "h2x-parse": "^1.1.1",
-        "h2x-traverse": "^1.1.0"
+        "h2x-generate": "1.1.0",
+        "h2x-parse": "1.1.1",
+        "h2x-traverse": "1.1.0"
       }
     },
     "h2x-generate": {
@@ -8426,7 +8423,7 @@
       "resolved": "https://registry.npmjs.org/h2x-generate/-/h2x-generate-1.1.0.tgz",
       "integrity": "sha512-L7Hym0yb20QIjvqeULUPOeh/cyvScdOAyJ6oRlh5dF0+w92hf3OiTk1q15KBijde7jGEe+0R4aOmtW8gkPNIzg==",
       "requires": {
-        "h2x-traverse": "^1.1.0"
+        "h2x-traverse": "1.1.0"
       }
     },
     "h2x-parse": {
@@ -8434,8 +8431,8 @@
       "resolved": "https://registry.npmjs.org/h2x-parse/-/h2x-parse-1.1.1.tgz",
       "integrity": "sha512-WRSmPF+tIWuUXVEZaYRhcZx/JGEJx8LjZpDDtrvMr5m/GTR0NerydCik5dRzcKXPWCtfXxuJRLR4v2P4HB2B1A==",
       "requires": {
-        "h2x-types": "^1.1.0",
-        "jsdom": ">=11.0.0"
+        "h2x-types": "1.1.0",
+        "jsdom": "13.2.0"
       }
     },
     "h2x-plugin-jsx": {
@@ -8443,7 +8440,7 @@
       "resolved": "https://registry.npmjs.org/h2x-plugin-jsx/-/h2x-plugin-jsx-1.2.0.tgz",
       "integrity": "sha512-a7Vb3BHhJJq0dPDNdqguEyQirENkVsFtvM2YkiaT5h/fmGhmM1nDy3BLeJeSKi2tL2g9v4ykm2Z+GG9QrhDgPA==",
       "requires": {
-        "h2x-types": "^1.1.0"
+        "h2x-types": "1.1.0"
       }
     },
     "h2x-traverse": {
@@ -8451,7 +8448,7 @@
       "resolved": "https://registry.npmjs.org/h2x-traverse/-/h2x-traverse-1.1.0.tgz",
       "integrity": "sha512-1ND8ZbISLSUgpLHYJRvhvElITvs0g44L7RxjeXViz5XP6rooa+FtXTFLByl2Yg01zj2txubifHIuU4pgvj8l+A==",
       "requires": {
-        "h2x-types": "^1.1.0"
+        "h2x-types": "1.1.0"
       }
     },
     "h2x-types": {
@@ -8469,10 +8466,10 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
       "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
       "requires": {
-        "async": "^2.5.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
+        "async": "2.6.1",
+        "optimist": "0.6.1",
+        "source-map": "0.6.1",
+        "uglify-js": "3.4.9"
       },
       "dependencies": {
         "async": {
@@ -8480,7 +8477,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
-            "lodash": "^4.17.10"
+            "lodash": "4.17.11"
           }
         },
         "source-map": {
@@ -8500,8 +8497,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
+        "ajv": "6.8.1",
+        "har-schema": "2.0.0"
       }
     },
     "harmony-reflect": {
@@ -8514,7 +8511,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
-        "function-bind": "^1.1.1"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -8522,7 +8519,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -8547,9 +8544,9 @@
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       }
     },
     "has-values": {
@@ -8557,8 +8554,8 @@
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -8566,7 +8563,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -8574,7 +8571,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -8584,7 +8581,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -8594,8 +8591,8 @@
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "hash.js": {
@@ -8603,8 +8600,8 @@
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "he": {
@@ -8622,11 +8619,11 @@
       "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
       "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
       "requires": {
-        "invariant": "^2.2.1",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^2.2.0",
-        "value-equal": "^0.4.0",
-        "warning": "^3.0.0"
+        "invariant": "2.2.4",
+        "loose-envify": "1.4.0",
+        "resolve-pathname": "2.2.0",
+        "value-equal": "0.4.0",
+        "warning": "3.0.0"
       },
       "dependencies": {
         "warning": {
@@ -8634,7 +8631,7 @@
           "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
           "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
           "requires": {
-            "loose-envify": "^1.0.0"
+            "loose-envify": "1.4.0"
           }
         }
       }
@@ -8644,9 +8641,9 @@
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
+        "hash.js": "1.1.7",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "hoek": {
@@ -8664,8 +8661,8 @@
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "homedir-polyfill": {
@@ -8673,7 +8670,7 @@
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hoopy": {
@@ -8691,10 +8688,10 @@
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "requires": {
-        "inherits": "^2.0.1",
-        "obuf": "^1.0.0",
-        "readable-stream": "^2.0.1",
-        "wbuf": "^1.1.0"
+        "inherits": "2.0.3",
+        "obuf": "1.1.2",
+        "readable-stream": "2.3.6",
+        "wbuf": "1.7.3"
       }
     },
     "hsl-regex": {
@@ -8717,7 +8714,7 @@
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "requires": {
-        "whatwg-encoding": "^1.0.1"
+        "whatwg-encoding": "1.0.5"
       }
     },
     "html-entities": {
@@ -8730,13 +8727,13 @@
       "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
       "integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
       "requires": {
-        "camel-case": "3.0.x",
-        "clean-css": "4.2.x",
-        "commander": "2.17.x",
-        "he": "1.2.x",
-        "param-case": "2.1.x",
-        "relateurl": "0.2.x",
-        "uglify-js": "3.4.x"
+        "camel-case": "3.0.0",
+        "clean-css": "4.2.1",
+        "commander": "2.17.1",
+        "he": "1.2.0",
+        "param-case": "2.1.1",
+        "relateurl": "0.2.7",
+        "uglify-js": "3.4.9"
       },
       "dependencies": {
         "commander": {
@@ -8752,11 +8749,11 @@
       "integrity": "sha512-tyvhjVpuGqD7QYHi1l1drMQTg5i+qRxpQEGbdnYFREgOKy7aFDf/ocQ/V1fuEDlQx7jV2zMap3Hj2nE9i5eGXw==",
       "requires": {
         "@types/tapable": "1.0.2",
-        "html-minifier": "^3.2.3",
-        "loader-utils": "^1.1.0",
-        "lodash": "^4.17.10",
-        "pretty-error": "^2.0.2",
-        "tapable": "^1.0.0",
+        "html-minifier": "3.5.21",
+        "loader-utils": "1.2.3",
+        "lodash": "4.17.11",
+        "pretty-error": "2.1.1",
+        "tapable": "1.1.1",
         "util.promisify": "1.0.0"
       }
     },
@@ -8765,10 +8762,10 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
       "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
       "requires": {
-        "domelementtype": "1",
-        "domhandler": "2.1",
-        "domutils": "1.1",
-        "readable-stream": "1.0"
+        "domelementtype": "1.3.1",
+        "domhandler": "2.1.0",
+        "domutils": "1.1.6",
+        "readable-stream": "1.0.34"
       },
       "dependencies": {
         "domutils": {
@@ -8776,7 +8773,7 @@
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
           "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.1"
           }
         },
         "isarray": {
@@ -8789,10 +8786,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -8812,10 +8809,10 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
+        "statuses": "1.4.0"
       }
     },
     "http-parser-js": {
@@ -8828,9 +8825,9 @@
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "requires": {
-        "eventemitter3": "^3.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
+        "eventemitter3": "3.1.0",
+        "follow-redirects": "1.6.1",
+        "requires-port": "1.0.0"
       }
     },
     "http-proxy-middleware": {
@@ -8838,10 +8835,10 @@
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
       "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
       "requires": {
-        "http-proxy": "^1.16.2",
-        "is-glob": "^4.0.0",
-        "lodash": "^4.17.5",
-        "micromatch": "^3.1.9"
+        "http-proxy": "1.17.0",
+        "is-glob": "4.0.0",
+        "lodash": "4.17.11",
+        "micromatch": "3.1.10"
       },
       "dependencies": {
         "arr-diff": {
@@ -8859,16 +8856,16 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.3",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -8876,7 +8873,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -8894,13 +8891,13 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -8908,7 +8905,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -8916,7 +8913,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -8924,7 +8921,7 @@
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -8932,7 +8929,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -8942,7 +8939,7 @@
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -8950,7 +8947,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -8960,9 +8957,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -8977,14 +8974,14 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -8992,7 +8989,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -9000,7 +8997,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -9010,10 +9007,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -9021,7 +9018,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -9031,7 +9028,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -9039,7 +9036,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -9047,9 +9044,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-extglob": {
@@ -9062,7 +9059,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -9070,7 +9067,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -9078,7 +9075,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -9093,19 +9090,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "ms": {
@@ -9120,9 +9117,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.16.1"
       }
     },
     "https-browserify": {
@@ -9135,7 +9132,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "icss-replace-symbols": {
@@ -9148,7 +9145,7 @@
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "6.0.23"
       }
     },
     "identity-obj-proxy": {
@@ -9156,7 +9153,7 @@
       "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
       "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
       "requires": {
-        "harmony-reflect": "^1.4.6"
+        "harmony-reflect": "1.6.1"
       }
     },
     "ieee754": {
@@ -9194,7 +9191,7 @@
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
       "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
       "requires": {
-        "import-from": "^2.1.0"
+        "import-from": "2.1.0"
       }
     },
     "import-fresh": {
@@ -9202,8 +9199,8 @@
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
       "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
       "requires": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
+        "caller-path": "2.0.0",
+        "resolve-from": "3.0.0"
       }
     },
     "import-from": {
@@ -9211,7 +9208,7 @@
       "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
       "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "3.0.0"
       }
     },
     "import-local": {
@@ -9219,8 +9216,8 @@
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
       "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
       "requires": {
-        "pkg-dir": "^2.0.0",
-        "resolve-cwd": "^2.0.0"
+        "pkg-dir": "2.0.0",
+        "resolve-cwd": "2.0.0"
       }
     },
     "imurmurhash": {
@@ -9243,8 +9240,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -9262,19 +9259,19 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
       "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
       "requires": {
-        "ansi-escapes": "^3.2.0",
-        "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.11",
+        "ansi-escapes": "3.2.0",
+        "chalk": "2.4.2",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "3.0.3",
+        "figures": "2.0.0",
+        "lodash": "4.17.11",
         "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^5.0.0",
-        "through": "^2.3.6"
+        "run-async": "2.3.0",
+        "rxjs": "6.4.0",
+        "string-width": "2.1.1",
+        "strip-ansi": "5.0.0",
+        "through": "2.3.8"
       },
       "dependencies": {
         "ansi-regex": {
@@ -9287,9 +9284,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "strip-ansi": {
@@ -9297,7 +9294,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
           "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
           "requires": {
-            "ansi-regex": "^4.0.0"
+            "ansi-regex": "4.0.0"
           }
         }
       }
@@ -9307,8 +9304,8 @@
       "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-3.0.1.tgz",
       "integrity": "sha512-NXXgESC2nNVtU+pqmC9e6R8B1GpKxzsAQhffvh5AL79qKnodd+L7tnEQmTiUAVngqLalPbSqRA7XGIEL5nCd0Q==",
       "requires": {
-        "default-gateway": "^2.6.0",
-        "ipaddr.js": "^1.5.2"
+        "default-gateway": "2.7.2",
+        "ipaddr.js": "1.8.0"
       }
     },
     "intl-format-cache": {
@@ -9334,7 +9331,7 @@
       "resolved": "https://registry.npmjs.org/intl-relativeformat/-/intl-relativeformat-2.1.0.tgz",
       "integrity": "sha1-AQ8RBYAiUfQKxH0OPhogE0iiVd8=",
       "requires": {
-        "intl-messageformat": "^2.0.0"
+        "intl-messageformat": "2.2.0"
       }
     },
     "invariant": {
@@ -9342,7 +9339,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "invert-kv": {
@@ -9375,7 +9372,7 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-arrayish": {
@@ -9388,7 +9385,7 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.13.0"
       }
     },
     "is-buffer": {
@@ -9401,7 +9398,7 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-callable": {
@@ -9414,7 +9411,7 @@
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
       "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
       "requires": {
-        "ci-info": "^1.5.0"
+        "ci-info": "1.6.0"
       }
     },
     "is-color-stop": {
@@ -9422,12 +9419,12 @@
       "resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
       "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
       "requires": {
-        "css-color-names": "^0.0.4",
-        "hex-color-regex": "^1.1.0",
-        "hsl-regex": "^1.0.0",
-        "hsla-regex": "^1.0.0",
-        "rgb-regex": "^1.0.1",
-        "rgba-regex": "^1.0.0"
+        "css-color-names": "0.0.4",
+        "hex-color-regex": "1.1.0",
+        "hsl-regex": "1.0.0",
+        "hsla-regex": "1.0.0",
+        "rgb-regex": "1.0.1",
+        "rgba-regex": "1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -9435,7 +9432,7 @@
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-date-object": {
@@ -9448,9 +9445,9 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -9475,7 +9472,7 @@
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -9493,7 +9490,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fn": {
@@ -9521,7 +9518,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "is-hex-prefixed": {
@@ -9534,7 +9531,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-obj": {
@@ -9552,7 +9549,7 @@
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -9560,7 +9557,7 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-object": {
@@ -9568,7 +9565,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "is-posix-bracket": {
@@ -9591,7 +9588,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.3"
       }
     },
     "is-regexp": {
@@ -9619,7 +9616,7 @@
       "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
       "integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
       "requires": {
-        "html-comment-regex": "^1.1.0"
+        "html-comment-regex": "1.1.2"
       }
     },
     "is-symbol": {
@@ -9627,7 +9624,7 @@
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "1.0.0"
       }
     },
     "is-typedarray": {
@@ -9665,7 +9662,7 @@
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
       "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
       "requires": {
-        "punycode": "2.x.x"
+        "punycode": "2.1.1"
       }
     },
     "isexe": {
@@ -9688,17 +9685,17 @@
       "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.7.tgz",
       "integrity": "sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==",
       "requires": {
-        "async": "^2.1.4",
-        "fileset": "^2.0.2",
-        "istanbul-lib-coverage": "^1.2.1",
-        "istanbul-lib-hook": "^1.2.2",
-        "istanbul-lib-instrument": "^1.10.2",
-        "istanbul-lib-report": "^1.1.5",
-        "istanbul-lib-source-maps": "^1.2.6",
-        "istanbul-reports": "^1.5.1",
-        "js-yaml": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "once": "^1.4.0"
+        "async": "2.6.1",
+        "fileset": "2.0.3",
+        "istanbul-lib-coverage": "1.2.1",
+        "istanbul-lib-hook": "1.2.2",
+        "istanbul-lib-instrument": "1.10.2",
+        "istanbul-lib-report": "1.1.5",
+        "istanbul-lib-source-maps": "1.2.6",
+        "istanbul-reports": "1.5.1",
+        "js-yaml": "3.12.1",
+        "mkdirp": "0.5.1",
+        "once": "1.4.0"
       },
       "dependencies": {
         "async": {
@@ -9706,7 +9703,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
-            "lodash": "^4.17.10"
+            "lodash": "4.17.11"
           }
         }
       }
@@ -9717,10 +9714,10 @@
       "integrity": "sha512-a5SPObZgS0jB/ixaKSMdn6n/gXSrK2S6q/UfRJBT3e6gQmVjwZROTODQsYW5ZNwOu78hG62Y3fWlebaVOL0C+w==",
       "dev": true,
       "requires": {
-        "convert-source-map": "^1.5.0",
-        "istanbul-lib-instrument": "^1.7.3",
-        "loader-utils": "^1.1.0",
-        "schema-utils": "^0.3.0"
+        "convert-source-map": "1.6.0",
+        "istanbul-lib-instrument": "1.10.2",
+        "loader-utils": "1.2.3",
+        "schema-utils": "0.3.0"
       },
       "dependencies": {
         "ajv": {
@@ -9729,10 +9726,10 @@
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         },
         "fast-deep-equal": {
@@ -9753,7 +9750,7 @@
           "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
           "dev": true,
           "requires": {
-            "ajv": "^5.0.0"
+            "ajv": "5.5.2"
           }
         }
       }
@@ -9768,7 +9765,7 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz",
       "integrity": "sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==",
       "requires": {
-        "append-transform": "^0.4.0"
+        "append-transform": "0.4.0"
       }
     },
     "istanbul-lib-instrument": {
@@ -9776,13 +9773,13 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz",
       "integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
       "requires": {
-        "babel-generator": "^6.18.0",
-        "babel-template": "^6.16.0",
-        "babel-traverse": "^6.18.0",
-        "babel-types": "^6.18.0",
-        "babylon": "^6.18.0",
-        "istanbul-lib-coverage": "^1.2.1",
-        "semver": "^5.3.0"
+        "babel-generator": "6.26.1",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "istanbul-lib-coverage": "1.2.1",
+        "semver": "5.6.0"
       }
     },
     "istanbul-lib-report": {
@@ -9790,10 +9787,10 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz",
       "integrity": "sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==",
       "requires": {
-        "istanbul-lib-coverage": "^1.2.1",
-        "mkdirp": "^0.5.1",
-        "path-parse": "^1.0.5",
-        "supports-color": "^3.1.2"
+        "istanbul-lib-coverage": "1.2.1",
+        "mkdirp": "0.5.1",
+        "path-parse": "1.0.6",
+        "supports-color": "3.2.3"
       },
       "dependencies": {
         "has-flag": {
@@ -9806,7 +9803,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -9816,11 +9813,11 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz",
       "integrity": "sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==",
       "requires": {
-        "debug": "^3.1.0",
-        "istanbul-lib-coverage": "^1.2.1",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.6.1",
-        "source-map": "^0.5.3"
+        "debug": "3.2.6",
+        "istanbul-lib-coverage": "1.2.1",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.3",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "debug": {
@@ -9828,7 +9825,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         }
       }
@@ -9838,7 +9835,7 @@
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.5.1.tgz",
       "integrity": "sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==",
       "requires": {
-        "handlebars": "^4.0.3"
+        "handlebars": "4.0.12"
       }
     },
     "jest": {
@@ -9846,8 +9843,8 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-23.6.0.tgz",
       "integrity": "sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==",
       "requires": {
-        "import-local": "^1.0.0",
-        "jest-cli": "^23.6.0"
+        "import-local": "1.0.0",
+        "jest-cli": "23.6.0"
       },
       "dependencies": {
         "camelcase": {
@@ -9860,9 +9857,9 @@
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.5",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
           }
         },
         "execa": {
@@ -9870,13 +9867,13 @@
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "find-up": {
@@ -9884,7 +9881,7 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "get-stream": {
@@ -9902,42 +9899,42 @@
           "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.6.0.tgz",
           "integrity": "sha512-hgeD1zRUp1E1zsiyOXjEn4LzRLWdJBV//ukAHGlx6s5mfCNJTbhbHjgxnDUXA8fsKWN/HqFFF6X5XcCwC/IvYQ==",
           "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.1",
-            "exit": "^0.1.2",
-            "glob": "^7.1.2",
-            "graceful-fs": "^4.1.11",
-            "import-local": "^1.0.0",
-            "is-ci": "^1.0.10",
-            "istanbul-api": "^1.3.1",
-            "istanbul-lib-coverage": "^1.2.0",
-            "istanbul-lib-instrument": "^1.10.1",
-            "istanbul-lib-source-maps": "^1.2.4",
-            "jest-changed-files": "^23.4.2",
-            "jest-config": "^23.6.0",
-            "jest-environment-jsdom": "^23.4.0",
-            "jest-get-type": "^22.1.0",
-            "jest-haste-map": "^23.6.0",
-            "jest-message-util": "^23.4.0",
-            "jest-regex-util": "^23.3.0",
-            "jest-resolve-dependencies": "^23.6.0",
-            "jest-runner": "^23.6.0",
-            "jest-runtime": "^23.6.0",
-            "jest-snapshot": "^23.6.0",
-            "jest-util": "^23.4.0",
-            "jest-validate": "^23.6.0",
-            "jest-watcher": "^23.4.0",
-            "jest-worker": "^23.2.0",
-            "micromatch": "^2.3.11",
-            "node-notifier": "^5.2.1",
-            "prompts": "^0.1.9",
-            "realpath-native": "^1.0.0",
-            "rimraf": "^2.5.4",
-            "slash": "^1.0.0",
-            "string-length": "^2.0.0",
-            "strip-ansi": "^4.0.0",
-            "which": "^1.2.12",
-            "yargs": "^11.0.0"
+            "ansi-escapes": "3.2.0",
+            "chalk": "2.4.1",
+            "exit": "0.1.2",
+            "glob": "7.1.3",
+            "graceful-fs": "4.1.15",
+            "import-local": "1.0.0",
+            "is-ci": "1.2.1",
+            "istanbul-api": "1.3.7",
+            "istanbul-lib-coverage": "1.2.1",
+            "istanbul-lib-instrument": "1.10.2",
+            "istanbul-lib-source-maps": "1.2.6",
+            "jest-changed-files": "23.4.2",
+            "jest-config": "23.6.0",
+            "jest-environment-jsdom": "23.4.0",
+            "jest-get-type": "22.4.3",
+            "jest-haste-map": "23.6.0",
+            "jest-message-util": "23.4.0",
+            "jest-regex-util": "23.3.0",
+            "jest-resolve-dependencies": "23.6.0",
+            "jest-runner": "23.6.0",
+            "jest-runtime": "23.6.0",
+            "jest-snapshot": "23.6.0",
+            "jest-util": "23.4.0",
+            "jest-validate": "23.6.0",
+            "jest-watcher": "23.4.0",
+            "jest-worker": "23.2.0",
+            "micromatch": "2.3.11",
+            "node-notifier": "5.4.0",
+            "prompts": "0.1.14",
+            "realpath-native": "1.0.2",
+            "rimraf": "2.6.3",
+            "slash": "1.0.0",
+            "string-length": "2.0.0",
+            "strip-ansi": "4.0.0",
+            "which": "1.3.1",
+            "yargs": "11.1.0"
           }
         },
         "lcid": {
@@ -9945,7 +9942,7 @@
           "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
           "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "requires": {
-            "invert-kv": "^1.0.0"
+            "invert-kv": "1.0.0"
           }
         },
         "locate-path": {
@@ -9953,8 +9950,8 @@
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "lru-cache": {
@@ -9962,8 +9959,8 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         },
         "mem": {
@@ -9971,7 +9968,7 @@
           "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
           "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
           "requires": {
-            "mimic-fn": "^1.0.0"
+            "mimic-fn": "1.2.0"
           }
         },
         "os-locale": {
@@ -9979,9 +9976,9 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "p-limit": {
@@ -9989,7 +9986,7 @@
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
@@ -9997,7 +9994,7 @@
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.3.0"
           }
         },
         "p-try": {
@@ -10015,18 +10012,18 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
           "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.3",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
           }
         },
         "yargs-parser": {
@@ -10034,7 +10031,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -10044,7 +10041,7 @@
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.4.2.tgz",
       "integrity": "sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==",
       "requires": {
-        "throat": "^4.0.0"
+        "throat": "4.1.0"
       }
     },
     "jest-config": {
@@ -10052,20 +10049,20 @@
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.6.0.tgz",
       "integrity": "sha512-i8V7z9BeDXab1+VNo78WM0AtWpBRXJLnkT+lyT+Slx/cbP5sZJ0+NDuLcmBE5hXAoK0aUp7vI+MOxR+R4d8SRQ==",
       "requires": {
-        "babel-core": "^6.0.0",
-        "babel-jest": "^23.6.0",
-        "chalk": "^2.0.1",
-        "glob": "^7.1.1",
-        "jest-environment-jsdom": "^23.4.0",
-        "jest-environment-node": "^23.4.0",
-        "jest-get-type": "^22.1.0",
-        "jest-jasmine2": "^23.6.0",
-        "jest-regex-util": "^23.3.0",
-        "jest-resolve": "^23.6.0",
-        "jest-util": "^23.4.0",
-        "jest-validate": "^23.6.0",
-        "micromatch": "^2.3.11",
-        "pretty-format": "^23.6.0"
+        "babel-core": "6.26.3",
+        "babel-jest": "23.6.0",
+        "chalk": "2.4.1",
+        "glob": "7.1.3",
+        "jest-environment-jsdom": "23.4.0",
+        "jest-environment-node": "23.4.0",
+        "jest-get-type": "22.4.3",
+        "jest-jasmine2": "23.6.0",
+        "jest-regex-util": "23.3.0",
+        "jest-resolve": "23.6.0",
+        "jest-util": "23.4.0",
+        "jest-validate": "23.6.0",
+        "micromatch": "2.3.11",
+        "pretty-format": "23.6.0"
       },
       "dependencies": {
         "babel-core": {
@@ -10073,25 +10070,25 @@
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
           "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
           "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-generator": "^6.26.0",
-            "babel-helpers": "^6.24.1",
-            "babel-messages": "^6.23.0",
-            "babel-register": "^6.26.0",
-            "babel-runtime": "^6.26.0",
-            "babel-template": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "convert-source-map": "^1.5.1",
-            "debug": "^2.6.9",
-            "json5": "^0.5.1",
-            "lodash": "^4.17.4",
-            "minimatch": "^3.0.4",
-            "path-is-absolute": "^1.0.1",
-            "private": "^0.1.8",
-            "slash": "^1.0.0",
-            "source-map": "^0.5.7"
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.1",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.6.0",
+            "debug": "2.6.9",
+            "json5": "0.5.1",
+            "lodash": "4.17.11",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
+            "slash": "1.0.0",
+            "source-map": "0.5.7"
           }
         },
         "debug": {
@@ -10119,10 +10116,10 @@
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.6.0.tgz",
       "integrity": "sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==",
       "requires": {
-        "chalk": "^2.0.1",
-        "diff": "^3.2.0",
-        "jest-get-type": "^22.1.0",
-        "pretty-format": "^23.6.0"
+        "chalk": "2.4.1",
+        "diff": "3.5.0",
+        "jest-get-type": "22.4.3",
+        "pretty-format": "23.6.0"
       }
     },
     "jest-docblock": {
@@ -10130,7 +10127,7 @@
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.2.0.tgz",
       "integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
       "requires": {
-        "detect-newline": "^2.1.0"
+        "detect-newline": "2.1.0"
       }
     },
     "jest-each": {
@@ -10138,8 +10135,8 @@
       "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.6.0.tgz",
       "integrity": "sha512-x7V6M/WGJo6/kLoissORuvLIeAoyo2YqLOoCDkohgJ4XOXSqOtyvr8FbInlAWS77ojBsZrafbozWoKVRdtxFCg==",
       "requires": {
-        "chalk": "^2.0.1",
-        "pretty-format": "^23.6.0"
+        "chalk": "2.4.1",
+        "pretty-format": "23.6.0"
       }
     },
     "jest-environment-jsdom": {
@@ -10147,9 +10144,9 @@
       "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz",
       "integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
       "requires": {
-        "jest-mock": "^23.2.0",
-        "jest-util": "^23.4.0",
-        "jsdom": "^11.5.1"
+        "jest-mock": "23.2.0",
+        "jest-util": "23.4.0",
+        "jsdom": "11.12.0"
       },
       "dependencies": {
         "acorn": {
@@ -10162,32 +10159,32 @@
           "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
           "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
           "requires": {
-            "abab": "^2.0.0",
-            "acorn": "^5.5.3",
-            "acorn-globals": "^4.1.0",
-            "array-equal": "^1.0.0",
-            "cssom": ">= 0.3.2 < 0.4.0",
-            "cssstyle": "^1.0.0",
-            "data-urls": "^1.0.0",
-            "domexception": "^1.0.1",
-            "escodegen": "^1.9.1",
-            "html-encoding-sniffer": "^1.0.2",
-            "left-pad": "^1.3.0",
-            "nwsapi": "^2.0.7",
+            "abab": "2.0.0",
+            "acorn": "5.7.3",
+            "acorn-globals": "4.3.0",
+            "array-equal": "1.0.0",
+            "cssom": "0.3.4",
+            "cssstyle": "1.1.1",
+            "data-urls": "1.1.0",
+            "domexception": "1.0.1",
+            "escodegen": "1.11.0",
+            "html-encoding-sniffer": "1.0.2",
+            "left-pad": "1.3.0",
+            "nwsapi": "2.1.0",
             "parse5": "4.0.0",
-            "pn": "^1.1.0",
-            "request": "^2.87.0",
-            "request-promise-native": "^1.0.5",
-            "sax": "^1.2.4",
-            "symbol-tree": "^3.2.2",
-            "tough-cookie": "^2.3.4",
-            "w3c-hr-time": "^1.0.1",
-            "webidl-conversions": "^4.0.2",
-            "whatwg-encoding": "^1.0.3",
-            "whatwg-mimetype": "^2.1.0",
-            "whatwg-url": "^6.4.1",
-            "ws": "^5.2.0",
-            "xml-name-validator": "^3.0.0"
+            "pn": "1.1.0",
+            "request": "2.88.0",
+            "request-promise-native": "1.0.5",
+            "sax": "1.2.4",
+            "symbol-tree": "3.2.2",
+            "tough-cookie": "2.5.0",
+            "w3c-hr-time": "1.0.1",
+            "webidl-conversions": "4.0.2",
+            "whatwg-encoding": "1.0.5",
+            "whatwg-mimetype": "2.3.0",
+            "whatwg-url": "6.5.0",
+            "ws": "5.2.2",
+            "xml-name-validator": "3.0.0"
           }
         },
         "parse5": {
@@ -10200,9 +10197,9 @@
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
           "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
           "requires": {
-            "lodash.sortby": "^4.7.0",
-            "tr46": "^1.0.1",
-            "webidl-conversions": "^4.0.2"
+            "lodash.sortby": "4.7.0",
+            "tr46": "1.0.1",
+            "webidl-conversions": "4.0.2"
           }
         },
         "ws": {
@@ -10210,7 +10207,7 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
           "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
           "requires": {
-            "async-limiter": "~1.0.0"
+            "async-limiter": "1.0.0"
           }
         }
       }
@@ -10220,8 +10217,8 @@
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.4.0.tgz",
       "integrity": "sha1-V+gO0IQd6jAxZ8zozXlSHeuv3hA=",
       "requires": {
-        "jest-mock": "^23.2.0",
-        "jest-util": "^23.4.0"
+        "jest-mock": "23.2.0",
+        "jest-util": "23.4.0"
       }
     },
     "jest-get-type": {
@@ -10234,14 +10231,14 @@
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.6.0.tgz",
       "integrity": "sha512-uyNhMyl6dr6HaXGHp8VF7cK6KpC6G9z9LiMNsst+rJIZ8l7wY0tk8qwjPmEghczojZ2/ZhtEdIabZ0OQRJSGGg==",
       "requires": {
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.1.11",
-        "invariant": "^2.2.4",
-        "jest-docblock": "^23.2.0",
-        "jest-serializer": "^23.0.1",
-        "jest-worker": "^23.2.0",
-        "micromatch": "^2.3.11",
-        "sane": "^2.0.0"
+        "fb-watchman": "2.0.0",
+        "graceful-fs": "4.1.15",
+        "invariant": "2.2.4",
+        "jest-docblock": "23.2.0",
+        "jest-serializer": "23.0.1",
+        "jest-worker": "23.2.0",
+        "micromatch": "2.3.11",
+        "sane": "2.5.2"
       }
     },
     "jest-jasmine2": {
@@ -10249,18 +10246,18 @@
       "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.6.0.tgz",
       "integrity": "sha512-pe2Ytgs1nyCs8IvsEJRiRTPC0eVYd8L/dXJGU08GFuBwZ4sYH/lmFDdOL3ZmvJR8QKqV9MFuwlsAi/EWkFUbsQ==",
       "requires": {
-        "babel-traverse": "^6.0.0",
-        "chalk": "^2.0.1",
-        "co": "^4.6.0",
-        "expect": "^23.6.0",
-        "is-generator-fn": "^1.0.0",
-        "jest-diff": "^23.6.0",
-        "jest-each": "^23.6.0",
-        "jest-matcher-utils": "^23.6.0",
-        "jest-message-util": "^23.4.0",
-        "jest-snapshot": "^23.6.0",
-        "jest-util": "^23.4.0",
-        "pretty-format": "^23.6.0"
+        "babel-traverse": "6.26.0",
+        "chalk": "2.4.1",
+        "co": "4.6.0",
+        "expect": "23.6.0",
+        "is-generator-fn": "1.0.0",
+        "jest-diff": "23.6.0",
+        "jest-each": "23.6.0",
+        "jest-matcher-utils": "23.6.0",
+        "jest-message-util": "23.4.0",
+        "jest-snapshot": "23.6.0",
+        "jest-util": "23.4.0",
+        "pretty-format": "23.6.0"
       }
     },
     "jest-leak-detector": {
@@ -10268,7 +10265,7 @@
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.6.0.tgz",
       "integrity": "sha512-f/8zA04rsl1Nzj10HIyEsXvYlMpMPcy0QkQilVZDFOaPbv2ur71X5u2+C4ZQJGyV/xvVXtCCZ3wQ99IgQxftCg==",
       "requires": {
-        "pretty-format": "^23.6.0"
+        "pretty-format": "23.6.0"
       }
     },
     "jest-matcher-utils": {
@@ -10276,9 +10273,9 @@
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz",
       "integrity": "sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==",
       "requires": {
-        "chalk": "^2.0.1",
-        "jest-get-type": "^22.1.0",
-        "pretty-format": "^23.6.0"
+        "chalk": "2.4.1",
+        "jest-get-type": "22.4.3",
+        "pretty-format": "23.6.0"
       }
     },
     "jest-message-util": {
@@ -10286,11 +10283,11 @@
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.4.0.tgz",
       "integrity": "sha1-F2EMUJQjSVCNAaPR4L2iwHkIap8=",
       "requires": {
-        "@babel/code-frame": "^7.0.0-beta.35",
-        "chalk": "^2.0.1",
-        "micromatch": "^2.3.11",
-        "slash": "^1.0.0",
-        "stack-utils": "^1.0.1"
+        "@babel/code-frame": "7.0.0",
+        "chalk": "2.4.1",
+        "micromatch": "2.3.11",
+        "slash": "1.0.0",
+        "stack-utils": "1.0.2"
       }
     },
     "jest-mock": {
@@ -10313,9 +10310,9 @@
       "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.6.0.tgz",
       "integrity": "sha512-XyoRxNtO7YGpQDmtQCmZjum1MljDqUCob7XlZ6jy9gsMugHdN2hY4+Acz9Qvjz2mSsOnPSH7skBmDYCHXVZqkA==",
       "requires": {
-        "browser-resolve": "^1.11.3",
-        "chalk": "^2.0.1",
-        "realpath-native": "^1.0.0"
+        "browser-resolve": "1.11.3",
+        "chalk": "2.4.1",
+        "realpath-native": "1.0.2"
       }
     },
     "jest-resolve-dependencies": {
@@ -10323,8 +10320,8 @@
       "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.6.0.tgz",
       "integrity": "sha512-EkQWkFWjGKwRtRyIwRwI6rtPAEyPWlUC2MpzHissYnzJeHcyCn1Hc8j7Nn1xUVrS5C6W5+ZL37XTem4D4pLZdA==",
       "requires": {
-        "jest-regex-util": "^23.3.0",
-        "jest-snapshot": "^23.6.0"
+        "jest-regex-util": "23.3.0",
+        "jest-snapshot": "23.6.0"
       }
     },
     "jest-runner": {
@@ -10332,19 +10329,19 @@
       "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.6.0.tgz",
       "integrity": "sha512-kw0+uj710dzSJKU6ygri851CObtCD9cN8aNkg8jWJf4ewFyEa6kwmiH/r/M1Ec5IL/6VFa0wnAk6w+gzUtjJzA==",
       "requires": {
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.1.11",
-        "jest-config": "^23.6.0",
-        "jest-docblock": "^23.2.0",
-        "jest-haste-map": "^23.6.0",
-        "jest-jasmine2": "^23.6.0",
-        "jest-leak-detector": "^23.6.0",
-        "jest-message-util": "^23.4.0",
-        "jest-runtime": "^23.6.0",
-        "jest-util": "^23.4.0",
-        "jest-worker": "^23.2.0",
-        "source-map-support": "^0.5.6",
-        "throat": "^4.0.0"
+        "exit": "0.1.2",
+        "graceful-fs": "4.1.15",
+        "jest-config": "23.6.0",
+        "jest-docblock": "23.2.0",
+        "jest-haste-map": "23.6.0",
+        "jest-jasmine2": "23.6.0",
+        "jest-leak-detector": "23.6.0",
+        "jest-message-util": "23.4.0",
+        "jest-runtime": "23.6.0",
+        "jest-util": "23.4.0",
+        "jest-worker": "23.2.0",
+        "source-map-support": "0.5.10",
+        "throat": "4.1.0"
       },
       "dependencies": {
         "source-map": {
@@ -10357,8 +10354,8 @@
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
           "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
           "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
+            "buffer-from": "1.1.1",
+            "source-map": "0.6.1"
           }
         }
       }
@@ -10368,27 +10365,27 @@
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.6.0.tgz",
       "integrity": "sha512-ycnLTNPT2Gv+TRhnAYAQ0B3SryEXhhRj1kA6hBPSeZaNQkJ7GbZsxOLUkwg6YmvWGdX3BB3PYKFLDQCAE1zNOw==",
       "requires": {
-        "babel-core": "^6.0.0",
-        "babel-plugin-istanbul": "^4.1.6",
-        "chalk": "^2.0.1",
-        "convert-source-map": "^1.4.0",
-        "exit": "^0.1.2",
-        "fast-json-stable-stringify": "^2.0.0",
-        "graceful-fs": "^4.1.11",
-        "jest-config": "^23.6.0",
-        "jest-haste-map": "^23.6.0",
-        "jest-message-util": "^23.4.0",
-        "jest-regex-util": "^23.3.0",
-        "jest-resolve": "^23.6.0",
-        "jest-snapshot": "^23.6.0",
-        "jest-util": "^23.4.0",
-        "jest-validate": "^23.6.0",
-        "micromatch": "^2.3.11",
-        "realpath-native": "^1.0.0",
-        "slash": "^1.0.0",
+        "babel-core": "6.26.3",
+        "babel-plugin-istanbul": "4.1.6",
+        "chalk": "2.4.1",
+        "convert-source-map": "1.6.0",
+        "exit": "0.1.2",
+        "fast-json-stable-stringify": "2.0.0",
+        "graceful-fs": "4.1.15",
+        "jest-config": "23.6.0",
+        "jest-haste-map": "23.6.0",
+        "jest-message-util": "23.4.0",
+        "jest-regex-util": "23.3.0",
+        "jest-resolve": "23.6.0",
+        "jest-snapshot": "23.6.0",
+        "jest-util": "23.4.0",
+        "jest-validate": "23.6.0",
+        "micromatch": "2.3.11",
+        "realpath-native": "1.0.2",
+        "slash": "1.0.0",
         "strip-bom": "3.0.0",
-        "write-file-atomic": "^2.1.0",
-        "yargs": "^11.0.0"
+        "write-file-atomic": "2.4.2",
+        "yargs": "11.1.0"
       },
       "dependencies": {
         "babel-core": {
@@ -10396,25 +10393,25 @@
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
           "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
           "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-generator": "^6.26.0",
-            "babel-helpers": "^6.24.1",
-            "babel-messages": "^6.23.0",
-            "babel-register": "^6.26.0",
-            "babel-runtime": "^6.26.0",
-            "babel-template": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "convert-source-map": "^1.5.1",
-            "debug": "^2.6.9",
-            "json5": "^0.5.1",
-            "lodash": "^4.17.4",
-            "minimatch": "^3.0.4",
-            "path-is-absolute": "^1.0.1",
-            "private": "^0.1.8",
-            "slash": "^1.0.0",
-            "source-map": "^0.5.7"
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.1",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.6.0",
+            "debug": "2.6.9",
+            "json5": "0.5.1",
+            "lodash": "4.17.11",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
+            "slash": "1.0.0",
+            "source-map": "0.5.7"
           }
         },
         "camelcase": {
@@ -10427,9 +10424,9 @@
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.5",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
           }
         },
         "debug": {
@@ -10445,13 +10442,13 @@
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "find-up": {
@@ -10459,7 +10456,7 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "get-stream": {
@@ -10482,7 +10479,7 @@
           "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
           "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "requires": {
-            "invert-kv": "^1.0.0"
+            "invert-kv": "1.0.0"
           }
         },
         "locate-path": {
@@ -10490,8 +10487,8 @@
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "lru-cache": {
@@ -10499,8 +10496,8 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         },
         "mem": {
@@ -10508,7 +10505,7 @@
           "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
           "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
           "requires": {
-            "mimic-fn": "^1.0.0"
+            "mimic-fn": "1.2.0"
           }
         },
         "ms": {
@@ -10521,9 +10518,9 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "p-limit": {
@@ -10531,7 +10528,7 @@
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
@@ -10539,7 +10536,7 @@
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.3.0"
           }
         },
         "p-try": {
@@ -10562,18 +10559,18 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
           "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.3",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
           }
         },
         "yargs-parser": {
@@ -10581,7 +10578,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -10596,16 +10593,16 @@
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.6.0.tgz",
       "integrity": "sha512-tM7/Bprftun6Cvj2Awh/ikS7zV3pVwjRYU2qNYS51VZHgaAMBs5l4o/69AiDHhQrj5+LA2Lq4VIvK7zYk/bswg==",
       "requires": {
-        "babel-types": "^6.0.0",
-        "chalk": "^2.0.1",
-        "jest-diff": "^23.6.0",
-        "jest-matcher-utils": "^23.6.0",
-        "jest-message-util": "^23.4.0",
-        "jest-resolve": "^23.6.0",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "pretty-format": "^23.6.0",
-        "semver": "^5.5.0"
+        "babel-types": "6.26.0",
+        "chalk": "2.4.1",
+        "jest-diff": "23.6.0",
+        "jest-matcher-utils": "23.6.0",
+        "jest-message-util": "23.4.0",
+        "jest-resolve": "23.6.0",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "pretty-format": "23.6.0",
+        "semver": "5.6.0"
       }
     },
     "jest-util": {
@@ -10613,14 +10610,14 @@
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.4.0.tgz",
       "integrity": "sha1-TQY8uSe68KI4Mf9hvsLLv0l5NWE=",
       "requires": {
-        "callsites": "^2.0.0",
-        "chalk": "^2.0.1",
-        "graceful-fs": "^4.1.11",
-        "is-ci": "^1.0.10",
-        "jest-message-util": "^23.4.0",
-        "mkdirp": "^0.5.1",
-        "slash": "^1.0.0",
-        "source-map": "^0.6.0"
+        "callsites": "2.0.0",
+        "chalk": "2.4.1",
+        "graceful-fs": "4.1.15",
+        "is-ci": "1.2.1",
+        "jest-message-util": "23.4.0",
+        "mkdirp": "0.5.1",
+        "slash": "1.0.0",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -10635,10 +10632,10 @@
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz",
       "integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
       "requires": {
-        "chalk": "^2.0.1",
-        "jest-get-type": "^22.1.0",
-        "leven": "^2.1.0",
-        "pretty-format": "^23.6.0"
+        "chalk": "2.4.1",
+        "jest-get-type": "22.4.3",
+        "leven": "2.1.0",
+        "pretty-format": "23.6.0"
       }
     },
     "jest-watcher": {
@@ -10646,9 +10643,9 @@
       "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.4.0.tgz",
       "integrity": "sha1-0uKM50+NrWxq/JIrksq+9u0FyRw=",
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.1",
-        "string-length": "^2.0.0"
+        "ansi-escapes": "3.2.0",
+        "chalk": "2.4.1",
+        "string-length": "2.0.0"
       }
     },
     "jest-worker": {
@@ -10656,7 +10653,7 @@
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.2.0.tgz",
       "integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
       "requires": {
-        "merge-stream": "^1.0.1"
+        "merge-stream": "1.0.1"
       }
     },
     "joi": {
@@ -10664,9 +10661,9 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-11.4.0.tgz",
       "integrity": "sha512-O7Uw+w/zEWgbL6OcHbyACKSj0PkQeUgmehdoXVSxt92QFCq4+1390Rwh5moI2K/OgC7D8RHRZqHZxT2husMJHA==",
       "requires": {
-        "hoek": "4.x.x",
-        "isemail": "3.x.x",
-        "topo": "2.x.x"
+        "hoek": "4.2.1",
+        "isemail": "3.2.0",
+        "topo": "2.0.2"
       }
     },
     "jquery": {
@@ -10689,8 +10686,8 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
       "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       }
     },
     "jsbn": {
@@ -10703,32 +10700,32 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-13.2.0.tgz",
       "integrity": "sha512-cG1NtMWO9hWpqRNRR3dSvEQa8bFI6iLlqU2x4kwX51FQjp0qus8T9aBaAO6iGp3DeBrhdwuKxckknohkmfvsFw==",
       "requires": {
-        "abab": "^2.0.0",
-        "acorn": "^6.0.4",
-        "acorn-globals": "^4.3.0",
-        "array-equal": "^1.0.0",
-        "cssom": "^0.3.4",
-        "cssstyle": "^1.1.1",
-        "data-urls": "^1.1.0",
-        "domexception": "^1.0.1",
-        "escodegen": "^1.11.0",
-        "html-encoding-sniffer": "^1.0.2",
-        "nwsapi": "^2.0.9",
+        "abab": "2.0.0",
+        "acorn": "6.0.7",
+        "acorn-globals": "4.3.0",
+        "array-equal": "1.0.0",
+        "cssom": "0.3.4",
+        "cssstyle": "1.1.1",
+        "data-urls": "1.1.0",
+        "domexception": "1.0.1",
+        "escodegen": "1.11.0",
+        "html-encoding-sniffer": "1.0.2",
+        "nwsapi": "2.1.0",
         "parse5": "5.1.0",
-        "pn": "^1.1.0",
-        "request": "^2.88.0",
-        "request-promise-native": "^1.0.5",
-        "saxes": "^3.1.5",
-        "symbol-tree": "^3.2.2",
-        "tough-cookie": "^2.5.0",
-        "w3c-hr-time": "^1.0.1",
-        "w3c-xmlserializer": "^1.0.1",
-        "webidl-conversions": "^4.0.2",
-        "whatwg-encoding": "^1.0.5",
-        "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^7.0.0",
-        "ws": "^6.1.2",
-        "xml-name-validator": "^3.0.0"
+        "pn": "1.1.0",
+        "request": "2.88.0",
+        "request-promise-native": "1.0.5",
+        "saxes": "3.1.6",
+        "symbol-tree": "3.2.2",
+        "tough-cookie": "2.5.0",
+        "w3c-hr-time": "1.0.1",
+        "w3c-xmlserializer": "1.0.1",
+        "webidl-conversions": "4.0.2",
+        "whatwg-encoding": "1.0.5",
+        "whatwg-mimetype": "2.3.0",
+        "whatwg-url": "7.0.0",
+        "ws": "6.1.3",
+        "xml-name-validator": "3.0.0"
       }
     },
     "jsesc": {
@@ -10746,12 +10743,12 @@
       "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-3.8.0.tgz",
       "integrity": "sha512-6QNcvm2gFuuK4TKU1uwfH0Qd/cOSb9c1lls0gbnIhciktIUQJwz6NQNAW4B1KiGPenv7IKu97V222Yo1bNhGuA==",
       "requires": {
-        "async": "^2.0.1",
-        "babel-preset-env": "^1.7.0",
-        "babelify": "^7.3.0",
-        "json-rpc-error": "^2.0.0",
-        "promise-to-callback": "^1.0.0",
-        "safe-event-emitter": "^1.0.1"
+        "async": "2.6.1",
+        "babel-preset-env": "1.7.0",
+        "babelify": "7.3.0",
+        "json-rpc-error": "2.0.0",
+        "promise-to-callback": "1.0.0",
+        "safe-event-emitter": "1.0.1"
       },
       "dependencies": {
         "async": {
@@ -10759,7 +10756,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
-            "lodash": "^4.17.10"
+            "lodash": "4.17.11"
           }
         }
       }
@@ -10769,7 +10766,7 @@
       "resolved": "https://registry.npmjs.org/json-rpc-error/-/json-rpc-error-2.0.0.tgz",
       "integrity": "sha1-p6+cICg4tekFxyUOVH8a/3cligI=",
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "2.0.3"
       }
     },
     "json-rpc-random-id": {
@@ -10792,7 +10789,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json-stable-stringify-without-jsonify": {
@@ -10815,7 +10812,7 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
       "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
       "requires": {
-        "minimist": "^1.2.0"
+        "minimist": "1.2.0"
       }
     },
     "jsonfile": {
@@ -10823,7 +10820,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.15"
       }
     },
     "jsonify": {
@@ -10847,7 +10844,7 @@
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
       "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
       "requires": {
-        "array-includes": "^3.0.3"
+        "array-includes": "3.0.3"
       }
     },
     "keccak": {
@@ -10855,10 +10852,10 @@
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
       "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
       "requires": {
-        "bindings": "^1.2.1",
-        "inherits": "^2.0.3",
-        "nan": "^2.2.1",
-        "safe-buffer": "^5.1.0"
+        "bindings": "1.4.0",
+        "inherits": "2.0.3",
+        "nan": "2.12.1",
+        "safe-buffer": "5.1.2"
       }
     },
     "keyboard-key": {
@@ -10876,7 +10873,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "klaw": {
@@ -10884,7 +10881,7 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "requires": {
-        "graceful-fs": "^4.1.9"
+        "graceful-fs": "4.1.15"
       }
     },
     "kleur": {
@@ -10897,8 +10894,8 @@
       "resolved": "https://registry.npmjs.org/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz",
       "integrity": "sha512-7KI2l2GIZa9p2spzPIVZBYyNKkN+e/SQPpnjlTiPhdbDW3F86tdKKELxKpzJ5sgU19wQWsACULZmpTPYHeWO5w==",
       "requires": {
-        "lodash": "^4.17.5",
-        "webpack-sources": "^1.1.0"
+        "lodash": "4.17.11",
+        "webpack-sources": "1.3.0"
       }
     },
     "lazy-cache": {
@@ -10911,7 +10908,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
       "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
       "requires": {
-        "invert-kv": "^2.0.0"
+        "invert-kv": "2.0.0"
       }
     },
     "left-pad": {
@@ -10929,7 +10926,7 @@
       "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
       "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
       "requires": {
-        "errno": "~0.1.1"
+        "errno": "0.1.7"
       }
     },
     "level-iterator-stream": {
@@ -10937,10 +10934,10 @@
       "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
       "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
       "requires": {
-        "inherits": "^2.0.1",
-        "level-errors": "^1.0.3",
-        "readable-stream": "^1.0.33",
-        "xtend": "^4.0.0"
+        "inherits": "2.0.3",
+        "level-errors": "1.0.5",
+        "readable-stream": "1.1.14",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -10953,10 +10950,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -10971,8 +10968,8 @@
       "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
       "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
       "requires": {
-        "readable-stream": "~1.0.15",
-        "xtend": "~2.1.1"
+        "readable-stream": "1.0.34",
+        "xtend": "2.1.2"
       },
       "dependencies": {
         "isarray": {
@@ -10990,10 +10987,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -11006,7 +11003,7 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "requires": {
-            "object-keys": "~0.4.0"
+            "object-keys": "0.4.0"
           }
         }
       }
@@ -11016,13 +11013,13 @@
       "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
       "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
       "requires": {
-        "deferred-leveldown": "~1.2.1",
-        "level-codec": "~7.0.0",
-        "level-errors": "~1.0.3",
-        "level-iterator-stream": "~1.3.0",
-        "prr": "~1.0.1",
-        "semver": "~5.4.1",
-        "xtend": "~4.0.0"
+        "deferred-leveldown": "1.2.2",
+        "level-codec": "7.0.1",
+        "level-errors": "1.0.5",
+        "level-iterator-stream": "1.3.1",
+        "prr": "1.0.1",
+        "semver": "5.4.1",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "semver": {
@@ -11042,8 +11039,8 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "lines-and-columns": {
@@ -11057,11 +11054,11 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "graceful-fs": "4.1.15",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
       },
       "dependencies": {
         "parse-json": {
@@ -11069,7 +11066,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.2"
           }
         }
       }
@@ -11079,7 +11076,7 @@
       "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.1.tgz",
       "integrity": "sha1-VuC/CL2XCLJqdltoUJhAyN7J/bw=",
       "requires": {
-        "find-cache-dir": "^0.1.1",
+        "find-cache-dir": "0.1.1",
         "mkdirp": "0.5.1"
       },
       "dependencies": {
@@ -11088,9 +11085,9 @@
           "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
           "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "requires": {
-            "commondir": "^1.0.1",
-            "mkdirp": "^0.5.1",
-            "pkg-dir": "^1.0.0"
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
           }
         },
         "find-up": {
@@ -11098,8 +11095,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-exists": {
@@ -11107,7 +11104,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "pkg-dir": {
@@ -11115,7 +11112,7 @@
           "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "requires": {
-            "find-up": "^1.0.0"
+            "find-up": "1.1.2"
           }
         }
       }
@@ -11130,9 +11127,9 @@
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
       "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
       "requires": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^2.0.0",
-        "json5": "^1.0.1"
+        "big.js": "5.2.2",
+        "emojis-list": "2.1.0",
+        "json5": "1.0.1"
       },
       "dependencies": {
         "json5": {
@@ -11140,7 +11137,7 @@
           "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.0"
           }
         }
       }
@@ -11150,8 +11147,8 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "requires": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "3.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
@@ -11234,8 +11231,8 @@
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "requires": {
-        "lodash._reinterpolate": "~3.0.0",
-        "lodash.templatesettings": "^4.0.0"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.templatesettings": "4.1.0"
       }
     },
     "lodash.templatesettings": {
@@ -11243,7 +11240,7 @@
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "requires": {
-        "lodash._reinterpolate": "~3.0.0"
+        "lodash._reinterpolate": "3.0.0"
       }
     },
     "lodash.uniq": {
@@ -11266,7 +11263,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
+        "js-tokens": "4.0.0"
       }
     },
     "lower-case": {
@@ -11289,7 +11286,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -11304,7 +11301,7 @@
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "requires": {
-        "tmpl": "1.0.x"
+        "tmpl": "1.0.4"
       }
     },
     "mamacro": {
@@ -11317,7 +11314,7 @@
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
       "requires": {
-        "p-defer": "^1.0.0"
+        "p-defer": "1.0.0"
       }
     },
     "map-cache": {
@@ -11330,7 +11327,7 @@
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "math-random": {
@@ -11343,9 +11340,9 @@
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "mdn-data": {
@@ -11363,9 +11360,9 @@
       "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
       "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
       "requires": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^1.0.0",
-        "p-is-promise": "^2.0.0"
+        "map-age-cleaner": "0.1.3",
+        "mimic-fn": "1.2.0",
+        "p-is-promise": "2.0.0"
       }
     },
     "memdown": {
@@ -11373,12 +11370,12 @@
       "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
       "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
       "requires": {
-        "abstract-leveldown": "~2.7.1",
-        "functional-red-black-tree": "^1.0.1",
-        "immediate": "^3.2.3",
-        "inherits": "~2.0.1",
-        "ltgt": "~2.2.0",
-        "safe-buffer": "~5.1.1"
+        "abstract-leveldown": "2.7.2",
+        "functional-red-black-tree": "1.0.1",
+        "immediate": "3.2.3",
+        "inherits": "2.0.3",
+        "ltgt": "2.2.1",
+        "safe-buffer": "5.1.2"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -11386,7 +11383,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
           "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
           "requires": {
-            "xtend": "~4.0.0"
+            "xtend": "4.0.1"
           }
         }
       }
@@ -11402,8 +11399,8 @@
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "requires": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
+        "errno": "0.1.7",
+        "readable-stream": "2.3.6"
       }
     },
     "memorystream": {
@@ -11421,9 +11418,9 @@
       "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
       "integrity": "sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==",
       "requires": {
-        "arr-union": "^3.1.0",
-        "clone-deep": "^0.2.4",
-        "kind-of": "^3.0.2"
+        "arr-union": "3.1.0",
+        "clone-deep": "0.2.4",
+        "kind-of": "3.2.2"
       }
     },
     "merge-descriptors": {
@@ -11436,7 +11433,7 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.6"
       }
     },
     "merge2": {
@@ -11449,14 +11446,14 @@
       "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
       "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
       "requires": {
-        "async": "^1.4.2",
-        "ethereumjs-util": "^5.0.0",
+        "async": "1.5.2",
+        "ethereumjs-util": "5.2.0",
         "level-ws": "0.0.0",
-        "levelup": "^1.2.1",
-        "memdown": "^1.0.0",
-        "readable-stream": "^2.0.0",
-        "rlp": "^2.0.0",
-        "semaphore": ">=1.0.1"
+        "levelup": "1.3.9",
+        "memdown": "1.4.1",
+        "readable-stream": "2.3.6",
+        "rlp": "2.2.2",
+        "semaphore": "1.1.0"
       },
       "dependencies": {
         "async": {
@@ -11476,19 +11473,19 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
       }
     },
     "miller-rabin": {
@@ -11496,8 +11493,8 @@
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "requires": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0"
       }
     },
     "mime": {
@@ -11515,7 +11512,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
       "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
       "requires": {
-        "mime-db": "~1.37.0"
+        "mime-db": "1.37.0"
       }
     },
     "mimic-fn": {
@@ -11528,7 +11525,7 @@
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "requires": {
-        "dom-walk": "^0.1.0"
+        "dom-walk": "0.1.1"
       }
     },
     "mini-css-extract-plugin": {
@@ -11536,9 +11533,9 @@
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.3.tgz",
       "integrity": "sha512-Mxs0nxzF1kxPv4TRi2NimewgXlJqh0rGE30vviCU2WHrpbta6wklnUV9dr9FUtoAHmB3p3LeXEC+ZjgHvB0Dzg==",
       "requires": {
-        "loader-utils": "^1.1.0",
-        "schema-utils": "^1.0.0",
-        "webpack-sources": "^1.1.0"
+        "loader-utils": "1.2.3",
+        "schema-utils": "1.0.0",
+        "webpack-sources": "1.3.0"
       }
     },
     "minimalistic-assert": {
@@ -11556,7 +11553,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -11569,16 +11566,16 @@
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
       "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
       "requires": {
-        "concat-stream": "^1.5.0",
-        "duplexify": "^3.4.2",
-        "end-of-stream": "^1.1.0",
-        "flush-write-stream": "^1.0.0",
-        "from2": "^2.1.0",
-        "parallel-transform": "^1.1.0",
-        "pump": "^3.0.0",
-        "pumpify": "^1.3.3",
-        "stream-each": "^1.1.0",
-        "through2": "^2.0.0"
+        "concat-stream": "1.6.2",
+        "duplexify": "3.7.1",
+        "end-of-stream": "1.4.1",
+        "flush-write-stream": "1.1.0",
+        "from2": "2.3.0",
+        "parallel-transform": "1.1.0",
+        "pump": "3.0.0",
+        "pumpify": "1.5.1",
+        "stream-each": "1.2.3",
+        "through2": "2.0.5"
       }
     },
     "mixin-deep": {
@@ -11586,8 +11583,8 @@
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -11595,7 +11592,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -11605,8 +11602,8 @@
       "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
       "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
       "requires": {
-        "for-in": "^0.1.3",
-        "is-extendable": "^0.1.1"
+        "for-in": "0.1.8",
+        "is-extendable": "0.1.1"
       },
       "dependencies": {
         "for-in": {
@@ -11641,12 +11638,12 @@
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "requires": {
-        "aproba": "^1.1.1",
-        "copy-concurrently": "^1.0.0",
-        "fs-write-stream-atomic": "^1.0.8",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.3"
+        "aproba": "1.2.0",
+        "copy-concurrently": "1.0.5",
+        "fs-write-stream-atomic": "1.0.10",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.3",
+        "run-queue": "1.0.3"
       }
     },
     "ms": {
@@ -11659,8 +11656,8 @@
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
       "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
       "requires": {
-        "dns-packet": "^1.3.1",
-        "thunky": "^1.0.2"
+        "dns-packet": "1.3.1",
+        "thunky": "1.0.3"
       }
     },
     "multicast-dns-service-types": {
@@ -11683,17 +11680,17 @@
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -11738,7 +11735,7 @@
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "requires": {
-        "lower-case": "^1.1.1"
+        "lower-case": "1.1.4"
       }
     },
     "node-fetch": {
@@ -11761,28 +11758,28 @@
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
       "integrity": "sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==",
       "requires": {
-        "assert": "^1.1.1",
-        "browserify-zlib": "^0.2.0",
-        "buffer": "^4.3.0",
-        "console-browserify": "^1.1.0",
-        "constants-browserify": "^1.0.0",
-        "crypto-browserify": "^3.11.0",
-        "domain-browser": "^1.1.1",
-        "events": "^3.0.0",
-        "https-browserify": "^1.0.0",
-        "os-browserify": "^0.3.0",
+        "assert": "1.4.1",
+        "browserify-zlib": "0.2.0",
+        "buffer": "4.9.1",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.12.0",
+        "domain-browser": "1.2.0",
+        "events": "3.0.0",
+        "https-browserify": "1.0.0",
+        "os-browserify": "0.3.0",
         "path-browserify": "0.0.0",
-        "process": "^0.11.10",
-        "punycode": "^1.2.4",
-        "querystring-es3": "^0.2.0",
-        "readable-stream": "^2.3.3",
-        "stream-browserify": "^2.0.1",
-        "stream-http": "^2.7.2",
-        "string_decoder": "^1.0.0",
-        "timers-browserify": "^2.0.4",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "readable-stream": "2.3.6",
+        "stream-browserify": "2.0.2",
+        "stream-http": "2.8.3",
+        "string_decoder": "1.1.1",
+        "timers-browserify": "2.0.10",
         "tty-browserify": "0.0.0",
-        "url": "^0.11.0",
-        "util": "^0.11.0",
+        "url": "0.11.0",
+        "util": "0.11.1",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -11803,11 +11800,11 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
       "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
       "requires": {
-        "growly": "^1.3.0",
-        "is-wsl": "^1.1.0",
-        "semver": "^5.5.0",
-        "shellwords": "^0.1.1",
-        "which": "^1.3.0"
+        "growly": "1.3.0",
+        "is-wsl": "1.1.0",
+        "semver": "5.6.0",
+        "shellwords": "0.1.1",
+        "which": "1.3.1"
       }
     },
     "node-releases": {
@@ -11815,7 +11812,7 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.7.tgz",
       "integrity": "sha512-bKdrwaqJUPHqlCzDD7so/R+Nk0jGv9a11ZhLrD9f6i947qGLrGAhU3OxRENa19QQmwzGy/g6zCDEuLGDO8HPvA==",
       "requires": {
-        "semver": "^5.3.0"
+        "semver": "5.6.0"
       }
     },
     "normalize-package-data": {
@@ -11823,10 +11820,10 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.2.tgz",
       "integrity": "sha512-YcMnjqeoUckXTPKZSAsPjUPLxH85XotbpqK3w4RyCwdFQSU5FxxBys8buehkSfg0j9fKvV1hn7O0+8reEgkAiw==",
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.7.1",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.6.0",
+        "validate-npm-package-license": "3.0.4"
       }
     },
     "normalize-path": {
@@ -11834,7 +11831,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "normalize-range": {
@@ -11852,7 +11849,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "npx": {
@@ -11868,7 +11865,7 @@
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "string-width": "^2.0.0"
+            "string-width": "2.1.1"
           }
         },
         "ansi-regex": {
@@ -11879,7 +11876,7 @@
           "version": "3.2.1",
           "bundled": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "balanced-match": {
@@ -11890,20 +11887,20 @@
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "ansi-align": "^2.0.0",
-            "camelcase": "^4.0.0",
-            "chalk": "^2.0.1",
-            "cli-boxes": "^1.0.0",
-            "string-width": "^2.0.0",
-            "term-size": "^1.2.0",
-            "widest-line": "^2.0.0"
+            "ansi-align": "2.0.0",
+            "camelcase": "4.1.0",
+            "chalk": "2.3.2",
+            "cli-boxes": "1.0.0",
+            "string-width": "2.1.1",
+            "term-size": "1.2.0",
+            "widest-line": "2.0.0"
           }
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -11923,9 +11920,9 @@
           "version": "2.3.2",
           "bundled": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "ci-info": {
@@ -11940,9 +11937,9 @@
           "version": "4.0.0",
           "bundled": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
           }
         },
         "code-point-at": {
@@ -11953,7 +11950,7 @@
           "version": "1.9.1",
           "bundled": true,
           "requires": {
-            "color-name": "^1.1.1"
+            "color-name": "1.1.3"
           }
         },
         "color-name": {
@@ -11968,28 +11965,28 @@
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "dot-prop": "^4.1.0",
-            "graceful-fs": "^4.1.2",
-            "make-dir": "^1.0.0",
-            "unique-string": "^1.0.0",
-            "write-file-atomic": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
+            "dot-prop": "4.2.0",
+            "graceful-fs": "4.1.11",
+            "make-dir": "1.2.0",
+            "unique-string": "1.0.0",
+            "write-file-atomic": "2.3.0",
+            "xdg-basedir": "3.0.0"
           }
         },
         "create-error-class": {
           "version": "3.0.2",
           "bundled": true,
           "requires": {
-            "capture-stack-trace": "^1.0.0"
+            "capture-stack-trace": "1.0.0"
           }
         },
         "cross-spawn": {
           "version": "5.1.0",
           "bundled": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.2",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
           }
         },
         "crypto-random-string": {
@@ -12008,7 +12005,7 @@
           "version": "4.2.0",
           "bundled": true,
           "requires": {
-            "is-obj": "^1.0.0"
+            "is-obj": "1.0.1"
           }
         },
         "dotenv": {
@@ -12027,20 +12024,20 @@
           "version": "0.7.0",
           "bundled": true,
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "find-up": {
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "fs.realpath": {
@@ -12059,36 +12056,36 @@
           "version": "7.1.2",
           "bundled": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "global-dirs": {
           "version": "0.1.1",
           "bundled": true,
           "requires": {
-            "ini": "^1.3.4"
+            "ini": "1.3.5"
           }
         },
         "got": {
           "version": "6.7.1",
           "bundled": true,
           "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
+            "create-error-class": "3.0.2",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.1",
+            "safe-buffer": "5.1.1",
+            "timed-out": "4.0.1",
+            "unzip-response": "2.0.1",
+            "url-parse-lax": "1.0.0"
           }
         },
         "graceful-fs": {
@@ -12115,8 +12112,8 @@
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -12135,7 +12132,7 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "ci-info": "^1.0.0"
+            "ci-info": "1.1.3"
           }
         },
         "is-fullwidth-code-point": {
@@ -12146,8 +12143,8 @@
           "version": "0.1.0",
           "bundled": true,
           "requires": {
-            "global-dirs": "^0.1.0",
-            "is-path-inside": "^1.0.0"
+            "global-dirs": "0.1.1",
+            "is-path-inside": "1.0.1"
           }
         },
         "is-npm": {
@@ -12162,7 +12159,7 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "path-is-inside": "^1.0.1"
+            "path-is-inside": "1.0.2"
           }
         },
         "is-redirect": {
@@ -12185,36 +12182,36 @@
           "version": "3.1.0",
           "bundled": true,
           "requires": {
-            "package-json": "^4.0.0"
+            "package-json": "4.0.1"
           }
         },
         "lcid": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "invert-kv": "^1.0.0"
+            "invert-kv": "1.0.0"
           }
         },
         "libnpx": {
           "version": "10.2.0",
           "bundled": true,
           "requires": {
-            "dotenv": "^5.0.1",
-            "npm-package-arg": "^6.0.0",
-            "rimraf": "^2.6.2",
-            "safe-buffer": "^5.1.0",
-            "update-notifier": "^2.3.0",
-            "which": "^1.3.0",
-            "y18n": "^4.0.0",
-            "yargs": "^11.0.0"
+            "dotenv": "5.0.1",
+            "npm-package-arg": "6.1.0",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.1",
+            "update-notifier": "2.4.0",
+            "which": "1.3.0",
+            "y18n": "4.0.0",
+            "yargs": "11.0.0"
           }
         },
         "locate-path": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "lowercase-keys": {
@@ -12225,22 +12222,22 @@
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         },
         "make-dir": {
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "mem": {
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "mimic-fn": "^1.0.0"
+            "mimic-fn": "1.2.0"
           }
         },
         "mimic-fn": {
@@ -12251,7 +12248,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -12262,110 +12259,110 @@
           "version": "5.1.0",
           "bundled": true,
           "requires": {
-            "JSONStream": "~1.3.1",
-            "abbrev": "~1.1.0",
-            "ansi-regex": "~3.0.0",
-            "ansicolors": "~0.3.2",
-            "ansistyles": "~0.1.3",
-            "aproba": "~1.1.2",
-            "archy": "~1.0.0",
-            "bluebird": "~3.5.0",
-            "cacache": "~9.2.9",
-            "call-limit": "~1.1.0",
-            "chownr": "~1.0.1",
-            "cmd-shim": "~2.0.2",
-            "columnify": "~1.5.4",
-            "config-chain": "~1.1.11",
-            "debuglog": "*",
-            "detect-indent": "~5.0.0",
-            "dezalgo": "~1.0.3",
-            "editor": "~1.0.0",
-            "fs-vacuum": "~1.2.10",
-            "fs-write-stream-atomic": "~1.0.10",
-            "fstream": "~1.0.11",
-            "fstream-npm": "~1.2.1",
-            "glob": "~7.1.2",
-            "graceful-fs": "~4.1.11",
-            "has-unicode": "~2.0.1",
-            "hosted-git-info": "~2.5.0",
-            "iferr": "~0.1.5",
-            "imurmurhash": "*",
-            "inflight": "~1.0.6",
-            "inherits": "~2.0.3",
-            "ini": "~1.3.4",
-            "init-package-json": "~1.10.1",
-            "lazy-property": "~1.0.0",
-            "lockfile": "~1.0.3",
-            "lodash._baseindexof": "*",
-            "lodash._baseuniq": "~4.6.0",
-            "lodash._bindcallback": "*",
-            "lodash._cacheindexof": "*",
-            "lodash._createcache": "*",
-            "lodash._getnative": "*",
-            "lodash.clonedeep": "~4.5.0",
-            "lodash.restparam": "*",
-            "lodash.union": "~4.6.0",
-            "lodash.uniq": "~4.5.0",
-            "lodash.without": "~4.4.0",
-            "lru-cache": "~4.1.1",
-            "mississippi": "~1.3.0",
-            "mkdirp": "~0.5.1",
-            "move-concurrently": "~1.0.1",
-            "node-gyp": "~3.6.2",
-            "nopt": "~4.0.1",
-            "normalize-package-data": "~2.4.0",
-            "npm-cache-filename": "~1.0.2",
-            "npm-install-checks": "~3.0.0",
-            "npm-package-arg": "~5.1.2",
-            "npm-registry-client": "~8.4.0",
-            "npm-user-validate": "~1.0.0",
-            "npmlog": "~4.1.2",
-            "once": "~1.4.0",
-            "opener": "~1.4.3",
-            "osenv": "~0.1.4",
-            "pacote": "~2.7.38",
-            "path-is-inside": "~1.0.2",
-            "promise-inflight": "~1.0.1",
-            "read": "~1.0.7",
-            "read-cmd-shim": "~1.0.1",
-            "read-installed": "~4.0.3",
-            "read-package-json": "~2.0.9",
-            "read-package-tree": "~5.1.6",
-            "readable-stream": "~2.3.2",
-            "readdir-scoped-modules": "*",
-            "request": "~2.81.0",
-            "retry": "~0.10.1",
-            "rimraf": "~2.6.1",
-            "safe-buffer": "~5.1.1",
-            "semver": "~5.3.0",
-            "sha": "~2.0.1",
-            "slide": "~1.1.6",
-            "sorted-object": "~2.0.1",
-            "sorted-union-stream": "~2.1.3",
-            "ssri": "~4.1.6",
-            "strip-ansi": "~4.0.0",
-            "tar": "~2.2.1",
-            "text-table": "~0.2.0",
+            "JSONStream": "1.3.1",
+            "abbrev": "1.1.0",
+            "ansi-regex": "3.0.0",
+            "ansicolors": "0.3.2",
+            "ansistyles": "0.1.3",
+            "aproba": "1.1.2",
+            "archy": "1.0.0",
+            "bluebird": "3.5.0",
+            "cacache": "9.2.9",
+            "call-limit": "1.1.0",
+            "chownr": "1.0.1",
+            "cmd-shim": "2.0.2",
+            "columnify": "1.5.4",
+            "config-chain": "1.1.11",
+            "debuglog": "1.0.1",
+            "detect-indent": "5.0.0",
+            "dezalgo": "1.0.3",
+            "editor": "1.0.0",
+            "fs-vacuum": "1.2.10",
+            "fs-write-stream-atomic": "1.0.10",
+            "fstream": "1.0.11",
+            "fstream-npm": "1.2.1",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "has-unicode": "2.0.1",
+            "hosted-git-info": "2.5.0",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "ini": "1.3.4",
+            "init-package-json": "1.10.1",
+            "lazy-property": "1.0.0",
+            "lockfile": "1.0.3",
+            "lodash._baseindexof": "3.1.0",
+            "lodash._baseuniq": "4.6.0",
+            "lodash._bindcallback": "3.0.1",
+            "lodash._cacheindexof": "3.0.2",
+            "lodash._createcache": "3.1.2",
+            "lodash._getnative": "3.9.1",
+            "lodash.clonedeep": "4.5.0",
+            "lodash.restparam": "3.6.1",
+            "lodash.union": "4.6.0",
+            "lodash.uniq": "4.5.0",
+            "lodash.without": "4.4.0",
+            "lru-cache": "4.1.1",
+            "mississippi": "1.3.0",
+            "mkdirp": "0.5.1",
+            "move-concurrently": "1.0.1",
+            "node-gyp": "3.6.2",
+            "nopt": "4.0.1",
+            "normalize-package-data": "2.4.0",
+            "npm-cache-filename": "1.0.2",
+            "npm-install-checks": "3.0.0",
+            "npm-package-arg": "5.1.2",
+            "npm-registry-client": "8.4.0",
+            "npm-user-validate": "1.0.0",
+            "npmlog": "4.1.2",
+            "once": "1.4.0",
+            "opener": "1.4.3",
+            "osenv": "0.1.4",
+            "pacote": "2.7.38",
+            "path-is-inside": "1.0.2",
+            "promise-inflight": "1.0.1",
+            "read": "1.0.7",
+            "read-cmd-shim": "1.0.1",
+            "read-installed": "4.0.3",
+            "read-package-json": "2.0.9",
+            "read-package-tree": "5.1.6",
+            "readable-stream": "2.3.2",
+            "readdir-scoped-modules": "1.0.2",
+            "request": "2.81.0",
+            "retry": "0.10.1",
+            "rimraf": "2.6.1",
+            "safe-buffer": "5.1.1",
+            "semver": "5.3.0",
+            "sha": "2.0.1",
+            "slide": "1.1.6",
+            "sorted-object": "2.0.1",
+            "sorted-union-stream": "2.1.3",
+            "ssri": "4.1.6",
+            "strip-ansi": "4.0.0",
+            "tar": "2.2.1",
+            "text-table": "0.2.0",
             "uid-number": "0.0.6",
-            "umask": "~1.1.0",
-            "unique-filename": "~1.1.0",
-            "unpipe": "~1.0.0",
-            "update-notifier": "~2.2.0",
-            "uuid": "~3.1.0",
-            "validate-npm-package-license": "*",
-            "validate-npm-package-name": "~3.0.0",
-            "which": "~1.2.14",
-            "worker-farm": "~1.3.1",
-            "wrappy": "~1.0.2",
-            "write-file-atomic": "~2.1.0"
+            "umask": "1.1.0",
+            "unique-filename": "1.1.0",
+            "unpipe": "1.0.0",
+            "update-notifier": "2.2.0",
+            "uuid": "3.1.0",
+            "validate-npm-package-license": "3.0.1",
+            "validate-npm-package-name": "3.0.0",
+            "which": "1.2.14",
+            "worker-farm": "1.3.1",
+            "wrappy": "1.0.2",
+            "write-file-atomic": "2.1.0"
           },
           "dependencies": {
             "JSONStream": {
               "version": "1.3.1",
               "bundled": true,
               "requires": {
-                "jsonparse": "^1.2.0",
-                "through": ">=2.2.7 <3"
+                "jsonparse": "1.3.1",
+                "through": "2.3.8"
               },
               "dependencies": {
                 "jsonparse": {
@@ -12410,27 +12407,27 @@
               "version": "9.2.9",
               "bundled": true,
               "requires": {
-                "bluebird": "^3.5.0",
-                "chownr": "^1.0.1",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^1.3.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.1",
-                "ssri": "^4.1.6",
-                "unique-filename": "^1.1.0",
-                "y18n": "^3.2.1"
+                "bluebird": "3.5.0",
+                "chownr": "1.0.1",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "lru-cache": "4.1.1",
+                "mississippi": "1.3.0",
+                "mkdirp": "0.5.1",
+                "move-concurrently": "1.0.1",
+                "promise-inflight": "1.0.1",
+                "rimraf": "2.6.1",
+                "ssri": "4.1.6",
+                "unique-filename": "1.1.0",
+                "y18n": "3.2.1"
               },
               "dependencies": {
                 "lru-cache": {
                   "version": "4.1.1",
                   "bundled": true,
                   "requires": {
-                    "pseudomap": "^1.0.2",
-                    "yallist": "^2.1.2"
+                    "pseudomap": "1.0.2",
+                    "yallist": "2.1.2"
                   },
                   "dependencies": {
                     "pseudomap": {
@@ -12461,23 +12458,23 @@
               "version": "2.0.2",
               "bundled": true,
               "requires": {
-                "graceful-fs": "^4.1.2",
-                "mkdirp": "~0.5.0"
+                "graceful-fs": "4.1.11",
+                "mkdirp": "0.5.1"
               }
             },
             "columnify": {
               "version": "1.5.4",
               "bundled": true,
               "requires": {
-                "strip-ansi": "^3.0.0",
-                "wcwidth": "^1.0.0"
+                "strip-ansi": "3.0.1",
+                "wcwidth": "1.0.1"
               },
               "dependencies": {
                 "strip-ansi": {
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "ansi-regex": "^2.0.0"
+                    "ansi-regex": "2.1.1"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -12490,14 +12487,14 @@
                   "version": "1.0.1",
                   "bundled": true,
                   "requires": {
-                    "defaults": "^1.0.3"
+                    "defaults": "1.0.3"
                   },
                   "dependencies": {
                     "defaults": {
                       "version": "1.0.3",
                       "bundled": true,
                       "requires": {
-                        "clone": "^1.0.2"
+                        "clone": "1.0.2"
                       },
                       "dependencies": {
                         "clone": {
@@ -12514,8 +12511,8 @@
               "version": "1.1.11",
               "bundled": true,
               "requires": {
-                "ini": "^1.3.4",
-                "proto-list": "~1.2.1"
+                "ini": "1.3.4",
+                "proto-list": "1.2.4"
               },
               "dependencies": {
                 "proto-list": {
@@ -12536,8 +12533,8 @@
               "version": "1.0.3",
               "bundled": true,
               "requires": {
-                "asap": "^2.0.0",
-                "wrappy": "1"
+                "asap": "2.0.5",
+                "wrappy": "1.0.2"
               },
               "dependencies": {
                 "asap": {
@@ -12554,60 +12551,60 @@
               "version": "1.2.10",
               "bundled": true,
               "requires": {
-                "graceful-fs": "^4.1.2",
-                "path-is-inside": "^1.0.1",
-                "rimraf": "^2.5.2"
+                "graceful-fs": "4.1.11",
+                "path-is-inside": "1.0.2",
+                "rimraf": "2.6.1"
               }
             },
             "fs-write-stream-atomic": {
               "version": "1.0.10",
               "bundled": true,
               "requires": {
-                "graceful-fs": "^4.1.2",
-                "iferr": "^0.1.5",
-                "imurmurhash": "^0.1.4",
-                "readable-stream": "1 || 2"
+                "graceful-fs": "4.1.11",
+                "iferr": "0.1.5",
+                "imurmurhash": "0.1.4",
+                "readable-stream": "2.3.2"
               }
             },
             "fstream": {
               "version": "1.0.11",
               "bundled": true,
               "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.1"
               }
             },
             "fstream-npm": {
               "version": "1.2.1",
               "bundled": true,
               "requires": {
-                "fstream-ignore": "^1.0.0",
-                "inherits": "2"
+                "fstream-ignore": "1.0.5",
+                "inherits": "2.0.3"
               },
               "dependencies": {
                 "fstream-ignore": {
                   "version": "1.0.5",
                   "bundled": true,
                   "requires": {
-                    "fstream": "^1.0.0",
-                    "inherits": "2",
-                    "minimatch": "^3.0.0"
+                    "fstream": "1.0.11",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.4"
                   },
                   "dependencies": {
                     "minimatch": {
                       "version": "3.0.4",
                       "bundled": true,
                       "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "brace-expansion": "1.1.8"
                       },
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.8",
                           "bundled": true,
                           "requires": {
-                            "balanced-match": "^1.0.0",
+                            "balanced-match": "1.0.0",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -12631,12 +12628,12 @@
               "version": "7.1.2",
               "bundled": true,
               "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
               },
               "dependencies": {
                 "fs.realpath": {
@@ -12647,14 +12644,14 @@
                   "version": "3.0.4",
                   "bundled": true,
                   "requires": {
-                    "brace-expansion": "^1.1.7"
+                    "brace-expansion": "1.1.8"
                   },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
                       "bundled": true,
                       "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -12700,8 +12697,8 @@
               "version": "1.0.6",
               "bundled": true,
               "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
               }
             },
             "inherits": {
@@ -12716,21 +12713,21 @@
               "version": "1.10.1",
               "bundled": true,
               "requires": {
-                "glob": "^7.1.1",
-                "npm-package-arg": "^4.0.0 || ^5.0.0",
-                "promzard": "^0.3.0",
-                "read": "~1.0.1",
-                "read-package-json": "1 || 2",
-                "semver": "2.x || 3.x || 4 || 5",
-                "validate-npm-package-license": "^3.0.1",
-                "validate-npm-package-name": "^3.0.0"
+                "glob": "7.1.2",
+                "npm-package-arg": "5.1.2",
+                "promzard": "0.3.0",
+                "read": "1.0.7",
+                "read-package-json": "2.0.9",
+                "semver": "5.3.0",
+                "validate-npm-package-license": "3.0.1",
+                "validate-npm-package-name": "3.0.0"
               },
               "dependencies": {
                 "promzard": {
                   "version": "0.3.0",
                   "bundled": true,
                   "requires": {
-                    "read": "1"
+                    "read": "1.0.7"
                   }
                 }
               }
@@ -12751,8 +12748,8 @@
               "version": "4.6.0",
               "bundled": true,
               "requires": {
-                "lodash._createset": "~4.0.0",
-                "lodash._root": "~3.0.0"
+                "lodash._createset": "4.0.3",
+                "lodash._root": "3.0.1"
               },
               "dependencies": {
                 "lodash._createset": {
@@ -12777,7 +12774,7 @@
               "version": "3.1.2",
               "bundled": true,
               "requires": {
-                "lodash._getnative": "^3.0.0"
+                "lodash._getnative": "3.9.1"
               }
             },
             "lodash._getnative": {
@@ -12808,8 +12805,8 @@
               "version": "4.1.1",
               "bundled": true,
               "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
               },
               "dependencies": {
                 "pseudomap": {
@@ -12826,25 +12823,25 @@
               "version": "1.3.0",
               "bundled": true,
               "requires": {
-                "concat-stream": "^1.5.0",
-                "duplexify": "^3.4.2",
-                "end-of-stream": "^1.1.0",
-                "flush-write-stream": "^1.0.0",
-                "from2": "^2.1.0",
-                "parallel-transform": "^1.1.0",
-                "pump": "^1.0.0",
-                "pumpify": "^1.3.3",
-                "stream-each": "^1.1.0",
-                "through2": "^2.0.0"
+                "concat-stream": "1.6.0",
+                "duplexify": "3.5.0",
+                "end-of-stream": "1.4.0",
+                "flush-write-stream": "1.0.2",
+                "from2": "2.3.0",
+                "parallel-transform": "1.1.0",
+                "pump": "1.0.2",
+                "pumpify": "1.3.5",
+                "stream-each": "1.2.0",
+                "through2": "2.0.3"
               },
               "dependencies": {
                 "concat-stream": {
                   "version": "1.6.0",
                   "bundled": true,
                   "requires": {
-                    "inherits": "^2.0.3",
-                    "readable-stream": "^2.2.2",
-                    "typedarray": "^0.0.6"
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.2",
+                    "typedarray": "0.0.6"
                   },
                   "dependencies": {
                     "typedarray": {
@@ -12858,23 +12855,23 @@
                   "bundled": true,
                   "requires": {
                     "end-of-stream": "1.0.0",
-                    "inherits": "^2.0.1",
-                    "readable-stream": "^2.0.0",
-                    "stream-shift": "^1.0.0"
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.2",
+                    "stream-shift": "1.0.0"
                   },
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "once": "~1.3.0"
+                        "once": "1.3.3"
                       },
                       "dependencies": {
                         "once": {
                           "version": "1.3.3",
                           "bundled": true,
                           "requires": {
-                            "wrappy": "1"
+                            "wrappy": "1.0.2"
                           }
                         }
                       }
@@ -12889,32 +12886,32 @@
                   "version": "1.4.0",
                   "bundled": true,
                   "requires": {
-                    "once": "^1.4.0"
+                    "once": "1.4.0"
                   }
                 },
                 "flush-write-stream": {
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "inherits": "^2.0.1",
-                    "readable-stream": "^2.0.4"
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.2"
                   }
                 },
                 "from2": {
                   "version": "2.3.0",
                   "bundled": true,
                   "requires": {
-                    "inherits": "^2.0.1",
-                    "readable-stream": "^2.0.0"
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.2"
                   }
                 },
                 "parallel-transform": {
                   "version": "1.1.0",
                   "bundled": true,
                   "requires": {
-                    "cyclist": "~0.2.2",
-                    "inherits": "^2.0.3",
-                    "readable-stream": "^2.1.5"
+                    "cyclist": "0.2.2",
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.2"
                   },
                   "dependencies": {
                     "cyclist": {
@@ -12927,25 +12924,25 @@
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "end-of-stream": "^1.1.0",
-                    "once": "^1.3.1"
+                    "end-of-stream": "1.4.0",
+                    "once": "1.4.0"
                   }
                 },
                 "pumpify": {
                   "version": "1.3.5",
                   "bundled": true,
                   "requires": {
-                    "duplexify": "^3.1.2",
-                    "inherits": "^2.0.1",
-                    "pump": "^1.0.0"
+                    "duplexify": "3.5.0",
+                    "inherits": "2.0.3",
+                    "pump": "1.0.2"
                   }
                 },
                 "stream-each": {
                   "version": "1.2.0",
                   "bundled": true,
                   "requires": {
-                    "end-of-stream": "^1.1.0",
-                    "stream-shift": "^1.0.0"
+                    "end-of-stream": "1.4.0",
+                    "stream-shift": "1.0.0"
                   },
                   "dependencies": {
                     "stream-shift": {
@@ -12958,8 +12955,8 @@
                   "version": "2.0.3",
                   "bundled": true,
                   "requires": {
-                    "readable-stream": "^2.1.5",
-                    "xtend": "~4.0.1"
+                    "readable-stream": "2.3.2",
+                    "xtend": "4.0.1"
                   },
                   "dependencies": {
                     "xtend": {
@@ -12987,31 +12984,31 @@
               "version": "1.0.1",
               "bundled": true,
               "requires": {
-                "aproba": "^1.1.1",
-                "copy-concurrently": "^1.0.0",
-                "fs-write-stream-atomic": "^1.0.8",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.3"
+                "aproba": "1.1.2",
+                "copy-concurrently": "1.0.3",
+                "fs-write-stream-atomic": "1.0.10",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.1",
+                "run-queue": "1.0.3"
               },
               "dependencies": {
                 "copy-concurrently": {
                   "version": "1.0.3",
                   "bundled": true,
                   "requires": {
-                    "aproba": "^1.1.1",
-                    "fs-write-stream-atomic": "^1.0.8",
-                    "iferr": "^0.1.5",
-                    "mkdirp": "^0.5.1",
-                    "rimraf": "^2.5.4",
-                    "run-queue": "^1.0.0"
+                    "aproba": "1.1.2",
+                    "fs-write-stream-atomic": "1.0.10",
+                    "iferr": "0.1.5",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.6.1",
+                    "run-queue": "1.0.3"
                   }
                 },
                 "run-queue": {
                   "version": "1.0.3",
                   "bundled": true,
                   "requires": {
-                    "aproba": "^1.1.1"
+                    "aproba": "1.1.2"
                   }
                 }
               }
@@ -13020,33 +13017,33 @@
               "version": "3.6.2",
               "bundled": true,
               "requires": {
-                "fstream": "^1.0.0",
-                "glob": "^7.0.3",
-                "graceful-fs": "^4.1.2",
-                "minimatch": "^3.0.2",
-                "mkdirp": "^0.5.0",
-                "nopt": "2 || 3",
-                "npmlog": "0 || 1 || 2 || 3 || 4",
-                "osenv": "0",
-                "request": "2",
-                "rimraf": "2",
-                "semver": "~5.3.0",
-                "tar": "^2.0.0",
-                "which": "1"
+                "fstream": "1.0.11",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "nopt": "3.0.6",
+                "npmlog": "4.1.2",
+                "osenv": "0.1.4",
+                "request": "2.81.0",
+                "rimraf": "2.6.1",
+                "semver": "5.3.0",
+                "tar": "2.2.1",
+                "which": "1.2.14"
               },
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
                   "bundled": true,
                   "requires": {
-                    "brace-expansion": "^1.1.7"
+                    "brace-expansion": "1.1.8"
                   },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
                       "bundled": true,
                       "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -13066,7 +13063,7 @@
                   "version": "3.0.6",
                   "bundled": true,
                   "requires": {
-                    "abbrev": "1"
+                    "abbrev": "1.1.0"
                   }
                 }
               }
@@ -13075,25 +13072,25 @@
               "version": "4.0.1",
               "bundled": true,
               "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
+                "abbrev": "1.1.0",
+                "osenv": "0.1.4"
               }
             },
             "normalize-package-data": {
               "version": "2.4.0",
               "bundled": true,
               "requires": {
-                "hosted-git-info": "^2.1.4",
-                "is-builtin-module": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
+                "hosted-git-info": "2.5.0",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.3.0",
+                "validate-npm-package-license": "3.0.1"
               },
               "dependencies": {
                 "is-builtin-module": {
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "builtin-modules": "^1.0.0"
+                    "builtin-modules": "1.1.1"
                   },
                   "dependencies": {
                     "builtin-modules": {
@@ -13112,43 +13109,43 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "semver": "^2.3.0 || 3.x || 4 || 5"
+                "semver": "5.3.0"
               }
             },
             "npm-package-arg": {
               "version": "5.1.2",
               "bundled": true,
               "requires": {
-                "hosted-git-info": "^2.4.2",
-                "osenv": "^0.1.4",
-                "semver": "^5.1.0",
-                "validate-npm-package-name": "^3.0.0"
+                "hosted-git-info": "2.5.0",
+                "osenv": "0.1.4",
+                "semver": "5.3.0",
+                "validate-npm-package-name": "3.0.0"
               }
             },
             "npm-registry-client": {
               "version": "8.4.0",
               "bundled": true,
               "requires": {
-                "concat-stream": "^1.5.2",
-                "graceful-fs": "^4.1.6",
-                "normalize-package-data": "~1.0.1 || ^2.0.0",
-                "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0",
-                "npmlog": "2 || ^3.1.0 || ^4.0.0",
-                "once": "^1.3.3",
-                "request": "^2.74.0",
-                "retry": "^0.10.0",
-                "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-                "slide": "^1.1.3",
-                "ssri": "^4.1.2"
+                "concat-stream": "1.6.0",
+                "graceful-fs": "4.1.11",
+                "normalize-package-data": "2.4.0",
+                "npm-package-arg": "5.1.2",
+                "npmlog": "4.1.2",
+                "once": "1.4.0",
+                "request": "2.81.0",
+                "retry": "0.10.1",
+                "semver": "5.3.0",
+                "slide": "1.1.6",
+                "ssri": "4.1.6"
               },
               "dependencies": {
                 "concat-stream": {
                   "version": "1.6.0",
                   "bundled": true,
                   "requires": {
-                    "inherits": "^2.0.3",
-                    "readable-stream": "^2.2.2",
-                    "typedarray": "^0.0.6"
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.3.2",
+                    "typedarray": "0.0.6"
                   },
                   "dependencies": {
                     "typedarray": {
@@ -13167,18 +13164,18 @@
               "version": "4.1.2",
               "bundled": true,
               "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
+                "are-we-there-yet": "1.1.4",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
               },
               "dependencies": {
                 "are-we-there-yet": {
                   "version": "1.1.4",
                   "bundled": true,
                   "requires": {
-                    "delegates": "^1.0.0",
-                    "readable-stream": "^2.0.6"
+                    "delegates": "1.0.0",
+                    "readable-stream": "2.3.2"
                   },
                   "dependencies": {
                     "delegates": {
@@ -13195,14 +13192,14 @@
                   "version": "2.7.4",
                   "bundled": true,
                   "requires": {
-                    "aproba": "^1.0.3",
-                    "console-control-strings": "^1.0.0",
-                    "has-unicode": "^2.0.0",
-                    "object-assign": "^4.1.0",
-                    "signal-exit": "^3.0.0",
-                    "string-width": "^1.0.1",
-                    "strip-ansi": "^3.0.1",
-                    "wide-align": "^1.1.0"
+                    "aproba": "1.1.2",
+                    "console-control-strings": "1.1.0",
+                    "has-unicode": "2.0.1",
+                    "object-assign": "4.1.1",
+                    "signal-exit": "3.0.2",
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wide-align": "1.1.2"
                   },
                   "dependencies": {
                     "object-assign": {
@@ -13217,9 +13214,9 @@
                       "version": "1.0.2",
                       "bundled": true,
                       "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
                       },
                       "dependencies": {
                         "code-point-at": {
@@ -13230,7 +13227,7 @@
                           "version": "1.0.0",
                           "bundled": true,
                           "requires": {
-                            "number-is-nan": "^1.0.0"
+                            "number-is-nan": "1.0.1"
                           },
                           "dependencies": {
                             "number-is-nan": {
@@ -13245,7 +13242,7 @@
                       "version": "3.0.1",
                       "bundled": true,
                       "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -13258,7 +13255,7 @@
                       "version": "1.1.2",
                       "bundled": true,
                       "requires": {
-                        "string-width": "^1.0.2"
+                        "string-width": "1.0.2"
                       }
                     }
                   }
@@ -13273,7 +13270,7 @@
               "version": "1.4.0",
               "bundled": true,
               "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
               }
             },
             "opener": {
@@ -13284,8 +13281,8 @@
               "version": "0.1.4",
               "bundled": true,
               "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
               },
               "dependencies": {
                 "os-homedir": {
@@ -13302,58 +13299,58 @@
               "version": "2.7.38",
               "bundled": true,
               "requires": {
-                "bluebird": "^3.5.0",
-                "cacache": "^9.2.9",
-                "glob": "^7.1.2",
-                "lru-cache": "^4.1.1",
-                "make-fetch-happen": "^2.4.13",
-                "minimatch": "^3.0.4",
-                "mississippi": "^1.2.0",
-                "normalize-package-data": "^2.4.0",
-                "npm-package-arg": "^5.1.2",
-                "npm-pick-manifest": "^1.0.4",
-                "osenv": "^0.1.4",
-                "promise-inflight": "^1.0.1",
-                "promise-retry": "^1.1.1",
-                "protoduck": "^4.0.0",
-                "safe-buffer": "^5.1.1",
-                "semver": "^5.3.0",
-                "ssri": "^4.1.6",
-                "tar-fs": "^1.15.3",
-                "tar-stream": "^1.5.4",
-                "unique-filename": "^1.1.0",
-                "which": "^1.2.12"
+                "bluebird": "3.5.0",
+                "cacache": "9.2.9",
+                "glob": "7.1.2",
+                "lru-cache": "4.1.1",
+                "make-fetch-happen": "2.4.13",
+                "minimatch": "3.0.4",
+                "mississippi": "1.3.0",
+                "normalize-package-data": "2.4.0",
+                "npm-package-arg": "5.1.2",
+                "npm-pick-manifest": "1.0.4",
+                "osenv": "0.1.4",
+                "promise-inflight": "1.0.1",
+                "promise-retry": "1.1.1",
+                "protoduck": "4.0.0",
+                "safe-buffer": "5.1.1",
+                "semver": "5.3.0",
+                "ssri": "4.1.6",
+                "tar-fs": "1.15.3",
+                "tar-stream": "1.5.4",
+                "unique-filename": "1.1.0",
+                "which": "1.2.14"
               },
               "dependencies": {
                 "make-fetch-happen": {
                   "version": "2.4.13",
                   "bundled": true,
                   "requires": {
-                    "agentkeepalive": "^3.3.0",
-                    "cacache": "^9.2.9",
-                    "http-cache-semantics": "^3.7.3",
-                    "http-proxy-agent": "^2.0.0",
-                    "https-proxy-agent": "^2.0.0",
-                    "lru-cache": "^4.1.1",
-                    "mississippi": "^1.2.0",
-                    "node-fetch-npm": "^2.0.1",
-                    "promise-retry": "^1.1.1",
-                    "socks-proxy-agent": "^3.0.0",
-                    "ssri": "^4.1.6"
+                    "agentkeepalive": "3.3.0",
+                    "cacache": "9.2.9",
+                    "http-cache-semantics": "3.7.3",
+                    "http-proxy-agent": "2.0.0",
+                    "https-proxy-agent": "2.0.0",
+                    "lru-cache": "4.1.1",
+                    "mississippi": "1.3.0",
+                    "node-fetch-npm": "2.0.1",
+                    "promise-retry": "1.1.1",
+                    "socks-proxy-agent": "3.0.0",
+                    "ssri": "4.1.6"
                   },
                   "dependencies": {
                     "agentkeepalive": {
                       "version": "3.3.0",
                       "bundled": true,
                       "requires": {
-                        "humanize-ms": "^1.2.1"
+                        "humanize-ms": "1.2.1"
                       },
                       "dependencies": {
                         "humanize-ms": {
                           "version": "1.2.1",
                           "bundled": true,
                           "requires": {
-                            "ms": "^2.0.0"
+                            "ms": "2.0.0"
                           },
                           "dependencies": {
                             "ms": {
@@ -13372,22 +13369,22 @@
                       "version": "2.0.0",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "4",
-                        "debug": "2"
+                        "agent-base": "4.1.0",
+                        "debug": "2.6.8"
                       },
                       "dependencies": {
                         "agent-base": {
                           "version": "4.1.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "^5.0.0"
+                            "es6-promisify": "5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "^4.0.3"
+                                "es6-promise": "4.1.1"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -13417,22 +13414,22 @@
                       "version": "2.0.0",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "^4.1.0",
-                        "debug": "^2.4.1"
+                        "agent-base": "4.1.0",
+                        "debug": "2.6.8"
                       },
                       "dependencies": {
                         "agent-base": {
                           "version": "4.1.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "^5.0.0"
+                            "es6-promisify": "5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "^4.0.3"
+                                "es6-promise": "4.1.1"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -13462,16 +13459,16 @@
                       "version": "2.0.1",
                       "bundled": true,
                       "requires": {
-                        "encoding": "^0.1.11",
-                        "json-parse-helpfulerror": "^1.0.3",
-                        "safe-buffer": "^5.0.1"
+                        "encoding": "0.1.12",
+                        "json-parse-helpfulerror": "1.0.3",
+                        "safe-buffer": "5.1.1"
                       },
                       "dependencies": {
                         "encoding": {
                           "version": "0.1.12",
                           "bundled": true,
                           "requires": {
-                            "iconv-lite": "~0.4.13"
+                            "iconv-lite": "0.4.18"
                           },
                           "dependencies": {
                             "iconv-lite": {
@@ -13484,7 +13481,7 @@
                           "version": "1.0.3",
                           "bundled": true,
                           "requires": {
-                            "jju": "^1.1.0"
+                            "jju": "1.3.0"
                           },
                           "dependencies": {
                             "jju": {
@@ -13499,22 +13496,22 @@
                       "version": "3.0.0",
                       "bundled": true,
                       "requires": {
-                        "agent-base": "^4.0.1",
-                        "socks": "^1.1.10"
+                        "agent-base": "4.1.0",
+                        "socks": "1.1.10"
                       },
                       "dependencies": {
                         "agent-base": {
                           "version": "4.1.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promisify": "^5.0.0"
+                            "es6-promisify": "5.0.0"
                           },
                           "dependencies": {
                             "es6-promisify": {
                               "version": "5.0.0",
                               "bundled": true,
                               "requires": {
-                                "es6-promise": "^4.0.3"
+                                "es6-promise": "4.1.1"
                               },
                               "dependencies": {
                                 "es6-promise": {
@@ -13529,8 +13526,8 @@
                           "version": "1.1.10",
                           "bundled": true,
                           "requires": {
-                            "ip": "^1.1.4",
-                            "smart-buffer": "^1.0.13"
+                            "ip": "1.1.5",
+                            "smart-buffer": "1.1.15"
                           },
                           "dependencies": {
                             "ip": {
@@ -13551,14 +13548,14 @@
                   "version": "3.0.4",
                   "bundled": true,
                   "requires": {
-                    "brace-expansion": "^1.1.7"
+                    "brace-expansion": "1.1.8"
                   },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
                       "bundled": true,
                       "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -13578,16 +13575,16 @@
                   "version": "1.0.4",
                   "bundled": true,
                   "requires": {
-                    "npm-package-arg": "^5.1.2",
-                    "semver": "^5.3.0"
+                    "npm-package-arg": "5.1.2",
+                    "semver": "5.3.0"
                   }
                 },
                 "promise-retry": {
                   "version": "1.1.1",
                   "bundled": true,
                   "requires": {
-                    "err-code": "^1.0.0",
-                    "retry": "^0.10.0"
+                    "err-code": "1.1.2",
+                    "retry": "0.10.1"
                   },
                   "dependencies": {
                     "err-code": {
@@ -13600,7 +13597,7 @@
                   "version": "4.0.0",
                   "bundled": true,
                   "requires": {
-                    "genfun": "^4.0.1"
+                    "genfun": "4.0.1"
                   },
                   "dependencies": {
                     "genfun": {
@@ -13613,25 +13610,25 @@
                   "version": "1.15.3",
                   "bundled": true,
                   "requires": {
-                    "chownr": "^1.0.1",
-                    "mkdirp": "^0.5.1",
-                    "pump": "^1.0.0",
-                    "tar-stream": "^1.1.2"
+                    "chownr": "1.0.1",
+                    "mkdirp": "0.5.1",
+                    "pump": "1.0.2",
+                    "tar-stream": "1.5.4"
                   },
                   "dependencies": {
                     "pump": {
                       "version": "1.0.2",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
+                        "end-of-stream": "1.4.0",
+                        "once": "1.4.0"
                       },
                       "dependencies": {
                         "end-of-stream": {
                           "version": "1.4.0",
                           "bundled": true,
                           "requires": {
-                            "once": "^1.4.0"
+                            "once": "1.4.0"
                           }
                         }
                       }
@@ -13642,24 +13639,24 @@
                   "version": "1.5.4",
                   "bundled": true,
                   "requires": {
-                    "bl": "^1.0.0",
-                    "end-of-stream": "^1.0.0",
-                    "readable-stream": "^2.0.0",
-                    "xtend": "^4.0.0"
+                    "bl": "1.2.1",
+                    "end-of-stream": "1.4.0",
+                    "readable-stream": "2.3.2",
+                    "xtend": "4.0.1"
                   },
                   "dependencies": {
                     "bl": {
                       "version": "1.2.1",
                       "bundled": true,
                       "requires": {
-                        "readable-stream": "^2.0.5"
+                        "readable-stream": "2.3.2"
                       }
                     },
                     "end-of-stream": {
                       "version": "1.4.0",
                       "bundled": true,
                       "requires": {
-                        "once": "^1.4.0"
+                        "once": "1.4.0"
                       }
                     },
                     "xtend": {
@@ -13682,7 +13679,7 @@
               "version": "1.0.7",
               "bundled": true,
               "requires": {
-                "mute-stream": "~0.0.4"
+                "mute-stream": "0.0.7"
               },
               "dependencies": {
                 "mute-stream": {
@@ -13695,20 +13692,20 @@
               "version": "1.0.1",
               "bundled": true,
               "requires": {
-                "graceful-fs": "^4.1.2"
+                "graceful-fs": "4.1.11"
               }
             },
             "read-installed": {
               "version": "4.0.3",
               "bundled": true,
               "requires": {
-                "debuglog": "^1.0.1",
-                "graceful-fs": "^4.1.2",
-                "read-package-json": "^2.0.0",
-                "readdir-scoped-modules": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "slide": "~1.1.3",
-                "util-extend": "^1.0.1"
+                "debuglog": "1.0.1",
+                "graceful-fs": "4.1.11",
+                "read-package-json": "2.0.9",
+                "readdir-scoped-modules": "1.0.2",
+                "semver": "5.3.0",
+                "slide": "1.1.6",
+                "util-extend": "1.0.3"
               },
               "dependencies": {
                 "util-extend": {
@@ -13721,17 +13718,17 @@
               "version": "2.0.9",
               "bundled": true,
               "requires": {
-                "glob": "^7.1.1",
-                "graceful-fs": "^4.1.2",
-                "json-parse-helpfulerror": "^1.0.2",
-                "normalize-package-data": "^2.0.0"
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "json-parse-helpfulerror": "1.0.3",
+                "normalize-package-data": "2.4.0"
               },
               "dependencies": {
                 "json-parse-helpfulerror": {
                   "version": "1.0.3",
                   "bundled": true,
                   "requires": {
-                    "jju": "^1.1.0"
+                    "jju": "1.3.0"
                   },
                   "dependencies": {
                     "jju": {
@@ -13746,24 +13743,24 @@
               "version": "5.1.6",
               "bundled": true,
               "requires": {
-                "debuglog": "^1.0.1",
-                "dezalgo": "^1.0.0",
-                "once": "^1.3.0",
-                "read-package-json": "^2.0.0",
-                "readdir-scoped-modules": "^1.0.0"
+                "debuglog": "1.0.1",
+                "dezalgo": "1.0.3",
+                "once": "1.4.0",
+                "read-package-json": "2.0.9",
+                "readdir-scoped-modules": "1.0.2"
               }
             },
             "readable-stream": {
               "version": "2.3.2",
               "bundled": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~1.0.6",
-                "safe-buffer": "~5.1.0",
-                "string_decoder": "~1.0.0",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.0.3",
+                "util-deprecate": "1.0.2"
               },
               "dependencies": {
                 "core-util-is": {
@@ -13782,7 +13779,7 @@
                   "version": "1.0.3",
                   "bundled": true,
                   "requires": {
-                    "safe-buffer": "~5.1.0"
+                    "safe-buffer": "5.1.1"
                   }
                 },
                 "util-deprecate": {
@@ -13795,38 +13792,38 @@
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "debuglog": "^1.0.1",
-                "dezalgo": "^1.0.0",
-                "graceful-fs": "^4.1.2",
-                "once": "^1.3.0"
+                "debuglog": "1.0.1",
+                "dezalgo": "1.0.3",
+                "graceful-fs": "4.1.11",
+                "once": "1.4.0"
               }
             },
             "request": {
               "version": "2.81.0",
               "bundled": true,
               "requires": {
-                "aws-sign2": "~0.6.0",
-                "aws4": "^1.2.1",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.0",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.1.1",
-                "har-validator": "~4.2.1",
-                "hawk": "~3.1.3",
-                "http-signature": "~1.1.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.7",
-                "oauth-sign": "~0.8.1",
-                "performance-now": "^0.2.0",
-                "qs": "~6.4.0",
-                "safe-buffer": "^5.0.1",
-                "stringstream": "~0.0.4",
-                "tough-cookie": "~2.3.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.0.0"
+                "aws-sign2": "0.6.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "4.2.1",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.15",
+                "oauth-sign": "0.8.2",
+                "performance-now": "0.2.0",
+                "qs": "6.4.0",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.2",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.1.0"
               },
               "dependencies": {
                 "aws-sign2": {
@@ -13845,7 +13842,7 @@
                   "version": "1.0.5",
                   "bundled": true,
                   "requires": {
-                    "delayed-stream": "~1.0.0"
+                    "delayed-stream": "1.0.0"
                   },
                   "dependencies": {
                     "delayed-stream": {
@@ -13866,9 +13863,9 @@
                   "version": "2.1.4",
                   "bundled": true,
                   "requires": {
-                    "asynckit": "^0.4.0",
-                    "combined-stream": "^1.0.5",
-                    "mime-types": "^2.1.12"
+                    "asynckit": "0.4.0",
+                    "combined-stream": "1.0.5",
+                    "mime-types": "2.1.15"
                   },
                   "dependencies": {
                     "asynckit": {
@@ -13881,16 +13878,16 @@
                   "version": "4.2.1",
                   "bundled": true,
                   "requires": {
-                    "ajv": "^4.9.1",
-                    "har-schema": "^1.0.5"
+                    "ajv": "4.11.8",
+                    "har-schema": "1.0.5"
                   },
                   "dependencies": {
                     "ajv": {
                       "version": "4.11.8",
                       "bundled": true,
                       "requires": {
-                        "co": "^4.6.0",
-                        "json-stable-stringify": "^1.0.1"
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
                       },
                       "dependencies": {
                         "co": {
@@ -13901,7 +13898,7 @@
                           "version": "1.0.1",
                           "bundled": true,
                           "requires": {
-                            "jsonify": "~0.0.0"
+                            "jsonify": "0.0.0"
                           },
                           "dependencies": {
                             "jsonify": {
@@ -13922,24 +13919,24 @@
                   "version": "3.1.3",
                   "bundled": true,
                   "requires": {
-                    "boom": "2.x.x",
-                    "cryptiles": "2.x.x",
-                    "hoek": "2.x.x",
-                    "sntp": "1.x.x"
+                    "boom": "2.10.1",
+                    "cryptiles": "2.0.5",
+                    "hoek": "2.16.3",
+                    "sntp": "1.0.9"
                   },
                   "dependencies": {
                     "boom": {
                       "version": "2.10.1",
                       "bundled": true,
                       "requires": {
-                        "hoek": "2.x.x"
+                        "hoek": "2.16.3"
                       }
                     },
                     "cryptiles": {
                       "version": "2.0.5",
                       "bundled": true,
                       "requires": {
-                        "boom": "2.x.x"
+                        "boom": "2.10.1"
                       }
                     },
                     "hoek": {
@@ -13950,7 +13947,7 @@
                       "version": "1.0.9",
                       "bundled": true,
                       "requires": {
-                        "hoek": "2.x.x"
+                        "hoek": "2.16.3"
                       }
                     }
                   }
@@ -13959,9 +13956,9 @@
                   "version": "1.1.1",
                   "bundled": true,
                   "requires": {
-                    "assert-plus": "^0.2.0",
-                    "jsprim": "^1.2.2",
-                    "sshpk": "^1.7.0"
+                    "assert-plus": "0.2.0",
+                    "jsprim": "1.4.0",
+                    "sshpk": "1.13.1"
                   },
                   "dependencies": {
                     "assert-plus": {
@@ -14003,14 +14000,14 @@
                       "version": "1.13.1",
                       "bundled": true,
                       "requires": {
-                        "asn1": "~0.2.3",
-                        "assert-plus": "^1.0.0",
-                        "bcrypt-pbkdf": "^1.0.0",
-                        "dashdash": "^1.12.0",
-                        "ecc-jsbn": "~0.1.1",
-                        "getpass": "^0.1.1",
-                        "jsbn": "~0.1.0",
-                        "tweetnacl": "~0.14.0"
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
                       },
                       "dependencies": {
                         "asn1": {
@@ -14026,14 +14023,14 @@
                           "bundled": true,
                           "optional": true,
                           "requires": {
-                            "tweetnacl": "^0.14.3"
+                            "tweetnacl": "0.14.5"
                           }
                         },
                         "dashdash": {
                           "version": "1.14.1",
                           "bundled": true,
                           "requires": {
-                            "assert-plus": "^1.0.0"
+                            "assert-plus": "1.0.0"
                           }
                         },
                         "ecc-jsbn": {
@@ -14041,14 +14038,14 @@
                           "bundled": true,
                           "optional": true,
                           "requires": {
-                            "jsbn": "~0.1.0"
+                            "jsbn": "0.1.1"
                           }
                         },
                         "getpass": {
                           "version": "0.1.7",
                           "bundled": true,
                           "requires": {
-                            "assert-plus": "^1.0.0"
+                            "assert-plus": "1.0.0"
                           }
                         },
                         "jsbn": {
@@ -14081,7 +14078,7 @@
                   "version": "2.1.15",
                   "bundled": true,
                   "requires": {
-                    "mime-db": "~1.27.0"
+                    "mime-db": "1.27.0"
                   },
                   "dependencies": {
                     "mime-db": {
@@ -14110,7 +14107,7 @@
                   "version": "2.3.2",
                   "bundled": true,
                   "requires": {
-                    "punycode": "^1.4.1"
+                    "punycode": "1.4.1"
                   },
                   "dependencies": {
                     "punycode": {
@@ -14123,7 +14120,7 @@
                   "version": "0.6.0",
                   "bundled": true,
                   "requires": {
-                    "safe-buffer": "^5.0.1"
+                    "safe-buffer": "5.1.1"
                   }
                 }
               }
@@ -14136,7 +14133,7 @@
               "version": "2.6.1",
               "bundled": true,
               "requires": {
-                "glob": "^7.0.5"
+                "glob": "7.1.2"
               }
             },
             "safe-buffer": {
@@ -14151,8 +14148,8 @@
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "graceful-fs": "^4.1.2",
-                "readable-stream": "^2.0.2"
+                "graceful-fs": "4.1.11",
+                "readable-stream": "2.3.2"
               }
             },
             "slide": {
@@ -14167,26 +14164,26 @@
               "version": "2.1.3",
               "bundled": true,
               "requires": {
-                "from2": "^1.3.0",
-                "stream-iterate": "^1.1.0"
+                "from2": "1.3.0",
+                "stream-iterate": "1.2.0"
               },
               "dependencies": {
                 "from2": {
                   "version": "1.3.0",
                   "bundled": true,
                   "requires": {
-                    "inherits": "~2.0.1",
-                    "readable-stream": "~1.1.10"
+                    "inherits": "2.0.3",
+                    "readable-stream": "1.1.14"
                   },
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.14",
                       "bundled": true,
                       "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -14209,8 +14206,8 @@
                   "version": "1.2.0",
                   "bundled": true,
                   "requires": {
-                    "readable-stream": "^2.1.5",
-                    "stream-shift": "^1.0.0"
+                    "readable-stream": "2.3.2",
+                    "stream-shift": "1.0.0"
                   },
                   "dependencies": {
                     "stream-shift": {
@@ -14225,14 +14222,14 @@
               "version": "4.1.6",
               "bundled": true,
               "requires": {
-                "safe-buffer": "^5.1.0"
+                "safe-buffer": "5.1.1"
               }
             },
             "strip-ansi": {
               "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -14245,16 +14242,16 @@
               "version": "2.2.1",
               "bundled": true,
               "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
               },
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
                   "bundled": true,
                   "requires": {
-                    "inherits": "~2.0.0"
+                    "inherits": "2.0.3"
                   }
                 }
               }
@@ -14275,14 +14272,14 @@
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "unique-slug": "^2.0.0"
+                "unique-slug": "2.0.0"
               },
               "dependencies": {
                 "unique-slug": {
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "imurmurhash": "^0.1.4"
+                    "imurmurhash": "0.1.4"
                   }
                 }
               }
@@ -14295,34 +14292,34 @@
               "version": "2.2.0",
               "bundled": true,
               "requires": {
-                "boxen": "^1.0.0",
-                "chalk": "^1.0.0",
-                "configstore": "^3.0.0",
-                "import-lazy": "^2.1.0",
-                "is-npm": "^1.0.0",
-                "latest-version": "^3.0.0",
-                "semver-diff": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
+                "boxen": "1.1.0",
+                "chalk": "1.1.3",
+                "configstore": "3.1.0",
+                "import-lazy": "2.1.0",
+                "is-npm": "1.0.0",
+                "latest-version": "3.1.0",
+                "semver-diff": "2.1.0",
+                "xdg-basedir": "3.0.0"
               },
               "dependencies": {
                 "boxen": {
                   "version": "1.1.0",
                   "bundled": true,
                   "requires": {
-                    "ansi-align": "^2.0.0",
-                    "camelcase": "^4.0.0",
-                    "chalk": "^1.1.1",
-                    "cli-boxes": "^1.0.0",
-                    "string-width": "^2.0.0",
-                    "term-size": "^0.1.0",
-                    "widest-line": "^1.0.0"
+                    "ansi-align": "2.0.0",
+                    "camelcase": "4.1.0",
+                    "chalk": "1.1.3",
+                    "cli-boxes": "1.0.0",
+                    "string-width": "2.1.0",
+                    "term-size": "0.1.1",
+                    "widest-line": "1.0.0"
                   },
                   "dependencies": {
                     "ansi-align": {
                       "version": "2.0.0",
                       "bundled": true,
                       "requires": {
-                        "string-width": "^2.0.0"
+                        "string-width": "2.1.0"
                       }
                     },
                     "camelcase": {
@@ -14337,8 +14334,8 @@
                       "version": "2.1.0",
                       "bundled": true,
                       "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
                       },
                       "dependencies": {
                         "is-fullwidth-code-point": {
@@ -14349,7 +14346,7 @@
                           "version": "4.0.0",
                           "bundled": true,
                           "requires": {
-                            "ansi-regex": "^3.0.0"
+                            "ansi-regex": "3.0.0"
                           }
                         }
                       }
@@ -14358,27 +14355,27 @@
                       "version": "0.1.1",
                       "bundled": true,
                       "requires": {
-                        "execa": "^0.4.0"
+                        "execa": "0.4.0"
                       },
                       "dependencies": {
                         "execa": {
                           "version": "0.4.0",
                           "bundled": true,
                           "requires": {
-                            "cross-spawn-async": "^2.1.1",
-                            "is-stream": "^1.1.0",
-                            "npm-run-path": "^1.0.0",
-                            "object-assign": "^4.0.1",
-                            "path-key": "^1.0.0",
-                            "strip-eof": "^1.0.0"
+                            "cross-spawn-async": "2.2.5",
+                            "is-stream": "1.1.0",
+                            "npm-run-path": "1.0.0",
+                            "object-assign": "4.1.1",
+                            "path-key": "1.0.0",
+                            "strip-eof": "1.0.0"
                           },
                           "dependencies": {
                             "cross-spawn-async": {
                               "version": "2.2.5",
                               "bundled": true,
                               "requires": {
-                                "lru-cache": "^4.0.0",
-                                "which": "^1.2.8"
+                                "lru-cache": "4.1.1",
+                                "which": "1.2.14"
                               }
                             },
                             "is-stream": {
@@ -14389,7 +14386,7 @@
                               "version": "1.0.0",
                               "bundled": true,
                               "requires": {
-                                "path-key": "^1.0.0"
+                                "path-key": "1.0.0"
                               }
                             },
                             "object-assign": {
@@ -14412,16 +14409,16 @@
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "string-width": "^1.0.1"
+                        "string-width": "1.0.2"
                       },
                       "dependencies": {
                         "string-width": {
                           "version": "1.0.2",
                           "bundled": true,
                           "requires": {
-                            "code-point-at": "^1.0.0",
-                            "is-fullwidth-code-point": "^1.0.0",
-                            "strip-ansi": "^3.0.0"
+                            "code-point-at": "1.1.0",
+                            "is-fullwidth-code-point": "1.0.0",
+                            "strip-ansi": "3.0.1"
                           },
                           "dependencies": {
                             "code-point-at": {
@@ -14432,7 +14429,7 @@
                               "version": "1.0.0",
                               "bundled": true,
                               "requires": {
-                                "number-is-nan": "^1.0.0"
+                                "number-is-nan": "1.0.1"
                               },
                               "dependencies": {
                                 "number-is-nan": {
@@ -14445,7 +14442,7 @@
                               "version": "3.0.1",
                               "bundled": true,
                               "requires": {
-                                "ansi-regex": "^2.0.0"
+                                "ansi-regex": "2.1.1"
                               },
                               "dependencies": {
                                 "ansi-regex": {
@@ -14464,11 +14461,11 @@
                   "version": "1.1.3",
                   "bundled": true,
                   "requires": {
-                    "ansi-styles": "^2.2.1",
-                    "escape-string-regexp": "^1.0.2",
-                    "has-ansi": "^2.0.0",
-                    "strip-ansi": "^3.0.0",
-                    "supports-color": "^2.0.0"
+                    "ansi-styles": "2.2.1",
+                    "escape-string-regexp": "1.0.5",
+                    "has-ansi": "2.0.0",
+                    "strip-ansi": "3.0.1",
+                    "supports-color": "2.0.0"
                   },
                   "dependencies": {
                     "ansi-styles": {
@@ -14483,7 +14480,7 @@
                       "version": "2.0.0",
                       "bundled": true,
                       "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -14496,7 +14493,7 @@
                       "version": "3.0.1",
                       "bundled": true,
                       "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -14515,19 +14512,19 @@
                   "version": "3.1.0",
                   "bundled": true,
                   "requires": {
-                    "dot-prop": "^4.1.0",
-                    "graceful-fs": "^4.1.2",
-                    "make-dir": "^1.0.0",
-                    "unique-string": "^1.0.0",
-                    "write-file-atomic": "^2.0.0",
-                    "xdg-basedir": "^3.0.0"
+                    "dot-prop": "4.1.1",
+                    "graceful-fs": "4.1.11",
+                    "make-dir": "1.0.0",
+                    "unique-string": "1.0.0",
+                    "write-file-atomic": "2.1.0",
+                    "xdg-basedir": "3.0.0"
                   },
                   "dependencies": {
                     "dot-prop": {
                       "version": "4.1.1",
                       "bundled": true,
                       "requires": {
-                        "is-obj": "^1.0.0"
+                        "is-obj": "1.0.1"
                       },
                       "dependencies": {
                         "is-obj": {
@@ -14540,7 +14537,7 @@
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "pify": "^2.3.0"
+                        "pify": "2.3.0"
                       },
                       "dependencies": {
                         "pify": {
@@ -14553,7 +14550,7 @@
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "crypto-random-string": "^1.0.0"
+                        "crypto-random-string": "1.0.0"
                       },
                       "dependencies": {
                         "crypto-random-string": {
@@ -14576,41 +14573,41 @@
                   "version": "3.1.0",
                   "bundled": true,
                   "requires": {
-                    "package-json": "^4.0.0"
+                    "package-json": "4.0.1"
                   },
                   "dependencies": {
                     "package-json": {
                       "version": "4.0.1",
                       "bundled": true,
                       "requires": {
-                        "got": "^6.7.1",
-                        "registry-auth-token": "^3.0.1",
-                        "registry-url": "^3.0.3",
-                        "semver": "^5.1.0"
+                        "got": "6.7.1",
+                        "registry-auth-token": "3.3.1",
+                        "registry-url": "3.1.0",
+                        "semver": "5.3.0"
                       },
                       "dependencies": {
                         "got": {
                           "version": "6.7.1",
                           "bundled": true,
                           "requires": {
-                            "create-error-class": "^3.0.0",
-                            "duplexer3": "^0.1.4",
-                            "get-stream": "^3.0.0",
-                            "is-redirect": "^1.0.0",
-                            "is-retry-allowed": "^1.0.0",
-                            "is-stream": "^1.0.0",
-                            "lowercase-keys": "^1.0.0",
-                            "safe-buffer": "^5.0.1",
-                            "timed-out": "^4.0.0",
-                            "unzip-response": "^2.0.1",
-                            "url-parse-lax": "^1.0.0"
+                            "create-error-class": "3.0.2",
+                            "duplexer3": "0.1.4",
+                            "get-stream": "3.0.0",
+                            "is-redirect": "1.0.0",
+                            "is-retry-allowed": "1.1.0",
+                            "is-stream": "1.1.0",
+                            "lowercase-keys": "1.0.0",
+                            "safe-buffer": "5.1.1",
+                            "timed-out": "4.0.1",
+                            "unzip-response": "2.0.1",
+                            "url-parse-lax": "1.0.0"
                           },
                           "dependencies": {
                             "create-error-class": {
                               "version": "3.0.2",
                               "bundled": true,
                               "requires": {
-                                "capture-stack-trace": "^1.0.0"
+                                "capture-stack-trace": "1.0.0"
                               },
                               "dependencies": {
                                 "capture-stack-trace": {
@@ -14655,7 +14652,7 @@
                               "version": "1.0.0",
                               "bundled": true,
                               "requires": {
-                                "prepend-http": "^1.0.1"
+                                "prepend-http": "1.0.4"
                               },
                               "dependencies": {
                                 "prepend-http": {
@@ -14670,18 +14667,18 @@
                           "version": "3.3.1",
                           "bundled": true,
                           "requires": {
-                            "rc": "^1.1.6",
-                            "safe-buffer": "^5.0.1"
+                            "rc": "1.2.1",
+                            "safe-buffer": "5.1.1"
                           },
                           "dependencies": {
                             "rc": {
                               "version": "1.2.1",
                               "bundled": true,
                               "requires": {
-                                "deep-extend": "~0.4.0",
-                                "ini": "~1.3.0",
-                                "minimist": "^1.2.0",
-                                "strip-json-comments": "~2.0.1"
+                                "deep-extend": "0.4.2",
+                                "ini": "1.3.4",
+                                "minimist": "1.2.0",
+                                "strip-json-comments": "2.0.1"
                               },
                               "dependencies": {
                                 "deep-extend": {
@@ -14704,17 +14701,17 @@
                           "version": "3.1.0",
                           "bundled": true,
                           "requires": {
-                            "rc": "^1.0.1"
+                            "rc": "1.2.1"
                           },
                           "dependencies": {
                             "rc": {
                               "version": "1.2.1",
                               "bundled": true,
                               "requires": {
-                                "deep-extend": "~0.4.0",
-                                "ini": "~1.3.0",
-                                "minimist": "^1.2.0",
-                                "strip-json-comments": "~2.0.1"
+                                "deep-extend": "0.4.2",
+                                "ini": "1.3.4",
+                                "minimist": "1.2.0",
+                                "strip-json-comments": "2.0.1"
                               },
                               "dependencies": {
                                 "deep-extend": {
@@ -14741,7 +14738,7 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "semver": "^5.0.3"
+                    "semver": "5.3.0"
                   }
                 },
                 "xdg-basedir": {
@@ -14758,15 +14755,15 @@
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "spdx-correct": "~1.0.0",
-                "spdx-expression-parse": "~1.0.0"
+                "spdx-correct": "1.0.2",
+                "spdx-expression-parse": "1.0.4"
               },
               "dependencies": {
                 "spdx-correct": {
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "spdx-license-ids": "^1.0.2"
+                    "spdx-license-ids": "1.2.2"
                   },
                   "dependencies": {
                     "spdx-license-ids": {
@@ -14785,7 +14782,7 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "builtins": "^1.0.3"
+                "builtins": "1.0.3"
               },
               "dependencies": {
                 "builtins": {
@@ -14798,7 +14795,7 @@
               "version": "1.2.14",
               "bundled": true,
               "requires": {
-                "isexe": "^2.0.0"
+                "isexe": "2.0.0"
               },
               "dependencies": {
                 "isexe": {
@@ -14811,15 +14808,15 @@
               "version": "1.3.1",
               "bundled": true,
               "requires": {
-                "errno": ">=0.1.1 <0.2.0-0",
-                "xtend": ">=4.0.0 <4.1.0-0"
+                "errno": "0.1.4",
+                "xtend": "4.0.1"
               },
               "dependencies": {
                 "errno": {
                   "version": "0.1.4",
                   "bundled": true,
                   "requires": {
-                    "prr": "~0.0.0"
+                    "prr": "0.0.0"
                   },
                   "dependencies": {
                     "prr": {
@@ -14842,9 +14839,9 @@
               "version": "2.1.0",
               "bundled": true,
               "requires": {
-                "graceful-fs": "^4.1.11",
-                "imurmurhash": "^0.1.4",
-                "slide": "^1.1.5"
+                "graceful-fs": "4.1.11",
+                "imurmurhash": "0.1.4",
+                "slide": "1.1.6"
               }
             }
           }
@@ -14853,17 +14850,17 @@
           "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "^2.6.0",
-            "osenv": "^0.1.5",
-            "semver": "^5.5.0",
-            "validate-npm-package-name": "^3.0.0"
+            "hosted-git-info": "2.6.0",
+            "osenv": "0.1.5",
+            "semver": "5.5.0",
+            "validate-npm-package-name": "3.0.0"
           }
         },
         "npm-run-path": {
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "path-key": "^2.0.0"
+            "path-key": "2.0.1"
           }
         },
         "number-is-nan": {
@@ -14874,7 +14871,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -14885,9 +14882,9 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "os-tmpdir": {
@@ -14898,8 +14895,8 @@
           "version": "0.1.5",
           "bundled": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "p-finally": {
@@ -14910,14 +14907,14 @@
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.2.0"
           }
         },
         "p-try": {
@@ -14928,10 +14925,10 @@
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "got": "^6.7.1",
-            "registry-auth-token": "^3.0.1",
-            "registry-url": "^3.0.3",
-            "semver": "^5.1.0"
+            "got": "6.7.1",
+            "registry-auth-token": "3.3.2",
+            "registry-url": "3.1.0",
+            "semver": "5.5.0"
           }
         },
         "path-exists": {
@@ -14966,25 +14963,25 @@
           "version": "1.2.6",
           "bundled": true,
           "requires": {
-            "deep-extend": "~0.4.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.4.2",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           }
         },
         "registry-auth-token": {
           "version": "3.3.2",
           "bundled": true,
           "requires": {
-            "rc": "^1.1.6",
-            "safe-buffer": "^5.0.1"
+            "rc": "1.2.6",
+            "safe-buffer": "5.1.1"
           }
         },
         "registry-url": {
           "version": "3.1.0",
           "bundled": true,
           "requires": {
-            "rc": "^1.0.1"
+            "rc": "1.2.6"
           }
         },
         "require-directory": {
@@ -14999,7 +14996,7 @@
           "version": "2.6.2",
           "bundled": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -15014,7 +15011,7 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "semver": "^5.0.3"
+            "semver": "5.5.0"
           }
         },
         "set-blocking": {
@@ -15025,7 +15022,7 @@
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "shebang-regex": "^1.0.0"
+            "shebang-regex": "1.0.0"
           }
         },
         "shebang-regex": {
@@ -15040,15 +15037,15 @@
           "version": "2.1.1",
           "bundled": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
           "version": "4.0.0",
           "bundled": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "strip-eof": {
@@ -15063,14 +15060,14 @@
           "version": "5.3.0",
           "bundled": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "term-size": {
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "execa": "^0.7.0"
+            "execa": "0.7.0"
           }
         },
         "timed-out": {
@@ -15081,7 +15078,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "crypto-random-string": "^1.0.0"
+            "crypto-random-string": "1.0.0"
           }
         },
         "unzip-response": {
@@ -15092,37 +15089,37 @@
           "version": "2.4.0",
           "bundled": true,
           "requires": {
-            "boxen": "^1.2.1",
-            "chalk": "^2.0.1",
-            "configstore": "^3.0.0",
-            "import-lazy": "^2.1.0",
-            "is-ci": "^1.0.10",
-            "is-installed-globally": "^0.1.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^3.0.0",
-            "semver-diff": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
+            "boxen": "1.3.0",
+            "chalk": "2.3.2",
+            "configstore": "3.1.2",
+            "import-lazy": "2.1.0",
+            "is-ci": "1.1.0",
+            "is-installed-globally": "0.1.0",
+            "is-npm": "1.0.0",
+            "latest-version": "3.1.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "3.0.0"
           }
         },
         "url-parse-lax": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "prepend-http": "^1.0.1"
+            "prepend-http": "1.0.4"
           }
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "builtins": "^1.0.3"
+            "builtins": "1.0.3"
           }
         },
         "which": {
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "isexe": "2.0.0"
           }
         },
         "which-module": {
@@ -15133,15 +15130,15 @@
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "string-width": "^2.1.1"
+            "string-width": "2.1.1"
           }
         },
         "wrap-ansi": {
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
           },
           "dependencies": {
             "ansi-regex": {
@@ -15152,23 +15149,23 @@
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "number-is-nan": "^1.0.0"
+                "number-is-nan": "1.0.1"
               }
             },
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
               }
             }
           }
@@ -15181,9 +15178,9 @@
           "version": "2.3.0",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "signal-exit": "3.0.2"
           }
         },
         "xdg-basedir": {
@@ -15202,18 +15199,18 @@
           "version": "11.0.0",
           "bundled": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
+            "cliui": "4.0.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
           },
           "dependencies": {
             "y18n": {
@@ -15226,7 +15223,7 @@
           "version": "9.0.2",
           "bundled": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -15236,7 +15233,7 @@
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "requires": {
-        "boolbase": "~1.0.0"
+        "boolbase": "1.0.0"
       }
     },
     "num2fraction": {
@@ -15269,9 +15266,9 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -15279,7 +15276,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -15304,7 +15301,7 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       }
     },
     "object.assign": {
@@ -15312,10 +15309,10 @@
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "object-keys": "1.0.12"
       }
     },
     "object.getownpropertydescriptors": {
@@ -15323,8 +15320,8 @@
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.13.0"
       }
     },
     "object.omit": {
@@ -15332,8 +15329,8 @@
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "object.pick": {
@@ -15341,7 +15338,7 @@
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "object.values": {
@@ -15349,10 +15346,10 @@
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
       "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.13.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.3"
       }
     },
     "obuf": {
@@ -15378,7 +15375,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -15386,7 +15383,7 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "opn": {
@@ -15394,7 +15391,7 @@
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
       "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
       "requires": {
-        "is-wsl": "^1.1.0"
+        "is-wsl": "1.1.0"
       }
     },
     "optimist": {
@@ -15402,8 +15399,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
       },
       "dependencies": {
         "minimist": {
@@ -15423,8 +15420,8 @@
       "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.1.tgz",
       "integrity": "sha512-Rqm6sSjWtx9FchdP0uzTQDc7GXDKnwVEGoSxjezPkzMewx7gEWE9IMUYKmigTRC4U3RaNSwYVnUDLuIdtTpm0A==",
       "requires": {
-        "cssnano": "^4.1.0",
-        "last-call-webpack-plugin": "^3.0.0"
+        "cssnano": "4.1.8",
+        "last-call-webpack-plugin": "3.0.0"
       }
     },
     "optionator": {
@@ -15432,12 +15429,12 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "original": {
@@ -15445,7 +15442,7 @@
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
       "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
       "requires": {
-        "url-parse": "^1.4.3"
+        "url-parse": "1.4.4"
       }
     },
     "os-browserify": {
@@ -15463,9 +15460,9 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
       "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
       "requires": {
-        "execa": "^1.0.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
+        "execa": "1.0.0",
+        "lcid": "2.0.0",
+        "mem": "4.1.0"
       }
     },
     "os-tmpdir": {
@@ -15493,7 +15490,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
       "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
       "requires": {
-        "p-try": "^2.0.0"
+        "p-try": "2.0.0"
       }
     },
     "p-locate": {
@@ -15501,7 +15498,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "requires": {
-        "p-limit": "^2.0.0"
+        "p-limit": "2.1.0"
       }
     },
     "p-map": {
@@ -15524,8 +15521,8 @@
       "resolved": "https://registry.npmjs.org/parallax-js/-/parallax-js-3.1.0.tgz",
       "integrity": "sha512-UONoPKSQykeNvFcemDPxYYDU/T89LSffoaZAwOMhDp0ABhmFPwthgn2GrfB7An9Qo+8nPZIuQeZsh2pWn1qN3A==",
       "requires": {
-        "object-assign": "^4.1.1",
-        "raf": "^3.3.0"
+        "object-assign": "4.1.1",
+        "raf": "3.4.1"
       }
     },
     "parallel-transform": {
@@ -15533,9 +15530,9 @@
       "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
       "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "requires": {
-        "cyclist": "~0.2.2",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.1.5"
+        "cyclist": "0.2.2",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "param-case": {
@@ -15543,7 +15540,7 @@
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "parse-asn1": {
@@ -15551,12 +15548,12 @@
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.3.tgz",
       "integrity": "sha512-VrPoetlz7B/FqjBLD2f5wBVZvsZVLnRUrxVLfRYhGXCODa/NWE4p3Wp+6+aV3ZPL3KM7/OZmxDIwwijD7yuucg==",
       "requires": {
-        "asn1.js": "^4.0.0",
-        "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3",
-        "safe-buffer": "^5.1.1"
+        "asn1.js": "4.10.1",
+        "browserify-aes": "1.2.0",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "pbkdf2": "3.0.17",
+        "safe-buffer": "5.1.2"
       }
     },
     "parse-glob": {
@@ -15564,10 +15561,10 @@
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "parse-headers": {
@@ -15575,7 +15572,7 @@
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
       "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
       "requires": {
-        "for-each": "^0.3.2",
+        "for-each": "0.3.3",
         "trim": "0.0.1"
       }
     },
@@ -15584,8 +15581,8 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
+        "error-ex": "1.3.2",
+        "json-parse-better-errors": "1.0.2"
       }
     },
     "parse-passwd": {
@@ -15663,9 +15660,9 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "graceful-fs": "4.1.15",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "pbkdf2": {
@@ -15673,11 +15670,11 @@
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
       "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
       "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
+        "sha.js": "2.4.11"
       }
     },
     "performance-now": {
@@ -15700,7 +15697,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pkg-dir": {
@@ -15708,7 +15705,7 @@
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "requires": {
-        "find-up": "^2.1.0"
+        "find-up": "2.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -15716,7 +15713,7 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "locate-path": {
@@ -15724,8 +15721,8 @@
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -15733,7 +15730,7 @@
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
@@ -15741,7 +15738,7 @@
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.3.0"
           }
         },
         "p-try": {
@@ -15756,7 +15753,7 @@
       "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
       "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
       "requires": {
-        "find-up": "^2.1.0"
+        "find-up": "2.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -15764,7 +15761,7 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "locate-path": {
@@ -15772,8 +15769,8 @@
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -15781,7 +15778,7 @@
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
@@ -15789,7 +15786,7 @@
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.3.0"
           }
         },
         "p-try": {
@@ -15819,9 +15816,9 @@
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
       "integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
       "requires": {
-        "async": "^1.5.2",
-        "debug": "^2.2.0",
-        "mkdirp": "0.5.x"
+        "async": "1.5.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1"
       },
       "dependencies": {
         "async": {
@@ -15854,9 +15851,9 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
       "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
       "requires": {
-        "chalk": "^2.4.1",
-        "source-map": "^0.6.1",
-        "supports-color": "^5.4.0"
+        "chalk": "2.4.1",
+        "source-map": "0.6.1",
+        "supports-color": "5.5.0"
       },
       "dependencies": {
         "source-map": {
@@ -15871,8 +15868,8 @@
       "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.1.tgz",
       "integrity": "sha512-L2YKB3vF4PetdTIthQVeT+7YiSzMoNMLLYxPXXppOOP7NoazEAy45sh2LvJ8leCQjfBcfkYQs8TtCcQjeZTp8A==",
       "requires": {
-        "postcss": "^7.0.2",
-        "postcss-selector-parser": "^5.0.0"
+        "postcss": "7.0.14",
+        "postcss-selector-parser": "5.0.0"
       },
       "dependencies": {
         "chalk": {
@@ -15880,9 +15877,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -15890,7 +15887,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -15900,9 +15897,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -15915,7 +15912,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -15925,10 +15922,10 @@
       "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.1.tgz",
       "integrity": "sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==",
       "requires": {
-        "css-unit-converter": "^1.1.1",
-        "postcss": "^7.0.5",
-        "postcss-selector-parser": "^5.0.0-rc.4",
-        "postcss-value-parser": "^3.3.1"
+        "css-unit-converter": "1.1.1",
+        "postcss": "7.0.14",
+        "postcss-selector-parser": "5.0.0",
+        "postcss-value-parser": "3.3.1"
       },
       "dependencies": {
         "chalk": {
@@ -15936,9 +15933,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -15946,7 +15943,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -15956,9 +15953,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -15971,7 +15968,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -15981,8 +15978,8 @@
       "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-2.0.1.tgz",
       "integrity": "sha512-ZBARCypjEDofW4P6IdPVTLhDNXPRn8T2s1zHbZidW6rPaaZvcnCS2soYFIQJrMZSxiePJ2XIYTlcb2ztr/eT2g==",
       "requires": {
-        "postcss": "^7.0.2",
-        "postcss-values-parser": "^2.0.0"
+        "postcss": "7.0.14",
+        "postcss-values-parser": "2.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -15990,9 +15987,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16000,7 +15997,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16010,9 +16007,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -16025,7 +16022,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16035,9 +16032,9 @@
       "resolved": "https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-5.0.0.tgz",
       "integrity": "sha512-q6BuRnAGKM/ZRpfDascZlIZPjvwsRye7UDNalqVz3s7GDxMtqPY6+Q871liNxsonUw8oC61OG+PSaysYpl1bnw==",
       "requires": {
-        "@csstools/convert-colors": "^1.4.0",
-        "postcss": "^7.0.5",
-        "postcss-values-parser": "^2.0.0"
+        "@csstools/convert-colors": "1.4.0",
+        "postcss": "7.0.14",
+        "postcss-values-parser": "2.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -16045,9 +16042,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16055,7 +16052,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16065,9 +16062,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -16080,7 +16077,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16090,8 +16087,8 @@
       "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.2.tgz",
       "integrity": "sha512-8bIOzQMGdZVifoBQUJdw+yIY00omBd2EwkJXepQo9cjp1UOHHHoeRDeSzTP6vakEpaRc6GAIOfvcQR7jBYaG5Q==",
       "requires": {
-        "postcss": "^7.0.2",
-        "postcss-values-parser": "^2.0.0"
+        "postcss": "7.0.14",
+        "postcss-values-parser": "2.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -16099,9 +16096,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16109,7 +16106,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16119,9 +16116,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -16134,7 +16131,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16144,9 +16141,9 @@
       "resolved": "https://registry.npmjs.org/postcss-color-mod-function/-/postcss-color-mod-function-3.0.3.tgz",
       "integrity": "sha512-YP4VG+xufxaVtzV6ZmhEtc+/aTXH3d0JLpnYfxqTvwZPbJhWqp8bSY3nfNzNRFLgB4XSaBA82OE4VjOOKpCdVQ==",
       "requires": {
-        "@csstools/convert-colors": "^1.4.0",
-        "postcss": "^7.0.2",
-        "postcss-values-parser": "^2.0.0"
+        "@csstools/convert-colors": "1.4.0",
+        "postcss": "7.0.14",
+        "postcss-values-parser": "2.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -16154,9 +16151,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16164,7 +16161,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16174,9 +16171,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -16189,7 +16186,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16199,8 +16196,8 @@
       "resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-4.0.1.tgz",
       "integrity": "sha512-aAe3OhkS6qJXBbqzvZth2Au4V3KieR5sRQ4ptb2b2O8wgvB3SJBsdG+jsn2BZbbwekDG8nTfcCNKcSfe/lEy8g==",
       "requires": {
-        "postcss": "^7.0.2",
-        "postcss-values-parser": "^2.0.0"
+        "postcss": "7.0.14",
+        "postcss-values-parser": "2.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -16208,9 +16205,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16218,7 +16215,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16228,9 +16225,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -16243,7 +16240,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16253,11 +16250,11 @@
       "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-4.0.2.tgz",
       "integrity": "sha512-1QJc2coIehnVFsz0otges8kQLsryi4lo19WD+U5xCWvXd0uw/Z+KKYnbiNDCnO9GP+PvErPHCG0jNvWTngk9Rw==",
       "requires": {
-        "browserslist": "^4.0.0",
-        "color": "^3.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "browserslist": "4.4.1",
+        "color": "3.1.0",
+        "has": "1.0.3",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.1"
       },
       "dependencies": {
         "chalk": {
@@ -16265,9 +16262,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16275,7 +16272,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16285,9 +16282,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -16300,7 +16297,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16310,8 +16307,8 @@
       "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
       "integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
       "requires": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.1"
       },
       "dependencies": {
         "chalk": {
@@ -16319,9 +16316,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16329,7 +16326,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16339,9 +16336,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -16354,7 +16351,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16364,7 +16361,7 @@
       "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-7.0.7.tgz",
       "integrity": "sha512-bWPCdZKdH60wKOTG4HKEgxWnZVjAIVNOJDvi3lkuTa90xo/K0YHa2ZnlKLC5e2qF8qCcMQXt0yzQITBp8d0OFA==",
       "requires": {
-        "postcss": "^7.0.5"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -16372,9 +16369,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16382,7 +16379,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16392,9 +16389,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -16407,7 +16404,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16417,8 +16414,8 @@
       "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.9.tgz",
       "integrity": "sha512-/Lbn5GP2JkKhgUO2elMs4NnbUJcvHX4AaF5nuJDaNkd2chYW1KA5qtOGGgdkBEWcXtKSQfHXzT7C6grEVyb13w==",
       "requires": {
-        "postcss": "^7.0.5",
-        "postcss-values-parser": "^2.0.0"
+        "postcss": "7.0.14",
+        "postcss-values-parser": "2.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -16426,9 +16423,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16436,7 +16433,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16446,9 +16443,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -16461,7 +16458,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16471,8 +16468,8 @@
       "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-5.1.2.tgz",
       "integrity": "sha512-DSGDhqinCqXqlS4R7KGxL1OSycd1lydugJ1ky4iRXPHdBRiozyMHrdu0H3o7qNOCiZwySZTUI5MV0T8QhCLu+w==",
       "requires": {
-        "postcss": "^7.0.2",
-        "postcss-selector-parser": "^5.0.0-rc.3"
+        "postcss": "7.0.14",
+        "postcss-selector-parser": "5.0.0"
       },
       "dependencies": {
         "chalk": {
@@ -16480,9 +16477,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16490,7 +16487,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16500,9 +16497,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -16515,7 +16512,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16525,8 +16522,8 @@
       "resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-5.0.0.tgz",
       "integrity": "sha512-3pm4oq8HYWMZePJY+5ANriPs3P07q+LW6FAdTlkFH2XqDdP4HeeJYMOzn0HYLhRSjBO3fhiqSwwU9xEULSrPgw==",
       "requires": {
-        "postcss": "^7.0.2",
-        "postcss-selector-parser": "^5.0.0-rc.3"
+        "postcss": "7.0.14",
+        "postcss-selector-parser": "5.0.0"
       },
       "dependencies": {
         "chalk": {
@@ -16534,9 +16531,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16544,7 +16541,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16554,9 +16551,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -16569,7 +16566,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16579,7 +16576,7 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.1.tgz",
       "integrity": "sha512-Ay+rZu1Sz6g8IdzRjUgG2NafSNpp2MSMOQUb+9kkzzzP+kh07fP0yNbhtFejURnyVXSX3FYy2nVNW1QTnNjgBQ==",
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -16587,9 +16584,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16597,7 +16594,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16607,9 +16604,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -16622,7 +16619,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16632,7 +16629,7 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
       "integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -16640,9 +16637,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16650,7 +16647,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16660,9 +16657,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -16675,7 +16672,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16685,7 +16682,7 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
       "integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -16693,9 +16690,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16703,7 +16700,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16713,9 +16710,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -16728,7 +16725,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16738,7 +16735,7 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
       "integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -16746,9 +16743,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16756,7 +16753,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16766,9 +16763,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -16781,7 +16778,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16791,8 +16788,8 @@
       "resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-1.0.0.tgz",
       "integrity": "sha512-G+nV8EnQq25fOI8CH/B6krEohGWnF5+3A6H/+JEpOncu5dCnkS1QQ6+ct3Jkaepw1NGVqqOZH6lqrm244mCftA==",
       "requires": {
-        "postcss": "^7.0.5",
-        "postcss-values-parser": "^2.0.0"
+        "postcss": "7.0.14",
+        "postcss-values-parser": "2.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -16800,9 +16797,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16810,7 +16807,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16820,9 +16817,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -16835,7 +16832,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16845,8 +16842,8 @@
       "resolved": "https://registry.npmjs.org/postcss-env-function/-/postcss-env-function-2.0.2.tgz",
       "integrity": "sha512-rwac4BuZlITeUbiBq60h/xbLzXY43qOsIErngWa4l7Mt+RaSkT7QBjXVGTcBHupykkblHMDrBFh30zchYPaOUw==",
       "requires": {
-        "postcss": "^7.0.2",
-        "postcss-values-parser": "^2.0.0"
+        "postcss": "7.0.14",
+        "postcss-values-parser": "2.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -16854,9 +16851,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16864,7 +16861,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16874,9 +16871,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -16889,7 +16886,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16899,7 +16896,7 @@
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.1.0.tgz",
       "integrity": "sha512-jr1LHxQvStNNAHlgco6PzY308zvLklh7SJVYuWUwyUQncofaAlD2l+P/gxKHOdqWKe7xJSkVLFF/2Tp+JqMSZA==",
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -16907,9 +16904,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16917,7 +16914,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16927,9 +16924,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -16942,7 +16939,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16952,7 +16949,7 @@
       "resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-4.0.0.tgz",
       "integrity": "sha512-Z5CkWBw0+idJHSV6+Bgf2peDOFf/x4o+vX/pwcNYrWpXFrSfTkQ3JQ1ojrq9yS+upnAlNRHeg8uEwFTgorjI8g==",
       "requires": {
-        "postcss": "^7.0.2"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -16960,9 +16957,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16970,7 +16967,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16980,9 +16977,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -16995,7 +16992,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -17005,7 +17002,7 @@
       "resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-3.0.0.tgz",
       "integrity": "sha512-W0APui8jQeBKbCGZudW37EeMCjDeVxKgiYfIIEo8Bdh5SpB9sxds/Iq8SEuzS0Q4YFOlG7EPFulbbxujpkrV2w==",
       "requires": {
-        "postcss": "^7.0.2"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -17013,9 +17010,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -17023,7 +17020,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -17033,9 +17030,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -17048,7 +17045,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -17058,7 +17055,7 @@
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-4.0.0.tgz",
       "integrity": "sha512-M8BFYKOvCrI2aITzDad7kWuXXTm0YhGdP9Q8HanmN4EF1Hmcgs1KK5rSHylt/lUJe8yLxiSwWAHdScoEiIxztg==",
       "requires": {
-        "postcss": "^7.0.2"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -17066,9 +17063,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -17076,7 +17073,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -17086,9 +17083,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -17101,7 +17098,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -17111,7 +17108,7 @@
       "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-2.0.0.tgz",
       "integrity": "sha512-QZSqDaMgXCHuHTEzMsS2KfVDOq7ZFiknSpkrPJY6jmxbugUPTuSzs/vuE5I3zv0WAS+3vhrlqhijiprnuQfzmg==",
       "requires": {
-        "postcss": "^7.0.2"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -17119,9 +17116,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -17129,7 +17126,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -17139,9 +17136,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -17154,7 +17151,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -17164,8 +17161,8 @@
       "resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-3.0.1.tgz",
       "integrity": "sha512-oPTcFFip5LZy8Y/whto91L9xdRHCWEMs3e1MdJxhgt4jy2WYXfhkng59fH5qLXSCPN8k4n94p1Czrfe5IOkKUw==",
       "requires": {
-        "postcss": "^7.0.2",
-        "postcss-values-parser": "^2.0.0"
+        "postcss": "7.0.14",
+        "postcss-values-parser": "2.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -17173,9 +17170,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -17183,7 +17180,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -17193,9 +17190,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -17208,7 +17205,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -17218,8 +17215,8 @@
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-3.0.0.tgz",
       "integrity": "sha512-WzrqZ5nG9R9fUtrA+we92R4jhVvEB32IIRTzfIG/PLL8UV4CvbF1ugTEHEFX6vWxl41Xt5RTCJPEZkuWzrOM+Q==",
       "requires": {
-        "lodash.template": "^4.2.4",
-        "postcss": "^7.0.2"
+        "lodash.template": "4.4.0",
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -17227,9 +17224,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -17237,7 +17234,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -17247,9 +17244,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -17262,7 +17259,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -17272,9 +17269,9 @@
       "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-2.0.1.tgz",
       "integrity": "sha512-whLy1IeZKY+3fYdqQFuDBf8Auw+qFuVnChWjmxm/UhHWqNHZx+B99EwxTvGYmUBqe3Fjxs4L1BoZTJmPu6usVg==",
       "requires": {
-        "@csstools/convert-colors": "^1.4.0",
-        "postcss": "^7.0.2",
-        "postcss-values-parser": "^2.0.0"
+        "@csstools/convert-colors": "1.4.0",
+        "postcss": "7.0.14",
+        "postcss-values-parser": "2.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -17282,9 +17279,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -17292,7 +17289,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -17302,9 +17299,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -17317,7 +17314,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -17327,8 +17324,8 @@
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.0.0.tgz",
       "integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
       "requires": {
-        "cosmiconfig": "^4.0.0",
-        "import-cwd": "^2.0.0"
+        "cosmiconfig": "4.0.0",
+        "import-cwd": "2.1.0"
       },
       "dependencies": {
         "cosmiconfig": {
@@ -17336,10 +17333,10 @@
           "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
           "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
           "requires": {
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.9.0",
-            "parse-json": "^4.0.0",
-            "require-from-string": "^2.0.1"
+            "is-directory": "0.3.1",
+            "js-yaml": "3.12.1",
+            "parse-json": "4.0.0",
+            "require-from-string": "2.0.2"
           }
         },
         "require-from-string": {
@@ -17354,10 +17351,10 @@
       "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-3.0.0.tgz",
       "integrity": "sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==",
       "requires": {
-        "loader-utils": "^1.1.0",
-        "postcss": "^7.0.0",
-        "postcss-load-config": "^2.0.0",
-        "schema-utils": "^1.0.0"
+        "loader-utils": "1.2.3",
+        "postcss": "7.0.14",
+        "postcss-load-config": "2.0.0",
+        "schema-utils": "1.0.0"
       },
       "dependencies": {
         "chalk": {
@@ -17365,9 +17362,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -17375,7 +17372,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -17385,9 +17382,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -17400,7 +17397,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -17410,7 +17407,7 @@
       "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-3.0.0.tgz",
       "integrity": "sha512-1SUKdJc2vuMOmeItqGuNaC+N8MzBWFWEkAnRnLpFYj1tGGa7NqyVBujfRtgNa2gXR+6RkGUiB2O5Vmh7E2RmiA==",
       "requires": {
-        "postcss": "^7.0.2"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -17418,9 +17415,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -17428,7 +17425,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -17438,9 +17435,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -17453,7 +17450,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -17463,7 +17460,7 @@
       "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-4.0.0.tgz",
       "integrity": "sha512-fo9moya6qyxsjbFAYl97qKO9gyre3qvbMnkOZeZwlsW6XYFsvs2DMGDlchVLfAd8LHPZDxivu/+qW2SMQeTHBw==",
       "requires": {
-        "postcss": "^7.0.2"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -17471,9 +17468,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -17481,7 +17478,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -17491,9 +17488,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -17506,7 +17503,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -17517,9 +17514,9 @@
       "integrity": "sha512-hME10s6CSjm9nlVIcO1ukR7Jr5RisTaaC1y83jWCivpuBtPohA3pZE7cGTIVSYjXvLnXozHTiVOkG4dnnl756g==",
       "requires": {
         "css-color-names": "0.0.4",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "stylehacks": "^4.0.0"
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.1",
+        "stylehacks": "4.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -17527,9 +17524,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -17537,7 +17534,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -17547,9 +17544,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -17562,7 +17559,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -17572,12 +17569,12 @@
       "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-4.0.2.tgz",
       "integrity": "sha512-UiuXwCCJtQy9tAIxsnurfF0mrNHKc4NnNx6NxqmzNNjXpQwLSukUxELHTRF0Rg1pAmcoKLih8PwvZbiordchag==",
       "requires": {
-        "browserslist": "^4.0.0",
-        "caniuse-api": "^3.0.0",
-        "cssnano-util-same-parent": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0",
-        "vendors": "^1.0.0"
+        "browserslist": "4.4.1",
+        "caniuse-api": "3.0.0",
+        "cssnano-util-same-parent": "4.0.1",
+        "postcss": "7.0.14",
+        "postcss-selector-parser": "3.1.1",
+        "vendors": "1.0.2"
       },
       "dependencies": {
         "chalk": {
@@ -17585,9 +17582,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -17595,7 +17592,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -17605,9 +17602,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "postcss-selector-parser": {
@@ -17615,9 +17612,9 @@
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "requires": {
-            "dot-prop": "^4.1.1",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
+            "dot-prop": "4.2.0",
+            "indexes-of": "1.0.1",
+            "uniq": "1.0.1"
           }
         },
         "source-map": {
@@ -17630,7 +17627,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -17640,8 +17637,8 @@
       "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
       "integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
       "requires": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.1"
       },
       "dependencies": {
         "chalk": {
@@ -17649,9 +17646,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -17659,7 +17656,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -17669,9 +17666,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -17684,7 +17681,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -17694,10 +17691,10 @@
       "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-4.0.1.tgz",
       "integrity": "sha512-pySEW3E6Ly5mHm18rekbWiAjVi/Wj8KKt2vwSfVFAWdW6wOIekgqxKxLU7vJfb107o3FDNPkaYFCxGAJBFyogA==",
       "requires": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "is-color-stop": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-arguments": "4.0.0",
+        "is-color-stop": "1.1.0",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.1"
       },
       "dependencies": {
         "chalk": {
@@ -17705,9 +17702,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -17715,7 +17712,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -17725,9 +17722,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -17740,7 +17737,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -17750,12 +17747,12 @@
       "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-4.0.1.tgz",
       "integrity": "sha512-h4W0FEMEzBLxpxIVelRtMheskOKKp52ND6rJv+nBS33G1twu2tCyurYj/YtgU76+UDCvWeNs0hs8HFAWE2OUFg==",
       "requires": {
-        "alphanum-sort": "^1.0.0",
-        "browserslist": "^4.0.0",
-        "cssnano-util-get-arguments": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "uniqs": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "browserslist": "4.4.1",
+        "cssnano-util-get-arguments": "4.0.0",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.1",
+        "uniqs": "2.0.0"
       },
       "dependencies": {
         "chalk": {
@@ -17763,9 +17760,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -17773,7 +17770,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -17783,9 +17780,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -17798,7 +17795,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -17808,10 +17805,10 @@
       "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-4.0.1.tgz",
       "integrity": "sha512-8+plQkomve3G+CodLCgbhAKrb5lekAnLYuL1d7Nz+/7RANpBEVdgBkPNwljfSKvZ9xkkZTZITd04KP+zeJTJqg==",
       "requires": {
-        "alphanum-sort": "^1.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0"
+        "alphanum-sort": "1.0.2",
+        "has": "1.0.3",
+        "postcss": "7.0.14",
+        "postcss-selector-parser": "3.1.1"
       },
       "dependencies": {
         "chalk": {
@@ -17819,9 +17816,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -17829,7 +17826,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -17839,9 +17836,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "postcss-selector-parser": {
@@ -17849,9 +17846,9 @@
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "requires": {
-            "dot-prop": "^4.1.1",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
+            "dot-prop": "4.2.0",
+            "indexes-of": "1.0.1",
+            "uniq": "1.0.1"
           }
         },
         "source-map": {
@@ -17864,7 +17861,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -17874,7 +17871,7 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
       "integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "6.0.23"
       }
     },
     "postcss-modules-local-by-default": {
@@ -17882,8 +17879,8 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "requires": {
-        "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.1"
+        "css-selector-tokenizer": "0.7.1",
+        "postcss": "6.0.23"
       }
     },
     "postcss-modules-scope": {
@@ -17891,8 +17888,8 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "requires": {
-        "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.1"
+        "css-selector-tokenizer": "0.7.1",
+        "postcss": "6.0.23"
       }
     },
     "postcss-modules-values": {
@@ -17900,8 +17897,8 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "requires": {
-        "icss-replace-symbols": "^1.1.0",
-        "postcss": "^6.0.1"
+        "icss-replace-symbols": "1.1.0",
+        "postcss": "6.0.23"
       }
     },
     "postcss-nesting": {
@@ -17909,7 +17906,7 @@
       "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-7.0.0.tgz",
       "integrity": "sha512-WSsbVd5Ampi3Y0nk/SKr5+K34n52PqMqEfswu6RtU4r7wA8vSD+gM8/D9qq4aJkHImwn1+9iEFTbjoWsQeqtaQ==",
       "requires": {
-        "postcss": "^7.0.2"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -17917,9 +17914,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -17927,7 +17924,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -17937,9 +17934,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -17952,7 +17949,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -17962,7 +17959,7 @@
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
       "integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -17970,9 +17967,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -17980,7 +17977,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -17990,9 +17987,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -18005,7 +18002,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -18015,9 +18012,9 @@
       "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.1.tgz",
       "integrity": "sha512-R5mC4vaDdvsrku96yXP7zak+O3Mm9Y8IslUobk7IMP+u/g+lXvcN4jngmHY5zeJnrQvE13dfAg5ViU05ZFDwdg==",
       "requires": {
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-match": "4.0.0",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.1"
       },
       "dependencies": {
         "chalk": {
@@ -18025,9 +18022,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -18035,7 +18032,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -18045,9 +18042,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -18060,7 +18057,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -18070,10 +18067,10 @@
       "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-4.0.1.tgz",
       "integrity": "sha512-GNoOaLRBM0gvH+ZRb2vKCIujzz4aclli64MBwDuYGU2EY53LwiP7MxOZGE46UGtotrSnmarPPZ69l2S/uxdaWA==",
       "requires": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-arguments": "4.0.0",
+        "has": "1.0.3",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.1"
       },
       "dependencies": {
         "chalk": {
@@ -18081,9 +18078,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -18091,7 +18088,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -18101,9 +18098,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -18116,7 +18113,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -18126,10 +18123,10 @@
       "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.1.tgz",
       "integrity": "sha512-fFHPGIjBUyUiswY2rd9rsFcC0t3oRta4wxE1h3lpwfQZwFeFjXFSiDtdJ7APCmHQOnUZnqYBADNRPKPwFAONgA==",
       "requires": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-arguments": "4.0.0",
+        "cssnano-util-get-match": "4.0.0",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.1"
       },
       "dependencies": {
         "chalk": {
@@ -18137,9 +18134,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -18147,7 +18144,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -18157,9 +18154,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -18172,7 +18169,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -18182,9 +18179,9 @@
       "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-4.0.1.tgz",
       "integrity": "sha512-IJoexFTkAvAq5UZVxWXAGE0yLoNN/012v7TQh5nDo6imZJl2Fwgbhy3J2qnIoaDBrtUP0H7JrXlX1jjn2YcvCQ==",
       "requires": {
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "has": "1.0.3",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.1"
       },
       "dependencies": {
         "chalk": {
@@ -18192,9 +18189,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -18202,7 +18199,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -18212,9 +18209,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -18227,7 +18224,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -18237,9 +18234,9 @@
       "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.1.tgz",
       "integrity": "sha512-1nOtk7ze36+63ONWD8RCaRDYsnzorrj+Q6fxkQV+mlY5+471Qx9kspqv0O/qQNMeApg8KNrRf496zHwJ3tBZ7w==",
       "requires": {
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-match": "4.0.0",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.1"
       },
       "dependencies": {
         "chalk": {
@@ -18247,9 +18244,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -18257,7 +18254,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -18267,9 +18264,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -18282,7 +18279,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -18292,9 +18289,9 @@
       "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
       "integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
       "requires": {
-        "browserslist": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "browserslist": "4.4.1",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.1"
       },
       "dependencies": {
         "chalk": {
@@ -18302,9 +18299,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -18312,7 +18309,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -18322,9 +18319,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -18337,7 +18334,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -18347,10 +18344,10 @@
       "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
       "integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
       "requires": {
-        "is-absolute-url": "^2.0.0",
-        "normalize-url": "^3.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "is-absolute-url": "2.1.0",
+        "normalize-url": "3.3.0",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.1"
       },
       "dependencies": {
         "chalk": {
@@ -18358,9 +18355,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -18368,7 +18365,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -18378,9 +18375,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -18393,7 +18390,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -18403,8 +18400,8 @@
       "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.1.tgz",
       "integrity": "sha512-U8MBODMB2L+nStzOk6VvWWjZgi5kQNShCyjRhMT3s+W9Jw93yIjOnrEkKYD3Ul7ChWbEcjDWmXq0qOL9MIAnAw==",
       "requires": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.1"
       },
       "dependencies": {
         "chalk": {
@@ -18412,9 +18409,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -18422,7 +18419,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -18432,9 +18429,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -18447,7 +18444,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -18457,9 +18454,9 @@
       "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-4.1.1.tgz",
       "integrity": "sha512-PeJiLgJWPzkVF8JuKSBcylaU+hDJ/TX3zqAMIjlghgn1JBi6QwQaDZoDIlqWRcCAI8SxKrt3FCPSRmOgKRB97Q==",
       "requires": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-arguments": "4.0.0",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.1"
       },
       "dependencies": {
         "chalk": {
@@ -18467,9 +18464,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -18477,7 +18474,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -18487,9 +18484,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -18502,7 +18499,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -18512,7 +18509,7 @@
       "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-2.0.0.tgz",
       "integrity": "sha512-aK0fHc9CBNx8jbzMYhshZcEv8LtYnBIRYQD5i7w/K/wS9c2+0NSR6B3OVMu5y0hBHYLcMGjfU+dmWYNKH0I85g==",
       "requires": {
-        "postcss": "^7.0.2"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -18520,9 +18517,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -18530,7 +18527,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -18540,9 +18537,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -18555,7 +18552,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -18565,7 +18562,7 @@
       "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-2.0.0.tgz",
       "integrity": "sha512-tkpTSrLpfLfD9HvgOlJuigLuk39wVTbbd8RKcy8/ugV2bNBUW3xU+AIqyxhDrQr1VUj1RmyJrBn1YWrqUm9zAQ==",
       "requires": {
-        "postcss": "^7.0.2"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -18573,9 +18570,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -18583,7 +18580,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -18593,9 +18590,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -18608,7 +18605,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -18618,8 +18615,8 @@
       "resolved": "https://registry.npmjs.org/postcss-place/-/postcss-place-4.0.1.tgz",
       "integrity": "sha512-Zb6byCSLkgRKLODj/5mQugyuj9bvAAw9LqJJjgwz5cYryGeXfFZfSXoP1UfveccFmeq0b/2xxwcTEVScnqGxBg==",
       "requires": {
-        "postcss": "^7.0.2",
-        "postcss-values-parser": "^2.0.0"
+        "postcss": "7.0.14",
+        "postcss-values-parser": "2.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -18627,9 +18624,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -18637,7 +18634,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -18647,9 +18644,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -18662,7 +18659,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -18672,40 +18669,40 @@
       "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-6.3.1.tgz",
       "integrity": "sha512-erl+OcCTr1+jsfJNQjBweyb8Y1s6KngUBwoqJnRXO197PmEE6u9HxZfnpKkTQqasxZljxNHzXR5hMb7MdD0Zdw==",
       "requires": {
-        "autoprefixer": "^9.3.1",
-        "browserslist": "^4.3.4",
-        "caniuse-lite": "^1.0.30000905",
-        "cssdb": "^4.1.0",
-        "postcss": "^7.0.5",
-        "postcss-attribute-case-insensitive": "^4.0.0",
-        "postcss-color-functional-notation": "^2.0.1",
-        "postcss-color-gray": "^5.0.0",
-        "postcss-color-hex-alpha": "^5.0.2",
-        "postcss-color-mod-function": "^3.0.3",
-        "postcss-color-rebeccapurple": "^4.0.1",
-        "postcss-custom-media": "^7.0.7",
-        "postcss-custom-properties": "^8.0.9",
-        "postcss-custom-selectors": "^5.1.2",
-        "postcss-dir-pseudo-class": "^5.0.0",
-        "postcss-double-position-gradients": "^1.0.0",
-        "postcss-env-function": "^2.0.2",
-        "postcss-focus-visible": "^4.0.0",
-        "postcss-focus-within": "^3.0.0",
-        "postcss-font-variant": "^4.0.0",
-        "postcss-gap-properties": "^2.0.0",
-        "postcss-image-set-function": "^3.0.1",
-        "postcss-initial": "^3.0.0",
-        "postcss-lab-function": "^2.0.1",
-        "postcss-logical": "^3.0.0",
-        "postcss-media-minmax": "^4.0.0",
-        "postcss-nesting": "^7.0.0",
-        "postcss-overflow-shorthand": "^2.0.0",
-        "postcss-page-break": "^2.0.0",
-        "postcss-place": "^4.0.1",
-        "postcss-pseudo-class-any-link": "^6.0.0",
-        "postcss-replace-overflow-wrap": "^3.0.0",
-        "postcss-selector-matches": "^4.0.0",
-        "postcss-selector-not": "^4.0.0"
+        "autoprefixer": "9.4.7",
+        "browserslist": "4.4.1",
+        "caniuse-lite": "1.0.30000934",
+        "cssdb": "4.3.0",
+        "postcss": "7.0.14",
+        "postcss-attribute-case-insensitive": "4.0.1",
+        "postcss-color-functional-notation": "2.0.1",
+        "postcss-color-gray": "5.0.0",
+        "postcss-color-hex-alpha": "5.0.2",
+        "postcss-color-mod-function": "3.0.3",
+        "postcss-color-rebeccapurple": "4.0.1",
+        "postcss-custom-media": "7.0.7",
+        "postcss-custom-properties": "8.0.9",
+        "postcss-custom-selectors": "5.1.2",
+        "postcss-dir-pseudo-class": "5.0.0",
+        "postcss-double-position-gradients": "1.0.0",
+        "postcss-env-function": "2.0.2",
+        "postcss-focus-visible": "4.0.0",
+        "postcss-focus-within": "3.0.0",
+        "postcss-font-variant": "4.0.0",
+        "postcss-gap-properties": "2.0.0",
+        "postcss-image-set-function": "3.0.1",
+        "postcss-initial": "3.0.0",
+        "postcss-lab-function": "2.0.1",
+        "postcss-logical": "3.0.0",
+        "postcss-media-minmax": "4.0.0",
+        "postcss-nesting": "7.0.0",
+        "postcss-overflow-shorthand": "2.0.0",
+        "postcss-page-break": "2.0.0",
+        "postcss-place": "4.0.1",
+        "postcss-pseudo-class-any-link": "6.0.0",
+        "postcss-replace-overflow-wrap": "3.0.0",
+        "postcss-selector-matches": "4.0.0",
+        "postcss-selector-not": "4.0.0"
       },
       "dependencies": {
         "chalk": {
@@ -18713,9 +18710,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -18723,7 +18720,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -18733,9 +18730,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -18748,7 +18745,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -18758,8 +18755,8 @@
       "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-6.0.0.tgz",
       "integrity": "sha512-lgXW9sYJdLqtmw23otOzrtbDXofUdfYzNm4PIpNE322/swES3VU9XlXHeJS46zT2onFO7V1QFdD4Q9LiZj8mew==",
       "requires": {
-        "postcss": "^7.0.2",
-        "postcss-selector-parser": "^5.0.0-rc.3"
+        "postcss": "7.0.14",
+        "postcss-selector-parser": "5.0.0"
       },
       "dependencies": {
         "chalk": {
@@ -18767,9 +18764,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -18777,7 +18774,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -18787,9 +18784,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -18802,7 +18799,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -18812,10 +18809,10 @@
       "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.2.tgz",
       "integrity": "sha512-epUiC39NonKUKG+P3eAOKKZtm5OtAtQJL7Ye0CBN1f+UQTHzqotudp+hki7zxXm7tT0ZAKDMBj1uihpPjP25ug==",
       "requires": {
-        "browserslist": "^4.0.0",
-        "caniuse-api": "^3.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0"
+        "browserslist": "4.4.1",
+        "caniuse-api": "3.0.0",
+        "has": "1.0.3",
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -18823,9 +18820,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -18833,7 +18830,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -18843,9 +18840,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -18858,7 +18855,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -18868,10 +18865,10 @@
       "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.1.tgz",
       "integrity": "sha512-sZVr3QlGs0pjh6JAIe6DzWvBaqYw05V1t3d9Tp+VnFRT5j+rsqoWsysh/iSD7YNsULjq9IAylCznIwVd5oU/zA==",
       "requires": {
-        "cssnano-util-get-match": "^4.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-match": "4.0.0",
+        "has": "1.0.3",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.1"
       },
       "dependencies": {
         "chalk": {
@@ -18879,9 +18876,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -18889,7 +18886,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -18899,9 +18896,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -18914,7 +18911,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -18924,7 +18921,7 @@
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-3.0.0.tgz",
       "integrity": "sha512-2T5hcEHArDT6X9+9dVSPQdo7QHzG4XKclFT8rU5TzJPDN7RIRTbO9c4drUISOVemLj03aezStHCR2AIcr8XLpw==",
       "requires": {
-        "postcss": "^7.0.2"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -18932,9 +18929,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -18942,7 +18939,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -18952,9 +18949,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -18967,7 +18964,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -18977,7 +18974,7 @@
       "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.1.tgz",
       "integrity": "sha512-xZsFA3uX8MO3yAda03QrG3/Eg1LN3EPfjjf07vke/46HERLZyHrTsQ9E1r1w1W//fWEhtYNndo2hQplN2cVpCQ==",
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -18985,9 +18982,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -18995,7 +18992,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -19005,9 +19002,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -19020,7 +19017,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -19030,8 +19027,8 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-4.0.0.tgz",
       "integrity": "sha512-LgsHwQR/EsRYSqlwdGzeaPKVT0Ml7LAT6E75T8W8xLJY62CE4S/l03BWIt3jT8Taq22kXP08s2SfTSzaraoPww==",
       "requires": {
-        "balanced-match": "^1.0.0",
-        "postcss": "^7.0.2"
+        "balanced-match": "1.0.0",
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -19039,9 +19036,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -19049,7 +19046,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -19059,9 +19056,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -19074,7 +19071,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -19084,8 +19081,8 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-4.0.0.tgz",
       "integrity": "sha512-W+bkBZRhqJaYN8XAnbbZPLWMvZD1wKTu0UxtFKdhtGjWYmxhkUneoeOhRJKdAE5V7ZTlnbHfCR+6bNwK9e1dTQ==",
       "requires": {
-        "balanced-match": "^1.0.0",
-        "postcss": "^7.0.2"
+        "balanced-match": "1.0.0",
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -19093,9 +19090,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -19103,7 +19100,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -19113,9 +19110,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -19128,7 +19125,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -19138,9 +19135,9 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
       "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
       "requires": {
-        "cssesc": "^2.0.0",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
+        "cssesc": "2.0.0",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
       },
       "dependencies": {
         "cssesc": {
@@ -19155,10 +19152,10 @@
       "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.1.tgz",
       "integrity": "sha512-YD5uIk5NDRySy0hcI+ZJHwqemv2WiqqzDgtvgMzO8EGSkK5aONyX8HMVFRFJSdO8wUWTuisUFn/d7yRRbBr5Qw==",
       "requires": {
-        "is-svg": "^3.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "svgo": "^1.0.0"
+        "is-svg": "3.0.0",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.1",
+        "svgo": "1.1.1"
       },
       "dependencies": {
         "chalk": {
@@ -19166,9 +19163,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -19176,7 +19173,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -19186,9 +19183,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -19201,7 +19198,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -19211,9 +19208,9 @@
       "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
       "integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
       "requires": {
-        "alphanum-sort": "^1.0.0",
-        "postcss": "^7.0.0",
-        "uniqs": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "postcss": "7.0.14",
+        "uniqs": "2.0.0"
       },
       "dependencies": {
         "chalk": {
@@ -19221,9 +19218,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -19231,7 +19228,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -19241,9 +19238,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "source-map": {
@@ -19256,7 +19253,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -19271,9 +19268,9 @@
       "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
       "integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
       "requires": {
-        "flatten": "^1.0.2",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
+        "flatten": "1.0.2",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
       }
     },
     "precond": {
@@ -19306,8 +19303,8 @@
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
       "requires": {
-        "renderkid": "^2.0.1",
-        "utila": "~0.4"
+        "renderkid": "2.0.2",
+        "utila": "0.4.0"
       }
     },
     "pretty-format": {
@@ -19315,8 +19312,8 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
       "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
       "requires": {
-        "ansi-regex": "^3.0.0",
-        "ansi-styles": "^3.2.0"
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.1"
       }
     },
     "private": {
@@ -19344,7 +19341,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.2.tgz",
       "integrity": "sha512-EIyzM39FpVOMbqgzEHhxdrEhtOSDOtjMZQ0M6iVfCE+kWNgCkAyOdnuCWqfmflylftfadU6FkiMgHZA2kUzwRw==",
       "requires": {
-        "asap": "~2.0.6"
+        "asap": "2.0.6"
       }
     },
     "promise-inflight": {
@@ -19357,8 +19354,8 @@
       "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
       "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
       "requires": {
-        "is-fn": "^1.0.0",
-        "set-immediate-shim": "^1.0.1"
+        "is-fn": "1.0.0",
+        "set-immediate-shim": "1.0.1"
       }
     },
     "prompts": {
@@ -19366,8 +19363,8 @@
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.14.tgz",
       "integrity": "sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==",
       "requires": {
-        "kleur": "^2.0.1",
-        "sisteransi": "^0.1.1"
+        "kleur": "2.0.2",
+        "sisteransi": "0.1.1"
       }
     },
     "prop-types": {
@@ -19375,8 +19372,8 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
       "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
       "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1"
       }
     },
     "proxy-addr": {
@@ -19384,7 +19381,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
       "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "requires": {
-        "forwarded": "~0.1.2",
+        "forwarded": "0.1.2",
         "ipaddr.js": "1.8.0"
       }
     },
@@ -19408,12 +19405,12 @@
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
       "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "requires": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1",
-        "safe-buffer": "^5.1.2"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "parse-asn1": "5.1.3",
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.2"
       }
     },
     "pump": {
@@ -19421,8 +19418,8 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
       }
     },
     "pumpify": {
@@ -19430,9 +19427,9 @@
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "requires": {
-        "duplexify": "^3.6.0",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
+        "duplexify": "3.7.1",
+        "inherits": "2.0.3",
+        "pump": "2.0.1"
       },
       "dependencies": {
         "pump": {
@@ -19440,8 +19437,8 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         }
       }
@@ -19481,7 +19478,7 @@
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
       "requires": {
-        "performance-now": "^2.1.0"
+        "performance-now": "2.1.0"
       }
     },
     "randomatic": {
@@ -19489,9 +19486,9 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
       "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
       "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.4"
       },
       "dependencies": {
         "is-number": {
@@ -19511,7 +19508,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "requires": {
-        "safe-buffer": "^5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "randomfill": {
@@ -19519,8 +19516,8 @@
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "requires": {
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.0"
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.2"
       }
     },
     "range-parser": {
@@ -19544,7 +19541,7 @@
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         }
       }
@@ -19554,8 +19551,8 @@
       "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-1.0.0.tgz",
       "integrity": "sha512-Uqy5AqELpytJTRxYT4fhltcKPj0TyaEpzJDcGz7DFJi+pQOOi3GjR/DOdxTkTsF+NzhnldIoG6TORaBlInUuqA==",
       "requires": {
-        "loader-utils": "^1.1.0",
-        "schema-utils": "^1.0.0"
+        "loader-utils": "1.2.3",
+        "schema-utils": "1.0.0"
       }
     },
     "react": {
@@ -19563,10 +19560,10 @@
       "resolved": "https://registry.npmjs.org/react/-/react-16.7.0.tgz",
       "integrity": "sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.12.0"
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.2",
+        "scheduler": "0.12.0"
       }
     },
     "react-app-polyfill": {
@@ -19591,7 +19588,7 @@
           "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
           "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
           "requires": {
-            "performance-now": "^2.1.0"
+            "performance-now": "2.1.0"
           }
         },
         "whatwg-fetch": {
@@ -19624,7 +19621,7 @@
         "loader-utils": "1.1.0",
         "opn": "5.4.0",
         "pkg-up": "2.0.0",
-        "react-error-overlay": "^5.1.2",
+        "react-error-overlay": "5.1.2",
         "recursive-readdir": "2.2.2",
         "shell-quote": "1.6.1",
         "sockjs-client": "1.1.5",
@@ -19642,9 +19639,9 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.1.1.tgz",
           "integrity": "sha512-VBorw+tgpOtZ1BYhrVSVTzTt/3+vSE3eFUh0N2GCFK1HffceOaf32YS/bs6WiFhjDAblAFrx85jMy3BG9fBK2Q==",
           "requires": {
-            "caniuse-lite": "^1.0.30000884",
-            "electron-to-chromium": "^1.3.62",
-            "node-releases": "^1.0.0-alpha.11"
+            "caniuse-lite": "1.0.30000934",
+            "electron-to-chromium": "1.3.113",
+            "node-releases": "1.1.7"
           }
         },
         "inquirer": {
@@ -19652,19 +19649,19 @@
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
           "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
           "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.0",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^3.0.0",
-            "figures": "^2.0.0",
-            "lodash": "^4.17.10",
+            "ansi-escapes": "3.2.0",
+            "chalk": "2.4.1",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.2.0",
+            "external-editor": "3.0.3",
+            "figures": "2.0.0",
+            "lodash": "4.17.11",
             "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rxjs": "^6.1.0",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^4.0.0",
-            "through": "^2.3.6"
+            "run-async": "2.3.0",
+            "rxjs": "6.4.0",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "through": "2.3.8"
           }
         },
         "json5": {
@@ -19677,9 +19674,9 @@
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         }
       }
@@ -19689,10 +19686,10 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.7.0.tgz",
       "integrity": "sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.12.0"
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.2",
+        "scheduler": "0.12.0"
       }
     },
     "react-error-overlay": {
@@ -19705,11 +19702,11 @@
       "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-2.8.0.tgz",
       "integrity": "sha512-1cSasNkHxZOXYYhms9Q1tSEWF8AWZQNq3nPLB/j8mYV0ZTSt2DhGQXHfKrKQMu4cgj9J1Crqg7xFPICTBgzqtQ==",
       "requires": {
-        "hoist-non-react-statics": "^2.5.5",
-        "intl-format-cache": "^2.0.5",
-        "intl-messageformat": "^2.1.0",
-        "intl-relativeformat": "^2.1.0",
-        "invariant": "^2.1.1"
+        "hoist-non-react-statics": "2.5.5",
+        "intl-format-cache": "2.1.0",
+        "intl-messageformat": "2.2.0",
+        "intl-relativeformat": "2.1.0",
+        "invariant": "2.2.4"
       }
     },
     "react-is": {
@@ -19722,12 +19719,12 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-6.0.0.tgz",
       "integrity": "sha512-EmbC3uLl60pw2VqSSkj6HpZ6jTk12RMrwXMBdYtM6niq0MdEaRq9KYCwpJflkOZj349BLGQm1MI/JO1W96kLWQ==",
       "requires": {
-        "@babel/runtime": "^7.2.0",
-        "hoist-non-react-statics": "^3.2.1",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.3"
+        "@babel/runtime": "7.3.1",
+        "hoist-non-react-statics": "3.3.0",
+        "invariant": "2.2.4",
+        "loose-envify": "1.4.0",
+        "prop-types": "15.6.2",
+        "react-is": "16.7.0"
       },
       "dependencies": {
         "@babel/runtime": {
@@ -19735,7 +19732,7 @@
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
           "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
           "requires": {
-            "regenerator-runtime": "^0.12.0"
+            "regenerator-runtime": "0.12.1"
           }
         },
         "hoist-non-react-statics": {
@@ -19743,7 +19740,7 @@
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
           "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
           "requires": {
-            "react-is": "^16.7.0"
+            "react-is": "16.7.0"
           }
         },
         "regenerator-runtime": {
@@ -19758,13 +19755,13 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
       "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
       "requires": {
-        "history": "^4.7.2",
-        "hoist-non-react-statics": "^2.5.0",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.1",
-        "warning": "^4.0.1"
+        "history": "4.7.2",
+        "hoist-non-react-statics": "2.5.5",
+        "invariant": "2.2.4",
+        "loose-envify": "1.4.0",
+        "path-to-regexp": "1.7.0",
+        "prop-types": "15.6.2",
+        "warning": "4.0.2"
       }
     },
     "react-router-dom": {
@@ -19772,12 +19769,12 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
       "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
       "requires": {
-        "history": "^4.7.2",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.1",
-        "react-router": "^4.3.1",
-        "warning": "^4.0.1"
+        "history": "4.7.2",
+        "invariant": "2.2.4",
+        "loose-envify": "1.4.0",
+        "prop-types": "15.6.2",
+        "react-router": "4.3.1",
+        "warning": "4.0.2"
       }
     },
     "react-router-redux": {
@@ -19790,9 +19787,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.2",
+        "path-type": "1.1.0"
       }
     },
     "read-pkg-up": {
@@ -19800,8 +19797,8 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -19809,8 +19806,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-exists": {
@@ -19818,7 +19815,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         }
       }
@@ -19828,13 +19825,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "readdirp": {
@@ -19842,9 +19839,9 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
       "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
+        "graceful-fs": "4.1.15",
+        "micromatch": "3.1.10",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "arr-diff": {
@@ -19862,16 +19859,16 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.3",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -19879,7 +19876,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -19897,13 +19894,13 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -19911,7 +19908,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -19919,7 +19916,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -19927,7 +19924,7 @@
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -19935,7 +19932,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -19945,7 +19942,7 @@
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -19953,7 +19950,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -19963,9 +19960,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -19980,14 +19977,14 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -19995,7 +19992,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -20003,7 +20000,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -20013,10 +20010,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -20024,7 +20021,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -20034,7 +20031,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -20042,7 +20039,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -20050,9 +20047,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-number": {
@@ -20060,7 +20057,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -20068,7 +20065,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -20083,19 +20080,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "ms": {
@@ -20110,7 +20107,7 @@
       "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.2.tgz",
       "integrity": "sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==",
       "requires": {
-        "util.promisify": "^1.0.0"
+        "util.promisify": "1.0.0"
       }
     },
     "recursive-readdir": {
@@ -20131,8 +20128,8 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
       "integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
       "requires": {
-        "loose-envify": "^1.4.0",
-        "symbol-observable": "^1.2.0"
+        "loose-envify": "1.4.0",
+        "symbol-observable": "1.2.0"
       }
     },
     "redux-actions": {
@@ -20140,7 +20137,7 @@
       "resolved": "https://registry.npmjs.org/redux-actions/-/redux-actions-0.10.1.tgz",
       "integrity": "sha1-u0Qu433ZZDqUkz5AceCJ9DVYcTU=",
       "requires": {
-        "reduce-reducers": "^0.1.0"
+        "reduce-reducers": "0.1.5"
       }
     },
     "redux-logger": {
@@ -20148,7 +20145,7 @@
       "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
       "integrity": "sha1-91VZZvMJjzyIYExEnPC69XeCdL8=",
       "requires": {
-        "deep-diff": "^0.3.5"
+        "deep-diff": "0.3.8"
       }
     },
     "redux-saga": {
@@ -20161,11 +20158,11 @@
       "resolved": "https://registry.npmjs.org/redux-storage/-/redux-storage-4.1.2.tgz",
       "integrity": "sha1-4G9L3u4mKurZEy/J9+rcZ+n5vqI=",
       "requires": {
-        "lodash.isfunction": "^3.0.8",
-        "lodash.isobject": "^3.0.2",
-        "loose-envify": "^1.2.0",
-        "redux-actions": "^0.10.1",
-        "redux-storage-merger-simple": "^1.0.2"
+        "lodash.isfunction": "3.0.9",
+        "lodash.isobject": "3.0.2",
+        "loose-envify": "1.4.0",
+        "redux-actions": "0.10.1",
+        "redux-storage-merger-simple": "1.0.5"
       }
     },
     "redux-storage-decorator-filter": {
@@ -20173,12 +20170,12 @@
       "resolved": "https://registry.npmjs.org/redux-storage-decorator-filter/-/redux-storage-decorator-filter-1.1.8.tgz",
       "integrity": "sha1-wLe1VjuLoTjOecA61UooeKOlPuU=",
       "requires": {
-        "lodash.get": "^4.1.2",
-        "lodash.isfunction": "^3.0.7",
-        "lodash.isobject": "^3.0.2",
-        "lodash.reduce": "^4.3.0",
-        "lodash.set": "^4.0.0",
-        "lodash.unset": "^4.1.0"
+        "lodash.get": "4.4.2",
+        "lodash.isfunction": "3.0.9",
+        "lodash.isobject": "3.0.2",
+        "lodash.reduce": "4.6.0",
+        "lodash.set": "4.3.2",
+        "lodash.unset": "4.5.2"
       }
     },
     "redux-storage-engine-localstorage": {
@@ -20191,8 +20188,8 @@
       "resolved": "https://registry.npmjs.org/redux-storage-merger-simple/-/redux-storage-merger-simple-1.0.5.tgz",
       "integrity": "sha1-KaKIaw53DZtwgRrKgAqo766J+3M=",
       "requires": {
-        "lodash.isobject": "^3.0.2",
-        "lodash.merge": "^4.3.1"
+        "lodash.isobject": "3.0.2",
+        "lodash.merge": "4.6.1"
       }
     },
     "redux-undo": {
@@ -20210,7 +20207,7 @@
       "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
       "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
       "requires": {
-        "regenerate": "^1.4.0"
+        "regenerate": "1.4.0"
       }
     },
     "regenerator-runtime": {
@@ -20223,7 +20220,7 @@
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
       "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
       "requires": {
-        "private": "^0.1.6"
+        "private": "0.1.8"
       }
     },
     "regex-cache": {
@@ -20231,7 +20228,7 @@
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regex-not": {
@@ -20239,8 +20236,8 @@
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "regexp-tree": {
@@ -20248,9 +20245,9 @@
       "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.1.tgz",
       "integrity": "sha512-HwRjOquc9QOwKTgbxvZTcddS5mlNlwePMQ3NFL8broajMLD5CXDAqas8Y5yxJH5QtZp5iRor3YCILd5pz71Cgw==",
       "requires": {
-        "cli-table3": "^0.5.0",
-        "colors": "^1.1.2",
-        "yargs": "^12.0.5"
+        "cli-table3": "0.5.1",
+        "colors": "1.3.3",
+        "yargs": "12.0.5"
       }
     },
     "regexpp": {
@@ -20263,12 +20260,12 @@
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.4.0.tgz",
       "integrity": "sha512-eDDWElbwwI3K0Lo6CqbQbA6FwgtCz4kYTarrri1okfkRLZAqstU+B3voZBCjg8Fl6iq0gXrJG6MvRgLthfvgOA==",
       "requires": {
-        "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^7.0.0",
-        "regjsgen": "^0.5.0",
-        "regjsparser": "^0.6.0",
-        "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.0.2"
+        "regenerate": "1.4.0",
+        "regenerate-unicode-properties": "7.0.0",
+        "regjsgen": "0.5.0",
+        "regjsparser": "0.6.0",
+        "unicode-match-property-ecmascript": "1.0.4",
+        "unicode-match-property-value-ecmascript": "1.0.2"
       }
     },
     "regjsgen": {
@@ -20281,7 +20278,7 @@
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
       "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -20306,11 +20303,11 @@
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.2.tgz",
       "integrity": "sha512-FsygIxevi1jSiPY9h7vZmBFUbAOcbYm9UwyiLNdVsLRs/5We9Ob5NMPbGYUTWiLq5L+ezlVdE0A8bbME5CWTpg==",
       "requires": {
-        "css-select": "^1.1.0",
-        "dom-converter": "~0.2",
-        "htmlparser2": "~3.3.0",
-        "strip-ansi": "^3.0.0",
-        "utila": "^0.4.0"
+        "css-select": "1.2.0",
+        "dom-converter": "0.2.0",
+        "htmlparser2": "3.3.0",
+        "strip-ansi": "3.0.1",
+        "utila": "0.4.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -20323,10 +20320,10 @@
           "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
           "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
           "requires": {
-            "boolbase": "~1.0.0",
-            "css-what": "2.1",
+            "boolbase": "1.0.0",
+            "css-what": "2.1.2",
             "domutils": "1.5.1",
-            "nth-check": "~1.0.1"
+            "nth-check": "1.0.2"
           }
         },
         "domutils": {
@@ -20334,8 +20331,8 @@
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
           "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
           "requires": {
-            "dom-serializer": "0",
-            "domelementtype": "1"
+            "dom-serializer": "0.1.0",
+            "domelementtype": "1.3.1"
           }
         },
         "strip-ansi": {
@@ -20343,7 +20340,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         }
       }
@@ -20363,7 +20360,7 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "request": {
@@ -20371,26 +20368,26 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.8.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.7",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.3",
+        "har-validator": "5.1.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.21",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
       },
       "dependencies": {
         "punycode": {
@@ -20403,8 +20400,8 @@
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
           "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
+            "psl": "1.1.31",
+            "punycode": "1.4.1"
           }
         }
       }
@@ -20414,7 +20411,7 @@
       "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-2.0.2.tgz",
       "integrity": "sha1-3urm1K8hdoSX24zQX6NxQ/jxJX4=",
       "requires": {
-        "is_js": "^0.9.0"
+        "is_js": "0.9.0"
       }
     },
     "request-promise-core": {
@@ -20422,7 +20419,7 @@
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "requires": {
-        "lodash": "^4.13.1"
+        "lodash": "4.17.11"
       }
     },
     "request-promise-native": {
@@ -20431,8 +20428,8 @@
       "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
       "requires": {
         "request-promise-core": "1.1.1",
-        "stealthy-require": "^1.1.0",
-        "tough-cookie": ">=2.3.3"
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.5.0"
       }
     },
     "require-directory": {
@@ -20455,8 +20452,8 @@
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
       },
       "dependencies": {
         "caller-path": {
@@ -20464,7 +20461,7 @@
           "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
           "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
           "requires": {
-            "callsites": "^0.2.0"
+            "callsites": "0.2.0"
           }
         },
         "callsites": {
@@ -20494,7 +20491,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.6"
       }
     },
     "resolve-cwd": {
@@ -20502,7 +20499,7 @@
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "3.0.0"
       }
     },
     "resolve-dir": {
@@ -20510,8 +20507,8 @@
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       }
     },
     "resolve-from": {
@@ -20534,8 +20531,8 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "resumer": {
@@ -20543,7 +20540,7 @@
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "requires": {
-        "through": "~2.3.4"
+        "through": "2.3.8"
       }
     },
     "ret": {
@@ -20566,7 +20563,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
-        "glob": "^7.1.3"
+        "glob": "7.1.3"
       }
     },
     "ripemd160": {
@@ -20574,8 +20571,8 @@
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       }
     },
     "rlp": {
@@ -20583,8 +20580,8 @@
       "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.2.tgz",
       "integrity": "sha512-Ng2kJEN731Sfv4ZAY2i0ytPMc0BbJKBsVNl0QZY8LxOWSwd+1xpg+fpSRfaMn0heHU447s6Kgy8qfHZR0XTyVw==",
       "requires": {
-        "bn.js": "^4.11.1",
-        "safe-buffer": "^5.1.1"
+        "bn.js": "4.11.8",
+        "safe-buffer": "5.1.2"
       }
     },
     "rollbar": {
@@ -20592,15 +20589,15 @@
       "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-2.5.2.tgz",
       "integrity": "sha512-eZyZ6/vakNQm02NvdE10a1tB7EUNbN8Q4GSI5OOMzH3Tzw2okVXh2Lhhi0rvbB5mxA2Pa2Qp1xzqJHdmPL05gw==",
       "requires": {
-        "async": "~1.2.1",
+        "async": "1.2.1",
         "console-polyfill": "0.3.0",
         "debug": "2.6.9",
-        "decache": "^3.0.5",
+        "decache": "3.1.0",
         "error-stack-parser": "1.3.3",
-        "json-stringify-safe": "~5.0.0",
-        "lru-cache": "~2.2.1",
-        "request-ip": "~2.0.1",
-        "uuid": "3.0.x"
+        "json-stringify-safe": "5.0.1",
+        "lru-cache": "2.2.4",
+        "request-ip": "2.0.2",
+        "uuid": "3.0.1"
       },
       "dependencies": {
         "debug": {
@@ -20633,7 +20630,7 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
     },
     "run-queue": {
@@ -20641,7 +20638,7 @@
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "requires": {
-        "aproba": "^1.1.1"
+        "aproba": "1.2.0"
       }
     },
     "rustbn.js": {
@@ -20654,7 +20651,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
       "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.3"
       }
     },
     "safe-buffer": {
@@ -20667,7 +20664,7 @@
       "resolved": "https://registry.npmjs.org/safe-event-emitter/-/safe-event-emitter-1.0.1.tgz",
       "integrity": "sha512-e1wFe99A91XYYxoQbcq2ZJUWurxEyP8vfz7A7vuUe1s95q8r5ebraVaA1BukYJcpM6V16ugWoD9vngi8Ccu5fg==",
       "requires": {
-        "events": "^3.0.0"
+        "events": "3.0.0"
       }
     },
     "safe-regex": {
@@ -20675,7 +20672,7 @@
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -20688,15 +20685,15 @@
       "resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
       "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
       "requires": {
-        "anymatch": "^2.0.0",
-        "capture-exit": "^1.2.0",
-        "exec-sh": "^0.2.0",
-        "fb-watchman": "^2.0.0",
-        "fsevents": "^1.2.3",
-        "micromatch": "^3.1.4",
-        "minimist": "^1.1.1",
-        "walker": "~1.0.5",
-        "watch": "~0.18.0"
+        "anymatch": "2.0.0",
+        "capture-exit": "1.2.0",
+        "exec-sh": "0.2.2",
+        "fb-watchman": "2.0.0",
+        "fsevents": "1.2.7",
+        "micromatch": "3.1.10",
+        "minimist": "1.2.0",
+        "walker": "1.0.7",
+        "watch": "0.18.0"
       },
       "dependencies": {
         "arr-diff": {
@@ -20714,16 +20711,16 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.3",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -20731,7 +20728,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -20749,13 +20746,13 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -20763,7 +20760,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -20771,7 +20768,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -20779,7 +20776,7 @@
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -20787,7 +20784,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -20797,7 +20794,7 @@
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -20805,7 +20802,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -20815,9 +20812,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -20832,14 +20829,14 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -20847,7 +20844,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -20855,7 +20852,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -20865,10 +20862,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -20876,7 +20873,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -20886,7 +20883,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -20894,7 +20891,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -20902,9 +20899,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-number": {
@@ -20912,7 +20909,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -20920,7 +20917,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -20935,19 +20932,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "ms": {
@@ -20962,12 +20959,12 @@
       "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-7.1.0.tgz",
       "integrity": "sha512-+G+BKGglmZM2GUSfT9TLuEp6tzehHPjAMoRRItOojWIqIGPloVCMhNIQuG639eJ+y033PaGTSjLaTHts8Kw79w==",
       "requires": {
-        "clone-deep": "^2.0.1",
-        "loader-utils": "^1.0.1",
-        "lodash.tail": "^4.1.1",
-        "neo-async": "^2.5.0",
-        "pify": "^3.0.0",
-        "semver": "^5.5.0"
+        "clone-deep": "2.0.2",
+        "loader-utils": "1.2.3",
+        "lodash.tail": "4.1.1",
+        "neo-async": "2.6.0",
+        "pify": "3.0.0",
+        "semver": "5.6.0"
       },
       "dependencies": {
         "clone-deep": {
@@ -20975,10 +20972,10 @@
           "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-2.0.2.tgz",
           "integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
           "requires": {
-            "for-own": "^1.0.0",
-            "is-plain-object": "^2.0.4",
-            "kind-of": "^6.0.0",
-            "shallow-clone": "^1.0.0"
+            "for-own": "1.0.0",
+            "is-plain-object": "2.0.4",
+            "kind-of": "6.0.2",
+            "shallow-clone": "1.0.0"
           }
         },
         "for-own": {
@@ -20986,7 +20983,7 @@
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         },
         "kind-of": {
@@ -21004,9 +21001,9 @@
           "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-1.0.0.tgz",
           "integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
           "requires": {
-            "is-extendable": "^0.1.1",
-            "kind-of": "^5.0.0",
-            "mixin-object": "^2.0.1"
+            "is-extendable": "0.1.1",
+            "kind-of": "5.1.0",
+            "mixin-object": "2.0.1"
           },
           "dependencies": {
             "kind-of": {
@@ -21028,7 +21025,7 @@
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.6.tgz",
       "integrity": "sha512-LAYs+lChg1v5uKNzPtsgTxSS5hLo8aIhSMCJt1WMpefAxm3D1RTpMwSpb6ebdL31cubiLTnhokVktBW+cv9Y9w==",
       "requires": {
-        "xmlchars": "^1.3.1"
+        "xmlchars": "1.3.1"
       }
     },
     "scheduler": {
@@ -21036,8 +21033,8 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.12.0.tgz",
       "integrity": "sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1"
       }
     },
     "schema-utils": {
@@ -21045,9 +21042,9 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
       "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
       "requires": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
+        "ajv": "6.8.1",
+        "ajv-errors": "1.0.1",
+        "ajv-keywords": "3.3.0"
       }
     },
     "seamless-immutable": {
@@ -21060,14 +21057,14 @@
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.6.2.tgz",
       "integrity": "sha512-90nYt7yb0LmI4A2jJs1grglkTAXrBwxYAjP9bpeKjvJKOjG2fOeH/YI/lchDMIvjrOasd5QXwvV2jwN168xNng==",
       "requires": {
-        "bindings": "^1.2.1",
-        "bip66": "^1.1.3",
-        "bn.js": "^4.11.3",
-        "create-hash": "^1.1.2",
-        "drbg.js": "^1.0.1",
-        "elliptic": "^6.2.3",
-        "nan": "^2.2.1",
-        "safe-buffer": "^5.1.0"
+        "bindings": "1.4.0",
+        "bip66": "1.1.5",
+        "bn.js": "4.11.8",
+        "create-hash": "1.2.0",
+        "drbg.js": "1.0.1",
+        "elliptic": "6.4.1",
+        "nan": "2.12.1",
+        "safe-buffer": "5.1.2"
       }
     },
     "select-hose": {
@@ -21088,7 +21085,7 @@
       "resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.4.1.tgz",
       "integrity": "sha512-Pkp0p9oWOxlH0kODx7qFpIRYpK1T4WJOO4lNnpNPOoWKCrYsfHqYSKgk5fHfQtnWnsAKy7nLJMW02bgDWWFZFg==",
       "requires": {
-        "jquery": "x.*"
+        "jquery": "3.3.1"
       }
     },
     "semantic-ui-react": {
@@ -21096,13 +21093,13 @@
       "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-0.84.0.tgz",
       "integrity": "sha512-OOqdtH+hBxVlh/lQa+zet9MEPcA8cBUo7ePVYZhx82hwF5Ky47FiWrgLk3ZSNie7bb4VkuiuLR9y5cY0EooRlw==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
-        "@semantic-ui-react/event-stack": "^3.0.1",
-        "classnames": "^2.2.6",
-        "keyboard-key": "^1.0.2",
-        "lodash": "^4.17.11",
-        "prop-types": "^15.6.2",
-        "shallowequal": "^1.1.0"
+        "@babel/runtime": "7.1.5",
+        "@semantic-ui-react/event-stack": "3.0.1",
+        "classnames": "2.2.6",
+        "keyboard-key": "1.0.4",
+        "lodash": "4.17.11",
+        "prop-types": "15.6.2",
+        "shallowequal": "1.1.0"
       }
     },
     "semaphore": {
@@ -21121,18 +21118,18 @@
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
+        "http-errors": "1.6.3",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "debug": {
@@ -21165,13 +21162,13 @@
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "~1.0.3",
-        "http-errors": "~1.6.2",
-        "mime-types": "~2.1.17",
-        "parseurl": "~1.3.2"
+        "escape-html": "1.0.3",
+        "http-errors": "1.6.3",
+        "mime-types": "2.1.21",
+        "parseurl": "1.3.2"
       },
       "dependencies": {
         "debug": {
@@ -21194,9 +21191,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
         "send": "0.16.2"
       }
     },
@@ -21215,10 +21212,10 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -21226,7 +21223,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -21246,8 +21243,8 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "shallow-clone": {
@@ -21255,10 +21252,10 @@
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
       "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
       "requires": {
-        "is-extendable": "^0.1.1",
-        "kind-of": "^2.0.1",
-        "lazy-cache": "^0.2.3",
-        "mixin-object": "^2.0.1"
+        "is-extendable": "0.1.1",
+        "kind-of": "2.0.1",
+        "lazy-cache": "0.2.7",
+        "mixin-object": "2.0.1"
       },
       "dependencies": {
         "kind-of": {
@@ -21266,7 +21263,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "requires": {
-            "is-buffer": "^1.0.2"
+            "is-buffer": "1.1.6"
           }
         },
         "lazy-cache": {
@@ -21286,7 +21283,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -21299,10 +21296,10 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "requires": {
-        "array-filter": "~0.0.0",
-        "array-map": "~0.0.0",
-        "array-reduce": "~0.0.0",
-        "jsonify": "~0.0.0"
+        "array-filter": "0.0.1",
+        "array-map": "0.0.0",
+        "array-reduce": "0.0.0",
+        "jsonify": "0.0.0"
       }
     },
     "shellwords": {
@@ -21320,7 +21317,7 @@
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
-        "is-arrayish": "^0.3.1"
+        "is-arrayish": "0.3.2"
       },
       "dependencies": {
         "is-arrayish": {
@@ -21345,7 +21342,7 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0"
+        "is-fullwidth-code-point": "2.0.0"
       }
     },
     "snapdragon": {
@@ -21353,14 +21350,14 @@
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.2",
+        "use": "3.1.1"
       },
       "dependencies": {
         "debug": {
@@ -21376,7 +21373,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -21384,7 +21381,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "ms": {
@@ -21399,9 +21396,9 @@
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -21409,7 +21406,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -21417,7 +21414,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -21425,7 +21422,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -21433,9 +21430,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "kind-of": {
@@ -21450,7 +21447,7 @@
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       }
     },
     "sockjs": {
@@ -21458,8 +21455,8 @@
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
       "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
       "requires": {
-        "faye-websocket": "^0.10.0",
-        "uuid": "^3.0.1"
+        "faye-websocket": "0.10.0",
+        "uuid": "3.3.2"
       },
       "dependencies": {
         "faye-websocket": {
@@ -21467,7 +21464,7 @@
           "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
           "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
           "requires": {
-            "websocket-driver": ">=0.5.1"
+            "websocket-driver": "0.7.0"
           }
         }
       }
@@ -21477,12 +21474,12 @@
       "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
       "integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
       "requires": {
-        "debug": "^2.6.6",
+        "debug": "2.6.9",
         "eventsource": "0.1.6",
-        "faye-websocket": "~0.11.0",
-        "inherits": "^2.0.1",
-        "json3": "^3.3.2",
-        "url-parse": "^1.1.8"
+        "faye-websocket": "0.11.1",
+        "inherits": "2.0.3",
+        "json3": "3.3.2",
+        "url-parse": "1.4.4"
       },
       "dependencies": {
         "debug": {
@@ -21505,11 +21502,11 @@
       "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.25.tgz",
       "integrity": "sha512-jU1YygRVy6zatgXrLY2rRm7HW1d7a8CkkEgNJwvH2VLpWhMFsMdWcJn6kUqZwcSz/Vm+w89dy7Z/aB5p6AFTrg==",
       "requires": {
-        "fs-extra": "^0.30.0",
-        "memorystream": "^0.3.1",
-        "require-from-string": "^1.1.0",
-        "semver": "^5.3.0",
-        "yargs": "^4.7.1"
+        "fs-extra": "0.30.0",
+        "memorystream": "0.3.1",
+        "require-from-string": "1.2.1",
+        "semver": "5.6.0",
+        "yargs": "4.8.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -21527,9 +21524,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           }
         },
         "fs-extra": {
@@ -21537,11 +21534,11 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "rimraf": "^2.2.8"
+            "graceful-fs": "4.1.15",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1",
+            "path-is-absolute": "1.0.1",
+            "rimraf": "2.6.3"
           }
         },
         "invert-kv": {
@@ -21554,7 +21551,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "lcid": {
@@ -21562,7 +21559,7 @@
           "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
           "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "requires": {
-            "invert-kv": "^1.0.0"
+            "invert-kv": "1.0.0"
           }
         },
         "os-locale": {
@@ -21570,7 +21567,7 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
-            "lcid": "^1.0.0"
+            "lcid": "1.0.0"
           }
         },
         "string-width": {
@@ -21578,9 +21575,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-ansi": {
@@ -21588,7 +21585,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "which-module": {
@@ -21606,20 +21603,20 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
           "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
           "requires": {
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "lodash.assign": "^4.0.3",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.1",
-            "which-module": "^1.0.0",
-            "window-size": "^0.2.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^2.4.1"
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.3",
+            "lodash.assign": "4.2.0",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "2.4.1"
           }
         },
         "yargs-parser": {
@@ -21627,8 +21624,8 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
           "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
           "requires": {
-            "camelcase": "^3.0.0",
-            "lodash.assign": "^4.0.6"
+            "camelcase": "3.0.0",
+            "lodash.assign": "4.2.0"
           }
         }
       }
@@ -21648,11 +21645,11 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "requires": {
-        "atob": "^2.1.1",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.2",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-support": {
@@ -21660,7 +21657,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "requires": {
-        "source-map": "^0.5.6"
+        "source-map": "0.5.7"
       }
     },
     "source-map-url": {
@@ -21679,8 +21676,8 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
       "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.3"
       }
     },
     "spdx-exceptions": {
@@ -21693,8 +21690,8 @@
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.2.0",
+        "spdx-license-ids": "3.0.3"
       }
     },
     "spdx-license-ids": {
@@ -21707,11 +21704,11 @@
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.0.tgz",
       "integrity": "sha512-ot0oEGT/PGUpzf/6uk4AWLqkq+irlqHXkrdbk51oWONh3bxQmBuljxPNl66zlRRcIJStWq0QkLUCPOPjgjvU0Q==",
       "requires": {
-        "debug": "^4.1.0",
-        "handle-thing": "^2.0.0",
-        "http-deceiver": "^1.2.7",
-        "select-hose": "^2.0.0",
-        "spdy-transport": "^3.0.0"
+        "debug": "4.1.1",
+        "handle-thing": "2.0.0",
+        "http-deceiver": "1.2.7",
+        "select-hose": "2.0.0",
+        "spdy-transport": "3.0.0"
       }
     },
     "spdy-transport": {
@@ -21719,12 +21716,12 @@
       "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
       "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
       "requires": {
-        "debug": "^4.1.0",
-        "detect-node": "^2.0.4",
-        "hpack.js": "^2.1.6",
-        "obuf": "^1.1.2",
-        "readable-stream": "^3.0.6",
-        "wbuf": "^1.7.3"
+        "debug": "4.1.1",
+        "detect-node": "2.0.4",
+        "hpack.js": "2.1.6",
+        "obuf": "1.1.2",
+        "readable-stream": "3.1.1",
+        "wbuf": "1.7.3"
       },
       "dependencies": {
         "readable-stream": {
@@ -21732,9 +21729,9 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
           "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
           "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
+            "inherits": "2.0.3",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         }
       }
@@ -21744,7 +21741,7 @@
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "sprintf-js": {
@@ -21757,15 +21754,15 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "ssri": {
@@ -21773,7 +21770,7 @@
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
       "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
       "requires": {
-        "figgy-pudding": "^3.5.1"
+        "figgy-pudding": "3.5.1"
       }
     },
     "stable": {
@@ -21796,8 +21793,8 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -21805,7 +21802,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -21825,8 +21822,8 @@
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
       "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
       "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "^2.0.2"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "stream-each": {
@@ -21834,8 +21831,8 @@
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
       "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "stream-shift": "1.0.0"
       }
     },
     "stream-http": {
@@ -21843,11 +21840,11 @@
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.6",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
       }
     },
     "stream-shift": {
@@ -21860,8 +21857,8 @@
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "requires": {
-        "astral-regex": "^1.0.0",
-        "strip-ansi": "^4.0.0"
+        "astral-regex": "1.0.0",
+        "strip-ansi": "4.0.0"
       }
     },
     "string-width": {
@@ -21869,8 +21866,8 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       }
     },
     "string.prototype.trim": {
@@ -21878,9 +21875,9 @@
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.0",
-        "function-bind": "^1.0.2"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.13.0",
+        "function-bind": "1.1.1"
       }
     },
     "string_decoder": {
@@ -21888,7 +21885,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "stringify-object": {
@@ -21896,9 +21893,9 @@
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
       "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
       "requires": {
-        "get-own-enumerable-property-symbols": "^3.0.0",
-        "is-obj": "^1.0.1",
-        "is-regexp": "^1.0.0"
+        "get-own-enumerable-property-symbols": "3.0.0",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
       }
     },
     "strip-ansi": {
@@ -21906,7 +21903,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "3.0.0"
       }
     },
     "strip-bom": {
@@ -21914,7 +21911,7 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "requires": {
-        "is-utf8": "^0.2.0"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-comments": {
@@ -21922,8 +21919,8 @@
       "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-1.0.2.tgz",
       "integrity": "sha512-kL97alc47hoyIQSV165tTt9rG5dn4w1dNnBhOQ3bOU1Nc1hel09jnXANaHJ7vzHLd4Ju8kseDGzlev96pghLFw==",
       "requires": {
-        "babel-extract-comments": "^1.0.0",
-        "babel-plugin-transform-object-rest-spread": "^6.26.0"
+        "babel-extract-comments": "1.0.0",
+        "babel-plugin-transform-object-rest-spread": "6.26.0"
       }
     },
     "strip-eof": {
@@ -21949,8 +21946,8 @@
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.0.tgz",
       "integrity": "sha512-uCcN7XWHkqwGVt7skpInW6IGO1tG6ReyFQ1Cseh0VcN6VdcFQi62aG/2F3Y9ueA8x4IVlfaSUxpmQXQD9QrEuQ==",
       "requires": {
-        "loader-utils": "^1.1.0",
-        "schema-utils": "^0.4.5"
+        "loader-utils": "1.2.3",
+        "schema-utils": "0.4.7"
       },
       "dependencies": {
         "schema-utils": {
@@ -21958,8 +21955,8 @@
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
           "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
           "requires": {
-            "ajv": "^6.1.0",
-            "ajv-keywords": "^3.1.0"
+            "ajv": "6.8.1",
+            "ajv-keywords": "3.3.0"
           }
         }
       }
@@ -21969,9 +21966,9 @@
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.1.tgz",
       "integrity": "sha512-TK5zEPeD9NyC1uPIdjikzsgWxdQQN/ry1X3d1iOz1UkYDCmcr928gWD1KHgyC27F50UnE0xCTrBOO1l6KR8M4w==",
       "requires": {
-        "browserslist": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0"
+        "browserslist": "4.4.1",
+        "postcss": "7.0.14",
+        "postcss-selector-parser": "3.1.1"
       },
       "dependencies": {
         "chalk": {
@@ -21979,9 +21976,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -21989,7 +21986,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -21999,9 +21996,9 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "postcss-selector-parser": {
@@ -22009,9 +22006,9 @@
           "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "requires": {
-            "dot-prop": "^4.1.1",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
+            "dot-prop": "4.2.0",
+            "indexes-of": "1.0.1",
+            "uniq": "1.0.1"
           }
         },
         "source-map": {
@@ -22024,7 +22021,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -22034,7 +22031,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "svgo": {
@@ -22042,20 +22039,20 @@
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.1.1.tgz",
       "integrity": "sha512-GBkJbnTuFpM4jFbiERHDWhZc/S/kpHToqmZag3aEBjPYK44JAN2QBjvrGIxLOoCyMZjuFQIfTO2eJd8uwLY/9g==",
       "requires": {
-        "coa": "~2.0.1",
-        "colors": "~1.1.2",
-        "css-select": "^2.0.0",
-        "css-select-base-adapter": "~0.1.0",
+        "coa": "2.0.2",
+        "colors": "1.1.2",
+        "css-select": "2.0.2",
+        "css-select-base-adapter": "0.1.1",
         "css-tree": "1.0.0-alpha.28",
-        "css-url-regex": "^1.1.0",
-        "csso": "^3.5.0",
-        "js-yaml": "^3.12.0",
-        "mkdirp": "~0.5.1",
-        "object.values": "^1.0.4",
-        "sax": "~1.2.4",
-        "stable": "~0.1.6",
-        "unquote": "~1.1.1",
-        "util.promisify": "~1.0.0"
+        "css-url-regex": "1.1.0",
+        "csso": "3.5.1",
+        "js-yaml": "3.12.1",
+        "mkdirp": "0.5.1",
+        "object.values": "1.1.0",
+        "sax": "1.2.4",
+        "stable": "0.1.8",
+        "unquote": "1.1.1",
+        "util.promisify": "1.0.0"
       },
       "dependencies": {
         "colors": {
@@ -22080,12 +22077,12 @@
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "requires": {
-        "ajv": "^6.0.1",
-        "ajv-keywords": "^3.0.0",
-        "chalk": "^2.1.0",
-        "lodash": "^4.17.4",
+        "ajv": "6.8.1",
+        "ajv-keywords": "3.3.0",
+        "chalk": "2.4.1",
+        "lodash": "4.17.11",
         "slice-ansi": "1.0.0",
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       }
     },
     "tapable": {
@@ -22098,19 +22095,19 @@
       "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.2.tgz",
       "integrity": "sha512-lPXKRKILZ1kZaUy5ynWKs8ATGSUO7HAFHCFnBam6FaGSqPdOwMWbxXHq4EXFLE8WRTleo/YOMXkaUTRmTB1Fiw==",
       "requires": {
-        "deep-equal": "~1.0.1",
-        "defined": "~1.0.0",
-        "for-each": "~0.3.3",
-        "function-bind": "~1.1.1",
-        "glob": "~7.1.2",
-        "has": "~1.0.3",
-        "inherits": "~2.0.3",
-        "minimist": "~1.2.0",
-        "object-inspect": "~1.6.0",
-        "resolve": "~1.7.1",
-        "resumer": "~0.0.0",
-        "string.prototype.trim": "~1.1.2",
-        "through": "~2.3.8"
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
+        "for-each": "0.3.3",
+        "function-bind": "1.1.1",
+        "glob": "7.1.3",
+        "has": "1.0.3",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "object-inspect": "1.6.0",
+        "resolve": "1.7.1",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.1.2",
+        "through": "2.3.8"
       },
       "dependencies": {
         "resolve": {
@@ -22118,7 +22115,7 @@
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
           "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
           "requires": {
-            "path-parse": "^1.0.5"
+            "path-parse": "1.0.6"
           }
         }
       }
@@ -22128,9 +22125,9 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-3.16.1.tgz",
       "integrity": "sha512-JDJjgleBROeek2iBcSNzOHLKsB/MdDf+E/BOAJ0Tk9r7p9/fVobfv7LMJ/g/k3v9SXdmjZnIlFd5nfn/Rt0Xow==",
       "requires": {
-        "commander": "~2.17.1",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.9"
+        "commander": "2.17.1",
+        "source-map": "0.6.1",
+        "source-map-support": "0.5.10"
       },
       "dependencies": {
         "commander": {
@@ -22148,8 +22145,8 @@
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
           "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
           "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
+            "buffer-from": "1.1.1",
+            "source-map": "0.6.1"
           }
         }
       }
@@ -22159,14 +22156,14 @@
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.1.0.tgz",
       "integrity": "sha512-61lV0DSxMAZ8AyZG7/A4a3UPlrbOBo8NIQ4tJzLPAdGOQ+yoNC7l5ijEow27lBAL2humer01KLS6bGIMYQxKoA==",
       "requires": {
-        "cacache": "^11.0.2",
-        "find-cache-dir": "^2.0.0",
-        "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.4.0",
-        "source-map": "^0.6.1",
-        "terser": "^3.8.1",
-        "webpack-sources": "^1.1.0",
-        "worker-farm": "^1.5.2"
+        "cacache": "11.3.2",
+        "find-cache-dir": "2.0.0",
+        "schema-utils": "1.0.0",
+        "serialize-javascript": "1.6.1",
+        "source-map": "0.6.1",
+        "terser": "3.16.1",
+        "webpack-sources": "1.3.0",
+        "worker-farm": "1.6.0"
       },
       "dependencies": {
         "find-cache-dir": {
@@ -22174,9 +22171,9 @@
           "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
           "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
           "requires": {
-            "commondir": "^1.0.1",
-            "make-dir": "^1.0.0",
-            "pkg-dir": "^3.0.0"
+            "commondir": "1.0.1",
+            "make-dir": "1.3.0",
+            "pkg-dir": "3.0.0"
           }
         },
         "pkg-dir": {
@@ -22184,7 +22181,7 @@
           "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
           "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
           "requires": {
-            "find-up": "^3.0.0"
+            "find-up": "3.0.0"
           }
         },
         "source-map": {
@@ -22199,11 +22196,11 @@
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.3.tgz",
       "integrity": "sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==",
       "requires": {
-        "arrify": "^1.0.1",
-        "micromatch": "^2.3.11",
-        "object-assign": "^4.1.0",
-        "read-pkg-up": "^1.0.1",
-        "require-main-filename": "^1.0.1"
+        "arrify": "1.0.1",
+        "micromatch": "2.3.11",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "require-main-filename": "1.0.1"
       }
     },
     "text-table": {
@@ -22226,8 +22223,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "requires": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "thunky": {
@@ -22240,7 +22237,7 @@
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
       "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
       "requires": {
-        "setimmediate": "^1.0.4"
+        "setimmediate": "1.0.5"
       }
     },
     "timsort": {
@@ -22253,7 +22250,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "tmpl": {
@@ -22276,7 +22273,7 @@
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "to-regex": {
@@ -22284,10 +22281,10 @@
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -22295,8 +22292,8 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       },
       "dependencies": {
         "is-number": {
@@ -22304,7 +22301,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         }
       }
@@ -22314,7 +22311,7 @@
       "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       }
     },
     "tough-cookie": {
@@ -22322,8 +22319,8 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
+        "psl": "1.1.31",
+        "punycode": "2.1.1"
       }
     },
     "tr46": {
@@ -22331,7 +22328,7 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "traverse-chain": {
@@ -22372,11 +22369,11 @@
       "integrity": "sha512-KwF1SplmOJepnoZ4eRIloH/zXL195F51skt7reEsS6jvDqzgc/YSbz9b8E07GxIUwLXdcD4ssrJu6v8CwaTafA==",
       "dev": true,
       "requires": {
-        "chalk": "^2.3.0",
-        "enhanced-resolve": "^4.0.0",
-        "loader-utils": "^1.0.2",
-        "micromatch": "^3.1.4",
-        "semver": "^5.0.1"
+        "chalk": "2.4.1",
+        "enhanced-resolve": "4.1.0",
+        "loader-utils": "1.2.3",
+        "micromatch": "3.1.10",
+        "semver": "5.6.0"
       },
       "dependencies": {
         "arr-diff": {
@@ -22397,16 +22394,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.3",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -22415,7 +22412,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -22435,13 +22432,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -22450,7 +22447,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -22459,7 +22456,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -22468,7 +22465,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -22477,7 +22474,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -22488,7 +22485,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -22497,7 +22494,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -22508,9 +22505,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -22527,14 +22524,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -22543,7 +22540,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -22552,7 +22549,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -22563,10 +22560,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -22575,7 +22572,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -22586,7 +22583,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -22595,7 +22592,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -22604,9 +22601,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-number": {
@@ -22615,7 +22612,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -22624,7 +22621,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -22641,19 +22638,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "ms": {
@@ -22670,11 +22667,11 @@
       "integrity": "sha512-7iE+Q/2E1lgvxD+c0Ot+GFFmgmfIjt/zCayyruXkXQ84BLT85gHXy0WSoQSiuFX9+d+keE/jiON7notV74ZY+A==",
       "dev": true,
       "requires": {
-        "@types/json5": "^0.0.29",
-        "deepmerge": "^2.0.1",
-        "json5": "^1.0.1",
-        "minimist": "^1.2.0",
-        "strip-bom": "^3.0.0"
+        "@types/json5": "0.0.29",
+        "deepmerge": "2.2.1",
+        "json5": "1.0.1",
+        "minimist": "1.2.0",
+        "strip-bom": "3.0.0"
       },
       "dependencies": {
         "json5": {
@@ -22683,7 +22680,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.0"
           }
         },
         "strip-bom": {
@@ -22700,9 +22697,9 @@
       "integrity": "sha512-S/gOOPOkV8rIL4LurZ1vUdYCVgo15iX9ZMJ6wx6w2OgcpT/G4wMyHB6WM+xheSqGMrWKuxFul+aXpCju3wmj/g==",
       "dev": true,
       "requires": {
-        "chalk": "^2.3.0",
-        "enhanced-resolve": "^4.0.0",
-        "tsconfig-paths": "^3.4.0"
+        "chalk": "2.4.1",
+        "enhanced-resolve": "4.1.0",
+        "tsconfig-paths": "3.7.0"
       }
     },
     "tslib": {
@@ -22715,18 +22712,18 @@
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.1.tgz",
       "integrity": "sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==",
       "requires": {
-        "babel-code-frame": "^6.22.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.3.0",
-        "commander": "^2.12.1",
-        "diff": "^3.2.0",
-        "glob": "^7.1.1",
-        "js-yaml": "^3.7.0",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.8.0",
-        "tsutils": "^2.27.2"
+        "babel-code-frame": "6.26.0",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.4.1",
+        "commander": "2.19.0",
+        "diff": "3.5.0",
+        "glob": "7.1.3",
+        "js-yaml": "3.12.1",
+        "minimatch": "3.0.4",
+        "resolve": "1.8.1",
+        "semver": "5.6.0",
+        "tslib": "1.9.3",
+        "tsutils": "2.29.0"
       }
     },
     "tslint-clean-code": {
@@ -22735,7 +22732,7 @@
       "integrity": "sha512-h9BqZIUsvqtns46IIto5fbouaERFd9Iu0NupTZ9s80frdm5eGhOWDp2VjfOx4LqgnvchMFX1xrj+dfWs4bVYog==",
       "dev": true,
       "requires": {
-        "memoize-decorator": "^1.0.2",
+        "memoize-decorator": "1.0.2",
         "tsutils": "2.7.1"
       },
       "dependencies": {
@@ -22745,7 +22742,7 @@
           "integrity": "sha1-QRoOlGZSWisoaSYKVWINcpIVXiQ=",
           "dev": true,
           "requires": {
-            "tslib": "^1.7.1"
+            "tslib": "1.9.3"
           }
         }
       }
@@ -22763,7 +22760,7 @@
       "requires": {
         "doctrine": "0.7.2",
         "tslib": "1.9.0",
-        "tsutils": "^3.0.0"
+        "tsutils": "3.8.0"
       },
       "dependencies": {
         "doctrine": {
@@ -22772,7 +22769,7 @@
           "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
           "dev": true,
           "requires": {
-            "esutils": "^1.1.6",
+            "esutils": "1.1.6",
             "isarray": "0.0.1"
           }
         },
@@ -22800,7 +22797,7 @@
           "integrity": "sha512-XQdPhgcoTbCD8baXC38PQ0vpTZ8T3YrE+vR66YIj/xvDt1//8iAhafpIT/4DmvzzC1QFapEImERu48Pa01dIUA==",
           "dev": true,
           "requires": {
-            "tslib": "^1.8.1"
+            "tslib": "1.9.0"
           }
         }
       }
@@ -22811,9 +22808,9 @@
       "integrity": "sha512-KK1GcYJcyCeiybEab59KAdSvLYgPUdiud41Fe/cT3ns2EpvZvzOn2HWrkPqh3uuJ6mgyB3LhfEvE13WoU+3e3A==",
       "dev": true,
       "requires": {
-        "@types/node": "^8.0.28",
-        "tslint": "^5.7.0",
-        "typescript": "^2.5.2"
+        "@types/node": "8.10.39",
+        "tslint": "5.12.1",
+        "typescript": "2.9.2"
       },
       "dependencies": {
         "@types/node": {
@@ -22836,9 +22833,9 @@
       "integrity": "sha512-4FX9JIx/1rKHIPJNfMb+ooX1gPk5Vg3vNi7+dyFYpLO+O57F4g+b/fo1+W/G0SUOkBLHB/YKScxjX/P+7ZT/Tw==",
       "dev": true,
       "requires": {
-        "eslint-plugin-prettier": "^2.2.0",
-        "lines-and-columns": "^1.1.6",
-        "tslib": "^1.7.1"
+        "eslint-plugin-prettier": "2.7.0",
+        "lines-and-columns": "1.1.6",
+        "tslib": "1.9.3"
       }
     },
     "tsutils": {
@@ -22846,7 +22843,7 @@
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
       "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
       "requires": {
-        "tslib": "^1.8.1"
+        "tslib": "1.9.3"
       }
     },
     "tty-browserify": {
@@ -22859,7 +22856,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -22872,7 +22869,7 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "type-is": {
@@ -22881,7 +22878,7 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "2.1.21"
       }
     },
     "typedarray": {
@@ -22909,8 +22906,8 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
       "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
       "requires": {
-        "commander": "~2.17.1",
-        "source-map": "~0.6.1"
+        "commander": "2.17.1",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "commander": {
@@ -22930,14 +22927,14 @@
       "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
       "integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
       "requires": {
-        "cacache": "^10.0.4",
-        "find-cache-dir": "^1.0.0",
-        "schema-utils": "^0.4.5",
-        "serialize-javascript": "^1.4.0",
-        "source-map": "^0.6.1",
-        "uglify-es": "^3.3.4",
-        "webpack-sources": "^1.1.0",
-        "worker-farm": "^1.5.2"
+        "cacache": "10.0.4",
+        "find-cache-dir": "1.0.0",
+        "schema-utils": "0.4.7",
+        "serialize-javascript": "1.6.1",
+        "source-map": "0.6.1",
+        "uglify-es": "3.3.9",
+        "webpack-sources": "1.3.0",
+        "worker-farm": "1.6.0"
       },
       "dependencies": {
         "cacache": {
@@ -22945,19 +22942,19 @@
           "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
           "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
           "requires": {
-            "bluebird": "^3.5.1",
-            "chownr": "^1.0.1",
-            "glob": "^7.1.2",
-            "graceful-fs": "^4.1.11",
-            "lru-cache": "^4.1.1",
-            "mississippi": "^2.0.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.2",
-            "ssri": "^5.2.4",
-            "unique-filename": "^1.1.0",
-            "y18n": "^4.0.0"
+            "bluebird": "3.5.3",
+            "chownr": "1.1.1",
+            "glob": "7.1.3",
+            "graceful-fs": "4.1.15",
+            "lru-cache": "4.1.5",
+            "mississippi": "2.0.0",
+            "mkdirp": "0.5.1",
+            "move-concurrently": "1.0.1",
+            "promise-inflight": "1.0.1",
+            "rimraf": "2.6.3",
+            "ssri": "5.3.0",
+            "unique-filename": "1.1.1",
+            "y18n": "4.0.0"
           }
         },
         "commander": {
@@ -22970,8 +22967,8 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         },
         "mississippi": {
@@ -22979,16 +22976,16 @@
           "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
           "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
           "requires": {
-            "concat-stream": "^1.5.0",
-            "duplexify": "^3.4.2",
-            "end-of-stream": "^1.1.0",
-            "flush-write-stream": "^1.0.0",
-            "from2": "^2.1.0",
-            "parallel-transform": "^1.1.0",
-            "pump": "^2.0.1",
-            "pumpify": "^1.3.3",
-            "stream-each": "^1.1.0",
-            "through2": "^2.0.0"
+            "concat-stream": "1.6.2",
+            "duplexify": "3.7.1",
+            "end-of-stream": "1.4.1",
+            "flush-write-stream": "1.1.0",
+            "from2": "2.3.0",
+            "parallel-transform": "1.1.0",
+            "pump": "2.0.1",
+            "pumpify": "1.5.1",
+            "stream-each": "1.2.3",
+            "through2": "2.0.5"
           }
         },
         "pump": {
@@ -22996,8 +22993,8 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         },
         "schema-utils": {
@@ -23005,8 +23002,8 @@
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
           "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
           "requires": {
-            "ajv": "^6.1.0",
-            "ajv-keywords": "^3.1.0"
+            "ajv": "6.8.1",
+            "ajv-keywords": "3.3.0"
           }
         },
         "source-map": {
@@ -23019,7 +23016,7 @@
           "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
           "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
           "requires": {
-            "safe-buffer": "^5.1.1"
+            "safe-buffer": "5.1.2"
           }
         },
         "uglify-es": {
@@ -23027,8 +23024,8 @@
           "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
           "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
           "requires": {
-            "commander": "~2.13.0",
-            "source-map": "~0.6.1"
+            "commander": "2.13.0",
+            "source-map": "0.6.1"
           }
         }
       }
@@ -23043,8 +23040,8 @@
       "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
       "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
       "requires": {
-        "unicode-canonical-property-names-ecmascript": "^1.0.4",
-        "unicode-property-aliases-ecmascript": "^1.0.4"
+        "unicode-canonical-property-names-ecmascript": "1.0.4",
+        "unicode-property-aliases-ecmascript": "1.0.4"
       }
     },
     "unicode-match-property-value-ecmascript": {
@@ -23062,10 +23059,10 @@
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -23073,7 +23070,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "set-value": {
@@ -23081,10 +23078,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -23104,7 +23101,7 @@
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
       "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "requires": {
-        "unique-slug": "^2.0.0"
+        "unique-slug": "2.0.1"
       }
     },
     "unique-slug": {
@@ -23112,7 +23109,7 @@
       "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
       "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
       "requires": {
-        "imurmurhash": "^0.1.4"
+        "imurmurhash": "0.1.4"
       }
     },
     "universalify": {
@@ -23135,8 +23132,8 @@
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -23144,9 +23141,9 @@
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -23181,7 +23178,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "urix": {
@@ -23210,9 +23207,9 @@
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.1.1.tgz",
       "integrity": "sha512-vugEeXjyYFBCUOpX+ZuaunbK3QXMKaQ3zUnRfIpRBlGkY7QizCnzyyn2ASfcxsvyU3ef+CJppVywnl3Kgf13Gg==",
       "requires": {
-        "loader-utils": "^1.1.0",
-        "mime": "^2.0.3",
-        "schema-utils": "^1.0.0"
+        "loader-utils": "1.2.3",
+        "mime": "2.4.0",
+        "schema-utils": "1.0.0"
       }
     },
     "url-parse": {
@@ -23220,8 +23217,8 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
       "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
       "requires": {
-        "querystringify": "^2.0.0",
-        "requires-port": "^1.0.0"
+        "querystringify": "2.1.0",
+        "requires-port": "1.0.0"
       }
     },
     "use": {
@@ -23252,8 +23249,8 @@
       "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
+        "define-properties": "1.1.3",
+        "object.getownpropertydescriptors": "2.0.3"
       }
     },
     "utila": {
@@ -23276,8 +23273,8 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.1.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "value-equal": {
@@ -23300,9 +23297,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "vm-browserify": {
@@ -23318,7 +23315,7 @@
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
       "requires": {
-        "browser-process-hrtime": "^0.1.2"
+        "browser-process-hrtime": "0.1.3"
       }
     },
     "w3c-xmlserializer": {
@@ -23326,9 +23323,9 @@
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.0.1.tgz",
       "integrity": "sha512-XZGI1OH/OLQr/NaJhhPmzhngwcAnZDLytsvXnRmlYeRkmbb0I7sqFFA22erq4WQR0sUu17ZSQOAV9mFwCqKRNg==",
       "requires": {
-        "domexception": "^1.0.1",
-        "webidl-conversions": "^4.0.2",
-        "xml-name-validator": "^3.0.0"
+        "domexception": "1.0.1",
+        "webidl-conversions": "4.0.2",
+        "xml-name-validator": "3.0.0"
       }
     },
     "walker": {
@@ -23336,7 +23333,7 @@
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
-        "makeerror": "1.0.x"
+        "makeerror": "1.0.11"
       }
     },
     "warning": {
@@ -23344,7 +23341,7 @@
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.2.tgz",
       "integrity": "sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==",
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "watch": {
@@ -23352,8 +23349,8 @@
       "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
       "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
       "requires": {
-        "exec-sh": "^0.2.0",
-        "minimist": "^1.2.0"
+        "exec-sh": "0.2.2",
+        "minimist": "1.2.0"
       }
     },
     "watchpack": {
@@ -23361,9 +23358,9 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
       "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
       "requires": {
-        "chokidar": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "chokidar": "2.0.4",
+        "graceful-fs": "4.1.15",
+        "neo-async": "2.6.0"
       }
     },
     "wbuf": {
@@ -23371,7 +23368,7 @@
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "requires": {
-        "minimalistic-assert": "^1.0.0"
+        "minimalistic-assert": "1.0.1"
       }
     },
     "web3": {
@@ -23380,10 +23377,10 @@
       "integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
       "requires": {
         "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-        "crypto-js": "^3.1.4",
-        "utf8": "^2.1.1",
-        "xhr2-cookies": "^1.1.0",
-        "xmlhttprequest": "*"
+        "crypto-js": "3.1.8",
+        "utf8": "2.1.2",
+        "xhr2-cookies": "1.1.0",
+        "xmlhttprequest": "1.8.0"
       }
     },
     "web3-provider-engine": {
@@ -23391,26 +23388,26 @@
       "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-14.1.0.tgz",
       "integrity": "sha512-vGZtqhSUzGTiMGhJXNnB/aRDlrPZLhLnBZ2NPArkZtr8XSrwg9m08tw4+PuWg5za0TJuoE/vuPQc501HddZZWw==",
       "requires": {
-        "async": "^2.5.0",
-        "backoff": "^2.5.0",
-        "clone": "^2.0.0",
-        "cross-fetch": "^2.1.0",
-        "eth-block-tracker": "^3.0.0",
-        "eth-json-rpc-infura": "^3.1.0",
-        "eth-sig-util": "^1.4.2",
-        "ethereumjs-block": "^1.2.2",
-        "ethereumjs-tx": "^1.2.0",
-        "ethereumjs-util": "^5.1.5",
-        "ethereumjs-vm": "^2.3.4",
-        "json-rpc-error": "^2.0.0",
-        "json-stable-stringify": "^1.0.1",
-        "promise-to-callback": "^1.0.0",
-        "readable-stream": "^2.2.9",
-        "request": "^2.85.0",
-        "semaphore": "^1.0.3",
-        "ws": "^5.1.1",
-        "xhr": "^2.2.0",
-        "xtend": "^4.0.1"
+        "async": "2.6.1",
+        "backoff": "2.5.0",
+        "clone": "2.1.2",
+        "cross-fetch": "2.2.3",
+        "eth-block-tracker": "3.0.1",
+        "eth-json-rpc-infura": "3.2.0",
+        "eth-sig-util": "1.4.2",
+        "ethereumjs-block": "1.7.1",
+        "ethereumjs-tx": "1.3.7",
+        "ethereumjs-util": "5.2.0",
+        "ethereumjs-vm": "2.5.1",
+        "json-rpc-error": "2.0.0",
+        "json-stable-stringify": "1.0.1",
+        "promise-to-callback": "1.0.0",
+        "readable-stream": "2.3.6",
+        "request": "2.88.0",
+        "semaphore": "1.1.0",
+        "ws": "5.2.2",
+        "xhr": "2.5.0",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "async": {
@@ -23418,7 +23415,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
-            "lodash": "^4.17.10"
+            "lodash": "4.17.11"
           }
         },
         "ws": {
@@ -23426,7 +23423,7 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
           "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
           "requires": {
-            "async-limiter": "~1.0.0"
+            "async-limiter": "1.0.0"
           }
         }
       }
@@ -23445,26 +23442,26 @@
         "@webassemblyjs/helper-module-context": "1.7.6",
         "@webassemblyjs/wasm-edit": "1.7.6",
         "@webassemblyjs/wasm-parser": "1.7.6",
-        "acorn": "^5.6.2",
-        "acorn-dynamic-import": "^3.0.0",
-        "ajv": "^6.1.0",
-        "ajv-keywords": "^3.1.0",
-        "chrome-trace-event": "^1.0.0",
-        "enhanced-resolve": "^4.1.0",
-        "eslint-scope": "^4.0.0",
-        "json-parse-better-errors": "^1.0.2",
-        "loader-runner": "^2.3.0",
-        "loader-utils": "^1.1.0",
-        "memory-fs": "~0.4.1",
-        "micromatch": "^3.1.8",
-        "mkdirp": "~0.5.0",
-        "neo-async": "^2.5.0",
-        "node-libs-browser": "^2.0.0",
-        "schema-utils": "^0.4.4",
-        "tapable": "^1.1.0",
-        "uglifyjs-webpack-plugin": "^1.2.4",
-        "watchpack": "^1.5.0",
-        "webpack-sources": "^1.2.0"
+        "acorn": "5.7.3",
+        "acorn-dynamic-import": "3.0.0",
+        "ajv": "6.8.1",
+        "ajv-keywords": "3.3.0",
+        "chrome-trace-event": "1.0.0",
+        "enhanced-resolve": "4.1.0",
+        "eslint-scope": "4.0.0",
+        "json-parse-better-errors": "1.0.2",
+        "loader-runner": "2.4.0",
+        "loader-utils": "1.2.3",
+        "memory-fs": "0.4.1",
+        "micromatch": "3.1.10",
+        "mkdirp": "0.5.1",
+        "neo-async": "2.6.0",
+        "node-libs-browser": "2.2.0",
+        "schema-utils": "0.4.7",
+        "tapable": "1.1.1",
+        "uglifyjs-webpack-plugin": "1.3.0",
+        "watchpack": "1.6.0",
+        "webpack-sources": "1.3.0"
       },
       "dependencies": {
         "acorn": {
@@ -23487,16 +23484,16 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.3",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -23504,7 +23501,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -23522,8 +23519,8 @@
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
           "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
           "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
+            "esrecurse": "4.2.1",
+            "estraverse": "4.2.0"
           }
         },
         "expand-brackets": {
@@ -23531,13 +23528,13 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -23545,7 +23542,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -23553,7 +23550,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -23561,7 +23558,7 @@
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -23569,7 +23566,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -23579,7 +23576,7 @@
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -23587,7 +23584,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -23597,9 +23594,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -23614,14 +23611,14 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -23629,7 +23626,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -23637,7 +23634,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -23647,10 +23644,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -23658,7 +23655,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -23668,7 +23665,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -23676,7 +23673,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -23684,9 +23681,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-number": {
@@ -23694,7 +23691,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -23702,7 +23699,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -23717,19 +23714,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "ms": {
@@ -23742,8 +23739,8 @@
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
           "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
           "requires": {
-            "ajv": "^6.1.0",
-            "ajv-keywords": "^3.1.0"
+            "ajv": "6.8.1",
+            "ajv-keywords": "3.3.0"
           }
         }
       }
@@ -23753,10 +23750,10 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.4.0.tgz",
       "integrity": "sha512-Q9Iyc0X9dP9bAsYskAVJ/hmIZZQwf/3Sy4xCAZgL5cUkjZmUZLt4l5HpbST/Pdgjn3u6pE7u5OdGd1apgzRujA==",
       "requires": {
-        "memory-fs": "~0.4.1",
-        "mime": "^2.3.1",
-        "range-parser": "^1.0.3",
-        "webpack-log": "^2.0.0"
+        "memory-fs": "0.4.1",
+        "mime": "2.4.0",
+        "range-parser": "1.2.0",
+        "webpack-log": "2.0.0"
       }
     },
     "webpack-dev-server": {
@@ -23765,34 +23762,34 @@
       "integrity": "sha512-mGXDgz5SlTxcF3hUpfC8hrQ11yhAttuUQWf1Wmb+6zo3x6rb7b9mIfuQvAPLdfDRCGRGvakBWHdHOa0I9p/EVQ==",
       "requires": {
         "ansi-html": "0.0.7",
-        "bonjour": "^3.5.0",
-        "chokidar": "^2.0.0",
-        "compression": "^1.5.2",
-        "connect-history-api-fallback": "^1.3.0",
-        "debug": "^3.1.0",
-        "del": "^3.0.0",
-        "express": "^4.16.2",
-        "html-entities": "^1.2.0",
-        "http-proxy-middleware": "~0.18.0",
-        "import-local": "^2.0.0",
-        "internal-ip": "^3.0.1",
-        "ip": "^1.1.5",
-        "killable": "^1.0.0",
-        "loglevel": "^1.4.1",
-        "opn": "^5.1.0",
-        "portfinder": "^1.0.9",
-        "schema-utils": "^1.0.0",
-        "selfsigned": "^1.9.1",
-        "semver": "^5.6.0",
-        "serve-index": "^1.7.2",
+        "bonjour": "3.5.0",
+        "chokidar": "2.0.4",
+        "compression": "1.7.3",
+        "connect-history-api-fallback": "1.6.0",
+        "debug": "3.2.6",
+        "del": "3.0.0",
+        "express": "4.16.4",
+        "html-entities": "1.2.1",
+        "http-proxy-middleware": "0.18.0",
+        "import-local": "2.0.0",
+        "internal-ip": "3.0.1",
+        "ip": "1.1.5",
+        "killable": "1.0.1",
+        "loglevel": "1.6.1",
+        "opn": "5.4.0",
+        "portfinder": "1.0.20",
+        "schema-utils": "1.0.0",
+        "selfsigned": "1.10.4",
+        "semver": "5.6.0",
+        "serve-index": "1.9.1",
         "sockjs": "0.3.19",
         "sockjs-client": "1.3.0",
-        "spdy": "^4.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^5.1.0",
-        "url": "^0.11.0",
+        "spdy": "4.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "5.5.0",
+        "url": "0.11.0",
         "webpack-dev-middleware": "3.4.0",
-        "webpack-log": "^2.0.0",
+        "webpack-log": "2.0.0",
         "yargs": "12.0.2"
       },
       "dependencies": {
@@ -23811,7 +23808,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "decamelize": {
@@ -23827,7 +23824,7 @@
           "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
           "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
           "requires": {
-            "original": "^1.0.0"
+            "original": "1.0.2"
           }
         },
         "import-local": {
@@ -23835,8 +23832,8 @@
           "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
           "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
           "requires": {
-            "pkg-dir": "^3.0.0",
-            "resolve-cwd": "^2.0.0"
+            "pkg-dir": "3.0.0",
+            "resolve-cwd": "2.0.0"
           }
         },
         "pkg-dir": {
@@ -23844,7 +23841,7 @@
           "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
           "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
           "requires": {
-            "find-up": "^3.0.0"
+            "find-up": "3.0.0"
           }
         },
         "sockjs-client": {
@@ -23852,12 +23849,12 @@
           "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz",
           "integrity": "sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==",
           "requires": {
-            "debug": "^3.2.5",
-            "eventsource": "^1.0.7",
-            "faye-websocket": "~0.11.1",
-            "inherits": "^2.0.3",
-            "json3": "^3.3.2",
-            "url-parse": "^1.4.3"
+            "debug": "3.2.6",
+            "eventsource": "1.0.7",
+            "faye-websocket": "0.11.1",
+            "inherits": "2.0.3",
+            "json3": "3.3.2",
+            "url-parse": "1.4.4"
           }
         },
         "strip-ansi": {
@@ -23865,7 +23862,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "yargs": {
@@ -23873,18 +23870,18 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
           "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^2.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^3.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1 || ^4.0.0",
-            "yargs-parser": "^10.1.0"
+            "cliui": "4.1.0",
+            "decamelize": "2.0.0",
+            "find-up": "3.0.0",
+            "get-caller-file": "1.0.3",
+            "os-locale": "3.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "4.0.0",
+            "yargs-parser": "10.1.0"
           }
         },
         "yargs-parser": {
@@ -23892,7 +23889,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
           "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -23902,8 +23899,8 @@
       "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
       "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
       "requires": {
-        "ansi-colors": "^3.0.0",
-        "uuid": "^3.3.2"
+        "ansi-colors": "3.2.3",
+        "uuid": "3.3.2"
       }
     },
     "webpack-manifest-plugin": {
@@ -23911,9 +23908,9 @@
       "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-2.0.4.tgz",
       "integrity": "sha512-nejhOHexXDBKQOj/5v5IZSfCeTO3x1Dt1RZEcGfBSul891X/eLIcIVH31gwxPDdsi2Z8LKKFGpM4w9+oTBOSCg==",
       "requires": {
-        "fs-extra": "^7.0.0",
-        "lodash": ">=3.5 <5",
-        "tapable": "^1.0.0"
+        "fs-extra": "7.0.0",
+        "lodash": "4.17.11",
+        "tapable": "1.1.1"
       }
     },
     "webpack-sources": {
@@ -23921,8 +23918,8 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
       "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
       "requires": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
+        "source-list-map": "2.0.1",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -23937,8 +23934,8 @@
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "requires": {
-        "http-parser-js": ">=0.4.0",
-        "websocket-extensions": ">=0.1.1"
+        "http-parser-js": "0.5.0",
+        "websocket-extensions": "0.1.3"
       }
     },
     "websocket-extensions": {
@@ -23969,9 +23966,9 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
       "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
       }
     },
     "which": {
@@ -23979,7 +23976,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -24002,7 +23999,7 @@
       "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-3.6.3.tgz",
       "integrity": "sha512-ypLo0B6dces4gSpaslmDg5wuoUWrHHVJfFWwl1udvSylLdXvnrfhFfriCS42SNEe5lsZtcNZF27W/SMzBlva7Q==",
       "requires": {
-        "workbox-core": "^3.6.3"
+        "workbox-core": "3.6.3"
       }
     },
     "workbox-broadcast-cache-update": {
@@ -24010,7 +24007,7 @@
       "resolved": "https://registry.npmjs.org/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-3.6.3.tgz",
       "integrity": "sha512-pJl4lbClQcvp0SyTiEw0zLSsVYE1RDlCPtpKnpMjxFtu8lCFTAEuVyzxp9w7GF4/b3P4h5nyQ+q7V9mIR7YzGg==",
       "requires": {
-        "workbox-core": "^3.6.3"
+        "workbox-core": "3.6.3"
       }
     },
     "workbox-build": {
@@ -24018,28 +24015,28 @@
       "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-3.6.3.tgz",
       "integrity": "sha512-w0clZ/pVjL8VXy6GfthefxpEXs0T8uiRuopZSFVQ8ovfbH6c6kUpEh6DcYwm/Y6dyWPiCucdyAZotgjz+nRz8g==",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "common-tags": "^1.4.0",
-        "fs-extra": "^4.0.2",
-        "glob": "^7.1.2",
-        "joi": "^11.1.1",
-        "lodash.template": "^4.4.0",
-        "pretty-bytes": "^4.0.2",
-        "stringify-object": "^3.2.2",
-        "strip-comments": "^1.0.2",
-        "workbox-background-sync": "^3.6.3",
-        "workbox-broadcast-cache-update": "^3.6.3",
-        "workbox-cache-expiration": "^3.6.3",
-        "workbox-cacheable-response": "^3.6.3",
-        "workbox-core": "^3.6.3",
-        "workbox-google-analytics": "^3.6.3",
-        "workbox-navigation-preload": "^3.6.3",
-        "workbox-precaching": "^3.6.3",
-        "workbox-range-requests": "^3.6.3",
-        "workbox-routing": "^3.6.3",
-        "workbox-strategies": "^3.6.3",
-        "workbox-streams": "^3.6.3",
-        "workbox-sw": "^3.6.3"
+        "babel-runtime": "6.26.0",
+        "common-tags": "1.8.0",
+        "fs-extra": "4.0.3",
+        "glob": "7.1.3",
+        "joi": "11.4.0",
+        "lodash.template": "4.4.0",
+        "pretty-bytes": "4.0.2",
+        "stringify-object": "3.3.0",
+        "strip-comments": "1.0.2",
+        "workbox-background-sync": "3.6.3",
+        "workbox-broadcast-cache-update": "3.6.3",
+        "workbox-cache-expiration": "3.6.3",
+        "workbox-cacheable-response": "3.6.3",
+        "workbox-core": "3.6.3",
+        "workbox-google-analytics": "3.6.3",
+        "workbox-navigation-preload": "3.6.3",
+        "workbox-precaching": "3.6.3",
+        "workbox-range-requests": "3.6.3",
+        "workbox-routing": "3.6.3",
+        "workbox-strategies": "3.6.3",
+        "workbox-streams": "3.6.3",
+        "workbox-sw": "3.6.3"
       },
       "dependencies": {
         "fs-extra": {
@@ -24047,9 +24044,9 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
           "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "graceful-fs": "4.1.15",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.2"
           }
         },
         "jsonfile": {
@@ -24057,7 +24054,7 @@
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.1.15"
           }
         }
       }
@@ -24067,7 +24064,7 @@
       "resolved": "https://registry.npmjs.org/workbox-cache-expiration/-/workbox-cache-expiration-3.6.3.tgz",
       "integrity": "sha512-+ECNph/6doYx89oopO/UolYdDmQtGUgo8KCgluwBF/RieyA1ZOFKfrSiNjztxOrGJoyBB7raTIOlEEwZ1LaHoA==",
       "requires": {
-        "workbox-core": "^3.6.3"
+        "workbox-core": "3.6.3"
       }
     },
     "workbox-cacheable-response": {
@@ -24075,7 +24072,7 @@
       "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-3.6.3.tgz",
       "integrity": "sha512-QpmbGA9SLcA7fklBLm06C4zFg577Dt8u3QgLM0eMnnbaVv3rhm4vbmDpBkyTqvgK/Ly8MBDQzlXDtUCswQwqqg==",
       "requires": {
-        "workbox-core": "^3.6.3"
+        "workbox-core": "3.6.3"
       }
     },
     "workbox-core": {
@@ -24088,10 +24085,10 @@
       "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-3.6.3.tgz",
       "integrity": "sha512-RQBUo/6SXtIaQTRFj4RQZ9e1gAl7D8oS5S+Hi173Kk70/BgJjzPwXpC5A249Jv5YfkCOLMQCeF9A27BiD0b0ig==",
       "requires": {
-        "workbox-background-sync": "^3.6.3",
-        "workbox-core": "^3.6.3",
-        "workbox-routing": "^3.6.3",
-        "workbox-strategies": "^3.6.3"
+        "workbox-background-sync": "3.6.3",
+        "workbox-core": "3.6.3",
+        "workbox-routing": "3.6.3",
+        "workbox-strategies": "3.6.3"
       }
     },
     "workbox-navigation-preload": {
@@ -24099,7 +24096,7 @@
       "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-3.6.3.tgz",
       "integrity": "sha512-dd26xTX16DUu0i+MhqZK/jQXgfIitu0yATM4jhRXEmpMqQ4MxEeNvl2CgjDMOHBnCVMax+CFZQWwxMx/X/PqCw==",
       "requires": {
-        "workbox-core": "^3.6.3"
+        "workbox-core": "3.6.3"
       }
     },
     "workbox-precaching": {
@@ -24107,7 +24104,7 @@
       "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-3.6.3.tgz",
       "integrity": "sha512-aBqT66BuMFviPTW6IpccZZHzpA8xzvZU2OM1AdhmSlYDXOJyb1+Z6blVD7z2Q8VNtV1UVwQIdImIX+hH3C3PIw==",
       "requires": {
-        "workbox-core": "^3.6.3"
+        "workbox-core": "3.6.3"
       }
     },
     "workbox-range-requests": {
@@ -24115,7 +24112,7 @@
       "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-3.6.3.tgz",
       "integrity": "sha512-R+yLWQy7D9aRF9yJ3QzwYnGFnGDhMUij4jVBUVtkl67oaVoP1ymZ81AfCmfZro2kpPRI+vmNMfxxW531cqdx8A==",
       "requires": {
-        "workbox-core": "^3.6.3"
+        "workbox-core": "3.6.3"
       }
     },
     "workbox-routing": {
@@ -24123,7 +24120,7 @@
       "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-3.6.3.tgz",
       "integrity": "sha512-bX20i95OKXXQovXhFOViOK63HYmXvsIwZXKWbSpVeKToxMrp0G/6LZXnhg82ijj/S5yhKNRf9LeGDzaqxzAwMQ==",
       "requires": {
-        "workbox-core": "^3.6.3"
+        "workbox-core": "3.6.3"
       }
     },
     "workbox-strategies": {
@@ -24131,7 +24128,7 @@
       "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-3.6.3.tgz",
       "integrity": "sha512-Pg5eulqeKet2y8j73Yw6xTgLdElktcWExGkzDVCGqfV9JCvnGuEpz5eVsCIK70+k4oJcBCin9qEg3g3CwEIH3g==",
       "requires": {
-        "workbox-core": "^3.6.3"
+        "workbox-core": "3.6.3"
       }
     },
     "workbox-streams": {
@@ -24139,7 +24136,7 @@
       "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-3.6.3.tgz",
       "integrity": "sha512-rqDuS4duj+3aZUYI1LsrD2t9hHOjwPqnUIfrXSOxSVjVn83W2MisDF2Bj+dFUZv4GalL9xqErcFW++9gH+Z27w==",
       "requires": {
-        "workbox-core": "^3.6.3"
+        "workbox-core": "3.6.3"
       }
     },
     "workbox-sw": {
@@ -24152,9 +24149,9 @@
       "resolved": "https://registry.npmjs.org/workbox-webpack-plugin/-/workbox-webpack-plugin-3.6.3.tgz",
       "integrity": "sha512-RwmKjc7HFHUFHoOlKoZUq9349u0QN3F8W5tZZU0vc1qsBZDINWXRiIBCAKvo/Njgay5sWz7z4I2adnyTo97qIQ==",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "json-stable-stringify": "^1.0.1",
-        "workbox-build": "^3.6.3"
+        "babel-runtime": "6.26.0",
+        "json-stable-stringify": "1.0.1",
+        "workbox-build": "3.6.3"
       }
     },
     "worker-farm": {
@@ -24162,7 +24159,7 @@
       "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
       "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
       "requires": {
-        "errno": "~0.1.7"
+        "errno": "0.1.7"
       }
     },
     "wrap-ansi": {
@@ -24170,8 +24167,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -24184,7 +24181,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -24192,9 +24189,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-ansi": {
@@ -24202,7 +24199,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         }
       }
@@ -24217,7 +24214,7 @@
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "write-file-atomic": {
@@ -24225,9 +24222,9 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
       "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "4.1.15",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
       }
     },
     "ws": {
@@ -24235,7 +24232,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.3.tgz",
       "integrity": "sha512-tbSxiT+qJI223AP4iLfQbkbxkwdFcneYinM2+x46Gx2wgvbaOMO36czfdfVUBRTHvzAMRhDd98sA5d/BuWbQdg==",
       "requires": {
-        "async-limiter": "~1.0.0"
+        "async-limiter": "1.0.0"
       }
     },
     "xhr": {
@@ -24243,10 +24240,10 @@
       "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
       "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
       "requires": {
-        "global": "~4.3.0",
-        "is-function": "^1.0.1",
-        "parse-headers": "^2.0.0",
-        "xtend": "^4.0.0"
+        "global": "4.3.2",
+        "is-function": "1.0.1",
+        "parse-headers": "2.0.1",
+        "xtend": "4.0.1"
       }
     },
     "xhr2-cookies": {
@@ -24254,7 +24251,7 @@
       "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
       "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
       "requires": {
-        "cookiejar": "^2.1.1"
+        "cookiejar": "2.1.2"
       }
     },
     "xml-name-validator": {
@@ -24297,18 +24294,18 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
       "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
       "requires": {
-        "cliui": "^4.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^3.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1 || ^4.0.0",
-        "yargs-parser": "^11.1.1"
+        "cliui": "4.1.0",
+        "decamelize": "1.2.0",
+        "find-up": "3.0.0",
+        "get-caller-file": "1.0.3",
+        "os-locale": "3.1.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "4.0.0",
+        "yargs-parser": "11.1.1"
       }
     },
     "yargs-parser": {
@@ -24316,8 +24313,8 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
       "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
       "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
+        "camelcase": "5.0.0",
+        "decamelize": "1.2.0"
       }
     }
   }

--- a/src/components/EditorPage/EditorPage.css
+++ b/src/components/EditorPage/EditorPage.css
@@ -12,7 +12,7 @@
 .toolbar > div {
   position: absolute;
   bottom: 14px;
-  z-index: var(--prewiew-z-index);
+  z-index: var(--preview-z-index);
   display: flex;
   align-items: center;
 }

--- a/src/components/Modals/ShortcutsModal/ShortcutsModal.tsx
+++ b/src/components/Modals/ShortcutsModal/ShortcutsModal.tsx
@@ -74,6 +74,15 @@ export default class ShortcutsModal extends React.PureComponent<Props> {
               </div>
 
               <div className="shortcut">
+                <div className="name">{t('shortcuts_modal.basic_controls.reset')}</div>
+                <div className="keybinding">
+                  <Chip text={this.getMainShortcutKey()} />
+                  <span className="plus">+</span>
+                  <Chip text="s" />
+                </div>
+              </div>
+
+              <div className="shortcut">
                 <div className="name">{t('shortcuts_modal.basic_controls.delete')}</div>
                 <div className="keybinding">
                   <Chip text="Delete" />
@@ -112,14 +121,14 @@ export default class ShortcutsModal extends React.PureComponent<Props> {
               <div className="shortcut">
                 <div className="name">{t('shortcuts_modal.edit_controls.move')}</div>
                 <div className="keybinding">
-                  <Chip text="m" />
+                  <Chip text="w" />
                 </div>
               </div>
 
               <div className="shortcut">
                 <div className="name">{t('shortcuts_modal.edit_controls.rotate')}</div>
                 <div className="keybinding">
-                  <Chip text="r" />
+                  <Chip text="e" />
                 </div>
               </div>
             </div>

--- a/src/components/Modals/ShortcutsModal/ShortcutsModal.tsx
+++ b/src/components/Modals/ShortcutsModal/ShortcutsModal.tsx
@@ -67,8 +67,6 @@ export default class ShortcutsModal extends React.PureComponent<Props> {
               <div className="shortcut">
                 <div className="name">{t('shortcuts_modal.basic_controls.duplicate')}</div>
                 <div className="keybinding">
-                  <Chip text={this.getMainShortcutKey()} />
-                  <span className="plus">+</span>
                   <Chip text="d" />
                 </div>
               </div>
@@ -76,8 +74,6 @@ export default class ShortcutsModal extends React.PureComponent<Props> {
               <div className="shortcut">
                 <div className="name">{t('shortcuts_modal.basic_controls.reset')}</div>
                 <div className="keybinding">
-                  <Chip text={this.getMainShortcutKey()} />
-                  <span className="plus">+</span>
                   <Chip text="s" />
                 </div>
               </div>

--- a/src/components/Preview/Preview.css
+++ b/src/components/Preview/Preview.css
@@ -15,7 +15,9 @@
 }
 
 .Preview > .overlay {
+  position: absolute;
   width: 100%;
   height: 100%;
   background: var(--preview-background);
+  z-index: var(--preview-z-index);
 }

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -3,7 +3,6 @@ import { Loader } from 'decentraland-ui'
 
 import { EditorWindow, Props, State } from './Preview.types'
 import './Preview.css'
-import { isLoading } from 'modules/project/selectors'
 
 const editorWindow = window as EditorWindow
 

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -31,6 +31,7 @@ export default class Preview extends React.Component<Props, State> {
   }
 
   render() {
+    const { isLoading } = this.props
     return (
       <div className="Preview" id="preview-viewport" ref={this.canvas}>
         {isLoading && (

--- a/src/components/Preview/Preview.types.ts
+++ b/src/components/Preview/Preview.types.ts
@@ -1,6 +1,7 @@
 import { Dispatch } from 'redux'
 import { Vector3 } from 'modules/common/types'
 import { UpdateEditorAction, SetEditorReadyAction, OpenEditorAction, openEditor } from 'modules/editor/actions'
+import { Gizmo } from 'modules/editor/types'
 
 export type Editor = {
   initEngine: () => Promise<void>
@@ -16,6 +17,7 @@ export type Editor = {
   setCameraRotation: (alpha: number) => void
   resetCameraZoom: () => void
   setCameraPosition: (position: Vector3) => void
+  selectGizmo: (gizmo: Gizmo) => void
 }
 
 export type EditorWindow = typeof window & {

--- a/src/components/SideBar/SideBar.container.tsx
+++ b/src/components/SideBar/SideBar.container.tsx
@@ -2,7 +2,7 @@ import { connect } from 'react-redux'
 
 import { RootState, Vector3 } from 'modules/common/types'
 import { getCategories } from 'modules/ui/sidebar/selectors'
-import { addAsset } from 'modules/scene/actions'
+import { addItem } from 'modules/scene/actions'
 import { AssetResource } from 'modules/asset/types'
 import { isLoading } from 'modules/assetPack/selectors'
 import { MapStateProps, MapDispatchProps, MapDispatch } from './SideBar.types'
@@ -14,7 +14,7 @@ const mapState = (state: RootState): MapStateProps => ({
 })
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
-  onAddAsset: (asset: AssetResource, position: Vector3) => dispatch(addAsset(asset, position))
+  onAddItem: (asset: AssetResource, position: Vector3) => dispatch(addItem(asset, position))
 })
 
 export default connect(

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -10,7 +10,7 @@ import './SideBar.css'
 export default class SideBar extends React.PureComponent<Props> {
   handleOnClick = (asset: Asset) => {
     // TODO: Using getPosition here is for demostration purposes, we'll always add assets on the same position once we have a camera
-    this.props.onAddAsset(asset, getRandomPosition())
+    this.props.onAddItem(asset, getRandomPosition())
   }
 
   renderItemDrawer() {

--- a/src/components/SideBar/SideBar.types.tsx
+++ b/src/components/SideBar/SideBar.types.tsx
@@ -1,14 +1,14 @@
 import { Dispatch } from 'redux'
 
 import { Category } from 'modules/ui/sidebar/types'
-import { addAsset, AddAssetAction } from 'modules/scene/actions'
+import { addItem, AddItemAction } from 'modules/scene/actions'
 
 export type Props = {
   categories?: Category[]
   isLoading?: boolean
-  onAddAsset: typeof addAsset
+  onAddItem: typeof addItem
 }
 
 export type MapStateProps = Pick<Props, 'categories' | 'isLoading'>
-export type MapDispatchProps = Pick<Props, 'onAddAsset'>
-export type MapDispatch = Dispatch<AddAssetAction>
+export type MapDispatchProps = Pick<Props, 'onAddItem'>
+export type MapDispatch = Dispatch<AddItemAction>

--- a/src/components/TopBar/TopBar.container.ts
+++ b/src/components/TopBar/TopBar.container.ts
@@ -3,26 +3,27 @@ import { openModal } from 'decentraland-dapps/dist/modules/modal/actions'
 
 import { RootState } from 'modules/common/types'
 import { getCurrentProject } from 'modules/project/selectors'
-import { getEditorMode, isPreviewing, isSidebarOpen, getSelectedEntityId } from 'modules/editor/selectors'
-import { setMode, togglePreview, toggleSidebar, editorUndo } from 'modules/editor/actions'
-import { hasHistory } from 'modules/scene/selectors'
 import { MapStateProps, MapDispatchProps, MapDispatch } from './TopBar.types'
+import { getGizmo, isPreviewing, isSidebarOpen, getSelectedEntityId } from 'modules/editor/selectors'
+import { setGizmo, togglePreview, toggleSidebar } from 'modules/editor/actions'
+import { resetItem, duplicateItem, deleteItem } from 'modules/scene/actions'
 import TopBar from './TopBar'
 
 const mapState = (state: RootState): MapStateProps => ({
   currentProject: getCurrentProject(state),
-  mode: getEditorMode(state),
+  gizmo: getGizmo(state),
   isPreviewing: isPreviewing(state),
   isSidebarOpen: isSidebarOpen(state),
-  hasHistory: hasHistory(state),
   selectedEntityId: getSelectedEntityId(state)
 })
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
-  onSetMode: mode => dispatch(setMode(mode)),
+  onSetGizmo: gizmo => dispatch(setGizmo(gizmo)),
   onTogglePreview: enabled => dispatch(togglePreview(enabled)),
   onToggleSidebar: enabled => dispatch(toggleSidebar(enabled)),
-  onUndo: () => dispatch(editorUndo()),
+  onReset: () => dispatch(resetItem()),
+  onDuplicate: () => dispatch(duplicateItem()),
+  onDelete: () => dispatch(deleteItem()),
   onOpenModal: (name: string) => dispatch(openModal(name))
 })
 

--- a/src/components/TopBar/TopBar.css
+++ b/src/components/TopBar/TopBar.css
@@ -23,6 +23,10 @@
   justify-content: flex-end;
 }
 
+.TopBar .middle-column .editor-actions {
+  display: flex;
+}
+
 .TopBar .middle-column .editor-modes {
   display: flex;
   margin-right: 32px;

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -7,16 +7,17 @@ import { locations } from 'routing/locations'
 import Chip from 'components/Chip'
 import { Props } from './TopBar.types'
 import './TopBar.css'
+import { Gizmo } from 'modules/editor/types'
 
 export default class TopBar extends React.PureComponent<Props> {
   handleMoveMode = () => {
-    const { onSetMode } = this.props
-    onSetMode('move')
+    const { onSetGizmo } = this.props
+    onSetGizmo(Gizmo.MOVE)
   }
 
   handleRotateMode = () => {
-    const { onSetMode } = this.props
-    onSetMode('rotate')
+    const { onSetGizmo } = this.props
+    onSetGizmo(Gizmo.ROTATE)
   }
 
   handleTogglePreview = () => {
@@ -34,7 +35,7 @@ export default class TopBar extends React.PureComponent<Props> {
   }
 
   render() {
-    const { currentProject, mode, isPreviewing, isSidebarOpen, hasHistory, selectedEntityId, onUndo } = this.props
+    const { currentProject, gizmo, isPreviewing, isSidebarOpen, selectedEntityId, onReset, onDelete, onDuplicate } = this.props
     return (
       <Grid className="TopBar">
         <Grid.Column mobile={4} tablet={4} computer={4} className="left-column" verticalAlign="middle">
@@ -47,13 +48,15 @@ export default class TopBar extends React.PureComponent<Props> {
         </Grid.Column>
         <Grid.Column mobile={6} tablet={6} computer={7} className="middle-column">
           <Grid.Row>
-            <span className="editor-modes">
-              <Chip icon="move" isActive={mode === 'move'} onClick={this.handleMoveMode} />
-              <Chip icon="rotate" isActive={mode === 'rotate'} onClick={this.handleRotateMode} />
-            </span>
-            <Chip icon="undo" isDisabled={!hasHistory} onClick={onUndo} />
-            <Chip icon="duplicate" isDisabled={!selectedEntityId} />
-            <Chip icon="delete" isDisabled={!selectedEntityId} />
+            <div className="editor-actions">
+              <span className="editor-modes">
+                <Chip icon="move" isActive={gizmo === Gizmo.MOVE} onClick={this.handleMoveMode} />
+                <Chip icon="rotate" isActive={gizmo === Gizmo.ROTATE} onClick={this.handleRotateMode} />
+              </span>
+              <Chip icon="undo" isDisabled={!selectedEntityId} onClick={onReset} />
+              <Chip icon="duplicate" isDisabled={!selectedEntityId} onClick={onDuplicate} />
+              <Chip icon="delete" isDisabled={!selectedEntityId} onClick={onDelete} />
+            </div>
           </Grid.Row>
         </Grid.Column>
         <Grid.Column mobile={6} tablet={6} computer={5} className="right-column">

--- a/src/components/TopBar/TopBar.types.ts
+++ b/src/components/TopBar/TopBar.types.ts
@@ -2,32 +2,45 @@ import { Dispatch } from 'redux'
 import { openModal, OpenModalAction } from 'decentraland-dapps/dist/modules/modal/actions'
 
 import { Project } from 'modules/project/types'
-import { EditorMode } from 'modules/editor/types'
+import { Gizmo } from 'modules/editor/types'
 import {
-  setMode,
+  setGizmo,
   togglePreview,
   toggleSidebar,
   SetModeAction,
   TogglePreviewAction,
   ToggleSidebarAction,
-  editorUndo,
   EditorUndoAction
 } from 'modules/editor/actions'
+import { resetItem, duplicateItem, deleteItem, ResetItemAction, DuplicateItemAction, DeleteItemAction } from 'modules/scene/actions'
 
 export type Props = {
   currentProject?: Project
-  mode: EditorMode
+  gizmo: Gizmo
   isPreviewing: boolean
   isSidebarOpen: boolean
-  hasHistory: boolean
   selectedEntityId: string | null
-  onSetMode: typeof setMode
+  onSetGizmo: typeof setGizmo
   onTogglePreview: typeof togglePreview
   onToggleSidebar: typeof toggleSidebar
-  onUndo: typeof editorUndo
+  onReset: typeof resetItem
+  onDuplicate: typeof duplicateItem
+  onDelete: typeof deleteItem
   onOpenModal: typeof openModal
 }
 
-export type MapStateProps = Pick<Props, 'currentProject' | 'mode' | 'isPreviewing' | 'isSidebarOpen' | 'selectedEntityId' | 'hasHistory'>
-export type MapDispatchProps = Pick<Props, 'onSetMode' | 'onTogglePreview' | 'onToggleSidebar' | 'onUndo' | 'onOpenModal'>
-export type MapDispatch = Dispatch<SetModeAction | TogglePreviewAction | ToggleSidebarAction | EditorUndoAction | OpenModalAction>
+export type MapStateProps = Pick<Props, 'currentProject' | 'gizmo' | 'isPreviewing' | 'isSidebarOpen' | 'selectedEntityId'>
+export type MapDispatchProps = Pick<
+  Props,
+  'onSetGizmo' | 'onTogglePreview' | 'onToggleSidebar' | 'onReset' | 'onDuplicate' | 'onDelete' | 'onOpenModal'
+>
+export type MapDispatch = Dispatch<
+  | SetModeAction
+  | TogglePreviewAction
+  | ToggleSidebarAction
+  | EditorUndoAction
+  | ResetItemAction
+  | DuplicateItemAction
+  | DeleteItemAction
+  | OpenModalAction
+>

--- a/src/components/TopBar/TopBar.types.ts
+++ b/src/components/TopBar/TopBar.types.ts
@@ -7,7 +7,7 @@ import {
   setGizmo,
   togglePreview,
   toggleSidebar,
-  SetModeAction,
+  SetGizmoAction,
   TogglePreviewAction,
   ToggleSidebarAction,
   EditorUndoAction
@@ -35,7 +35,7 @@ export type MapDispatchProps = Pick<
   'onSetGizmo' | 'onTogglePreview' | 'onToggleSidebar' | 'onReset' | 'onDuplicate' | 'onDelete' | 'onOpenModal'
 >
 export type MapDispatch = Dispatch<
-  | SetModeAction
+  | SetGizmoAction
   | TogglePreviewAction
   | ToggleSidebarAction
   | EditorUndoAction

--- a/src/components/ViewPort/ViewPort.css
+++ b/src/components/ViewPort/ViewPort.css
@@ -5,7 +5,7 @@
   width: 40px;
   height: 40px;
   background: #0004;
-  z-index: var(--prewiew-z-index);
+  z-index: var(--preview-z-index);
   border-radius: 100%;
   cursor: pointer;
   display: flex;

--- a/src/modules/common/store.ts
+++ b/src/modules/common/store.ts
@@ -9,7 +9,7 @@ import { createStorageMiddleware } from 'decentraland-dapps/dist/modules/storage
 import { createAnalyticsMiddleware } from 'decentraland-dapps/dist/modules/analytics/middleware'
 
 import { scenarioMiddleware, eventEmitter } from 'scenarios/helpers/middleware'
-import { CREATE_SCENE, PROVISION_SCENE, UPDATE_TRANSFORM } from 'modules/scene/actions'
+import { CREATE_SCENE, PROVISION_SCENE } from 'modules/scene/actions'
 import { CREATE_PROJECT } from 'modules/project/actions'
 import { EDITOR_UNDO, EDITOR_REDO } from 'modules/editor/actions'
 import { createRootReducer } from './reducer'
@@ -30,7 +30,7 @@ const loggerMiddleware = createLogger({
 const { storageMiddleware, loadStorageMiddleware } = createStorageMiddleware({
   storageKey: env.get('REACT_APP_LOCAL_STORAGE_KEY'),
   paths: ['project', ['scene', 'present']] as any,
-  actions: [CREATE_PROJECT, CREATE_SCENE, PROVISION_SCENE, EDITOR_UNDO, EDITOR_REDO, UPDATE_TRANSFORM]
+  actions: [CREATE_PROJECT, CREATE_SCENE, PROVISION_SCENE, EDITOR_UNDO, EDITOR_REDO]
 })
 const analyticsMiddleware = createAnalyticsMiddleware(env.get('REACT_APP_SEGMENT_API_KEY'))
 

--- a/src/modules/editor/actions.ts
+++ b/src/modules/editor/actions.ts
@@ -1,7 +1,7 @@
 import { action } from 'typesafe-actions'
 import { SceneDefinition } from 'modules/scene/types'
 import { AssetMappings } from 'modules/asset/types'
-import { EditorMode } from './types'
+import { Gizmo } from './types'
 
 // Bind keyboard shortcuts
 
@@ -55,13 +55,13 @@ export const editorRedo = () => action(EDITOR_REDO, {})
 export type EditorUndoAction = ReturnType<typeof editorUndo>
 export type EditorRedoAction = ReturnType<typeof editorRedo>
 
-// Set Mode
+// Set Gizmo
 
-export const SET_MODE = 'Set mode'
+export const SET_GIZMO = 'Set gizmo'
 
-export const setMode = (mode: EditorMode) => action(SET_MODE, { mode })
+export const setGizmo = (gizmo: Gizmo) => action(SET_GIZMO, { gizmo })
 
-export type SetModeAction = ReturnType<typeof setMode>
+export type SetModeAction = ReturnType<typeof setGizmo>
 
 // Toggle Play
 

--- a/src/modules/editor/actions.ts
+++ b/src/modules/editor/actions.ts
@@ -61,7 +61,7 @@ export const SET_GIZMO = 'Set gizmo'
 
 export const setGizmo = (gizmo: Gizmo) => action(SET_GIZMO, { gizmo })
 
-export type SetModeAction = ReturnType<typeof setGizmo>
+export type SetGizmoAction = ReturnType<typeof setGizmo>
 
 // Toggle Play
 

--- a/src/modules/editor/reducer.ts
+++ b/src/modules/editor/reducer.ts
@@ -44,10 +44,10 @@ export type EditorReducerAction =
 export const editorReducer = (state = INITIAL_STATE, action: EditorReducerAction): EditorState => {
   switch (action.type) {
     case SET_GIZMO: {
-      const { gizmo: mode } = action.payload
+      const { gizmo } = action.payload
       return {
         ...state,
-        gizmo: mode
+        gizmo
       }
     }
     case TOGGLE_PREVIEW: {

--- a/src/modules/editor/reducer.ts
+++ b/src/modules/editor/reducer.ts
@@ -2,7 +2,7 @@ import {
   SetModeAction,
   TogglePreviewAction,
   ToggleSidebarAction,
-  SET_MODE,
+  SET_GIZMO,
   TOGGLE_PREVIEW,
   TOGGLE_SIDEBAR,
   SelectEntityAction,
@@ -14,10 +14,10 @@ import {
   SetEditorReadyAction,
   CloseEditorAction
 } from './actions'
-import { EditorMode } from './types'
+import { Gizmo } from './types'
 
 export type EditorState = {
-  mode: EditorMode
+  gizmo: Gizmo
   preview: boolean
   sidebar: boolean
   selectedEntityId: string | null
@@ -25,7 +25,7 @@ export type EditorState = {
 }
 
 const INITIAL_STATE: EditorState = {
-  mode: 'move',
+  gizmo: Gizmo.MOVE,
   preview: false,
   sidebar: true,
   selectedEntityId: null,
@@ -43,11 +43,11 @@ export type EditorReducerAction =
 
 export const editorReducer = (state = INITIAL_STATE, action: EditorReducerAction): EditorState => {
   switch (action.type) {
-    case SET_MODE: {
-      const { mode } = action.payload
+    case SET_GIZMO: {
+      const { gizmo: mode } = action.payload
       return {
         ...state,
-        mode
+        gizmo: mode
       }
     }
     case TOGGLE_PREVIEW: {

--- a/src/modules/editor/reducer.ts
+++ b/src/modules/editor/reducer.ts
@@ -1,5 +1,5 @@
 import {
-  SetModeAction,
+  SetGizmoAction,
   TogglePreviewAction,
   ToggleSidebarAction,
   SET_GIZMO,
@@ -33,7 +33,7 @@ const INITIAL_STATE: EditorState = {
 }
 
 export type EditorReducerAction =
-  | SetModeAction
+  | SetGizmoAction
   | TogglePreviewAction
   | ToggleSidebarAction
   | SelectEntityAction

--- a/src/modules/editor/sagas.ts
+++ b/src/modules/editor/sagas.ts
@@ -9,7 +9,7 @@ import {
   UNBIND_KEYBOARD_SHORTCUTS,
   CLOSE_EDITOR,
   SET_GIZMO,
-  SetModeAction,
+  SetGizmoAction,
   TogglePreviewAction,
   TOGGLE_PREVIEW,
   TOGGLE_SIDEBAR,
@@ -222,7 +222,7 @@ function* handleCloseEditor() {
   yield call(() => editorWindow.editor.off('metrics', handleMetricsChange))
 }
 
-function* handleSetGizmo(action: SetModeAction) {
+function* handleSetGizmo(action: SetGizmoAction) {
   yield call(() => editorWindow.editor.selectGizmo(action.payload.gizmo))
 }
 

--- a/src/modules/editor/sagas.ts
+++ b/src/modules/editor/sagas.ts
@@ -29,7 +29,15 @@ import {
   EDITOR_REDO,
   EDITOR_UNDO
 } from 'modules/editor/actions'
-import { PROVISION_SCENE, updateMetrics, updateTransform, resetItem, duplicateItem, deleteItem } from 'modules/scene/actions'
+import {
+  PROVISION_SCENE,
+  updateMetrics,
+  updateTransform,
+  resetItem,
+  duplicateItem,
+  deleteItem,
+  DUPLICATE_ITEM
+} from 'modules/scene/actions'
 import { bindKeyboardShortcuts, unbindKeyboardShortcuts } from 'modules/keyboard/actions'
 import { getCurrentScene, getEntityComponentByType } from 'modules/scene/selectors'
 import { getAssetMappings } from 'modules/asset/selectors'
@@ -61,6 +69,7 @@ export function* editorSaga() {
   yield takeLatest(ZOOM_IN, handleZoomIn)
   yield takeLatest(ZOOM_OUT, handleZoomOut)
   yield takeLatest(RESET_CAMERA, handleResetCamera)
+  yield takeLatest(DUPLICATE_ITEM, handleDuplicateItem)
 }
 
 function* handleBindEditorKeyboardShortcuts() {
@@ -216,6 +225,10 @@ function* handleOpenEditor() {
 
   // Spawns the assets
   yield handleRenderScene()
+}
+
+function* handleDuplicateItem() {
+  yield call(() => editorWindow.editor.selectGizmo(Gizmo.NONE))
 }
 
 function* handleCloseEditor() {

--- a/src/modules/editor/sagas.ts
+++ b/src/modules/editor/sagas.ts
@@ -85,11 +85,11 @@ function getKeyboardShortcuts(): KeyboardShortcut[] {
       callback: () => store.dispatch(setGizmo(Gizmo.ROTATE))
     },
     {
-      combination: ['command+s'],
+      combination: ['s'],
       callback: () => store.dispatch(resetItem())
     },
     {
-      combination: ['command+d'],
+      combination: ['d'],
       callback: () => store.dispatch(duplicateItem())
     },
     {

--- a/src/modules/editor/selectors.ts
+++ b/src/modules/editor/selectors.ts
@@ -1,7 +1,7 @@
 import { RootState } from 'modules/common/types'
 
 export const getState = (state: RootState) => state.editor
-export const getEditorMode = (state: RootState) => getState(state).mode
+export const getGizmo = (state: RootState) => getState(state).gizmo
 export const isSidebarOpen = (state: RootState) => getState(state).sidebar
 export const isPreviewing = (state: RootState) => getState(state).preview
 export const getSelectedEntityId = (state: RootState) => getState(state).selectedEntityId

--- a/src/modules/editor/types.ts
+++ b/src/modules/editor/types.ts
@@ -1,4 +1,9 @@
-export type EditorMode = 'move' | 'rotate' | 'select'
+export enum Gizmo {
+  MOVE = 'MOVE',
+  ROTATE = 'ROTATE',
+  SCALE = 'SCALE',
+  NONE = 'NONE'
+}
 
 export type EditorScene = {
   baseUrl: string

--- a/src/modules/scene/actions.ts
+++ b/src/modules/scene/actions.ts
@@ -1,7 +1,7 @@
 import { action } from 'typesafe-actions'
 import { Vector3 } from 'modules/common/types'
 import { AssetResource } from 'modules/asset/types'
-import { SceneDefinition, EntityDefinition, AnyComponent, SceneMetrics, ComponentType, ComponentData } from './types'
+import { SceneDefinition, SceneMetrics, ComponentType, ComponentData } from './types'
 
 // Create scene
 
@@ -13,17 +13,17 @@ export type CreateSceneAction = ReturnType<typeof createScene>
 
 // Spawn items
 
-export const ADD_ASSET = 'Add asset'
+export const ADD_ITEM = 'Add item'
 
-export const addAsset = (asset: AssetResource, position: Vector3) => action(ADD_ASSET, { asset, position })
+export const addItem = (asset: AssetResource, position: Vector3) => action(ADD_ITEM, { asset, position })
 
-export type AddAssetAction = ReturnType<typeof addAsset>
+export type AddItemAction = ReturnType<typeof addItem>
 
-// Provision a scene: add components and entities
+// Provision a scene
 
 export const PROVISION_SCENE = 'Provision scene'
 
-export const provisionScene = (sceneId: string, components: AnyComponent[], entities: EntityDefinition[]) =>
+export const provisionScene = (sceneId: string, components: SceneDefinition['components'], entities: SceneDefinition['entities']) =>
   action(PROVISION_SCENE, { sceneId, components, entities })
 
 export type ProvisionSceneAction = ReturnType<typeof provisionScene>
@@ -44,4 +44,28 @@ export const UPDATE_TRANSFORM = 'Update transform'
 export const updateTransform = (sceneId: string, componentId: string, data: ComponentData[ComponentType.Transform]) =>
   action(UPDATE_TRANSFORM, { sceneId, componentId, data })
 
-export type UpdateComponentAction = ReturnType<typeof updateTransform>
+export type UpdateTransfromAction = ReturnType<typeof updateTransform>
+
+// Reset object
+
+export const RESET_ITEM = 'Reset item'
+
+export const resetItem = () => action(RESET_ITEM, {})
+
+export type ResetItemAction = ReturnType<typeof resetItem>
+
+// Duplicate object
+
+export const DUPLICATE_ITEM = 'Duplicate item'
+
+export const duplicateItem = () => action(DUPLICATE_ITEM, {})
+
+export type DuplicateItemAction = ReturnType<typeof duplicateItem>
+
+// Delete object
+
+export const DELETE_ITEM = 'Delete item'
+
+export const deleteItem = () => action(DELETE_ITEM, {})
+
+export type DeleteItemAction = ReturnType<typeof deleteItem>

--- a/src/modules/scene/actions.ts
+++ b/src/modules/scene/actions.ts
@@ -46,7 +46,7 @@ export const updateTransform = (sceneId: string, componentId: string, data: Comp
 
 export type UpdateTransfromAction = ReturnType<typeof updateTransform>
 
-// Reset object
+// Reset item
 
 export const RESET_ITEM = 'Reset item'
 
@@ -54,7 +54,7 @@ export const resetItem = () => action(RESET_ITEM, {})
 
 export type ResetItemAction = ReturnType<typeof resetItem>
 
-// Duplicate object
+// Duplicate item
 
 export const DUPLICATE_ITEM = 'Duplicate item'
 
@@ -62,7 +62,7 @@ export const duplicateItem = () => action(DUPLICATE_ITEM, {})
 
 export type DuplicateItemAction = ReturnType<typeof duplicateItem>
 
-// Delete object
+// Delete item
 
 export const DELETE_ITEM = 'Delete item'
 

--- a/src/modules/scene/reducer.ts
+++ b/src/modules/scene/reducer.ts
@@ -9,8 +9,7 @@ import {
   PROVISION_SCENE,
   UpdateMetricsAction,
   UPDATE_METRICS,
-  UPDATE_TRANSFORM,
-  UpdateComponentAction
+  UpdateTransfromAction
 } from 'modules/scene/actions'
 
 export type SceneState = {
@@ -20,7 +19,7 @@ export type SceneState = {
 }
 export type UndoableSceneState = StateWithHistory<SceneState>
 
-export type SceneReducerAction = CreateSceneAction | ProvisionSceneAction | UpdateMetricsAction | UpdateComponentAction
+export type SceneReducerAction = CreateSceneAction | ProvisionSceneAction | UpdateMetricsAction | UpdateTransfromAction
 
 const INITIAL_STATE: SceneState = {
   data: {},
@@ -45,8 +44,6 @@ const baseSceneReducer = (state: SceneState = INITIAL_STATE, action: SceneReduce
 
     case PROVISION_SCENE: {
       const { sceneId, components, entities } = action.payload
-      const currentComponents = { ...state.data[sceneId].components }
-      const currentEntities = { ...state.data[sceneId].entities }
 
       return {
         ...state,
@@ -54,8 +51,8 @@ const baseSceneReducer = (state: SceneState = INITIAL_STATE, action: SceneReduce
           ...state.data,
           [sceneId]: {
             ...state.data[sceneId],
-            components: components.reduce((acc, components) => ({ ...acc, [components.id]: { ...components } }), currentComponents),
-            entities: entities.reduce((acc, entity) => ({ ...acc, [entity.id]: { ...entity } }), currentEntities)
+            components,
+            entities
           }
         }
       }
@@ -82,28 +79,6 @@ const baseSceneReducer = (state: SceneState = INITIAL_STATE, action: SceneReduce
       }
     }
 
-    case UPDATE_TRANSFORM: {
-      const { sceneId, componentId, data } = action.payload
-      return {
-        ...state,
-        data: {
-          ...state.data,
-          [sceneId]: {
-            ...state.data[sceneId],
-            components: {
-              ...state.data[sceneId].components,
-              [componentId]: {
-                ...state.data[sceneId].components[componentId],
-                data: {
-                  ...data
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
     default:
       return state
   }
@@ -116,7 +91,7 @@ const undoableReducer = undoable<SceneState>(baseSceneReducer as any, {
   undoType: EDITOR_UNDO,
   redoType: EDITOR_REDO,
   clearHistoryType: CLOSE_EDITOR,
-  filter: includeAction([CREATE_SCENE, PROVISION_SCENE, UPDATE_TRANSFORM])
+  filter: includeAction([CREATE_SCENE, PROVISION_SCENE])
 })
 
 export const sceneReducer = (state: any, action: any) => {

--- a/src/modules/scene/sagas.ts
+++ b/src/modules/scene/sagas.ts
@@ -1,44 +1,170 @@
 import uuidv4 from 'uuid/v4'
 import { takeLatest, put, select } from 'redux-saga/effects'
-import { ADD_ASSET, AddAssetAction, provisionScene } from 'modules/scene/actions'
-import { getGLTFId, getCurrentScene } from 'modules/scene/selectors'
-import { ComponentType, AnyComponent, EntityDefinition } from 'modules/scene/types'
+import {
+  ADD_ITEM,
+  AddItemAction,
+  provisionScene,
+  RESET_ITEM,
+  ResetItemAction,
+  UPDATE_TRANSFORM,
+  UpdateTransfromAction,
+  DUPLICATE_ITEM,
+  DELETE_ITEM,
+  DuplicateItemAction,
+  DeleteItemAction
+} from 'modules/scene/actions'
+import { getGLTFId, getCurrentScene, getEntityComponentByType, getEntityComponents } from 'modules/scene/selectors'
+import { ComponentType, SceneDefinition, ComponentDefinition } from 'modules/scene/types'
+import { getSelectedEntityId } from 'modules/editor/selectors'
+import { selectEntity, unselectEntity } from 'modules/editor/actions'
 
 export function* sceneSaga() {
-  yield takeLatest(ADD_ASSET, handleAddAsset)
+  yield takeLatest(ADD_ITEM, handleAddItem)
+  yield takeLatest(UPDATE_TRANSFORM, handleUpdateTransfrom)
+  yield takeLatest(RESET_ITEM, handleResetItem)
+  yield takeLatest(DUPLICATE_ITEM, handleDuplicateItem)
+  yield takeLatest(DELETE_ITEM, handleDeleteItem)
 }
 
-function* handleAddAsset(action: AddAssetAction) {
+function* handleAddItem(action: AddItemAction) {
+  const scene: SceneDefinition = yield select(getCurrentScene)
+  if (!scene) return
+
   const { asset, position } = action.payload
-  const scene = yield select(getCurrentScene)
 
   let gltfId = yield select(getGLTFId(asset.url))
-  let transformId = uuidv4()
-  const components: AnyComponent[] = []
+  const transformId = uuidv4()
+
+  const newComponents = { ...scene.components }
 
   if (!gltfId) {
-    const id = uuidv4()
-    components.push({
-      id,
+    gltfId = uuidv4()
+    newComponents[gltfId] = {
+      id: gltfId,
       type: ComponentType.GLTFShape,
       data: {
         src: asset.url
       }
-    })
-
-    gltfId = id
+    }
   }
 
-  components.push({
+  newComponents[transformId] = {
     id: transformId,
     type: ComponentType.Transform,
     data: {
       position,
       rotation: { x: 0, y: 0, z: 0, w: 1 }
     }
-  })
+  }
 
-  const entities: EntityDefinition[] = [{ id: uuidv4(), components: [gltfId, transformId] }]
+  const newEntities = { ...scene.entities }
+  const entityId = uuidv4()
+  newEntities[entityId] = { id: entityId, components: [gltfId, transformId] }
 
-  yield put(provisionScene(scene.id, components, entities))
+  yield put(provisionScene(scene.id, newComponents, newEntities))
+}
+
+function* handleUpdateTransfrom(action: UpdateTransfromAction) {
+  const scene: SceneDefinition = yield select(getCurrentScene)
+  if (!scene) return
+
+  const { componentId, data } = action.payload
+
+  const newComponents: SceneDefinition['components'] = { ...scene.components }
+  newComponents[componentId] = {
+    ...newComponents[componentId],
+    data
+  }
+
+  yield put(provisionScene(scene.id, newComponents, scene.entities))
+}
+
+function* handleResetItem(_: ResetItemAction) {
+  const scene: SceneDefinition = yield select(getCurrentScene)
+  if (!scene) return
+
+  const selectedEntityId: string | null = yield select(getSelectedEntityId)
+  if (!selectedEntityId) return
+
+  const transform: ComponentDefinition<ComponentType.Transform> | null = yield select(
+    getEntityComponentByType(selectedEntityId, ComponentType.Transform)
+  )
+  if (!transform) return
+
+  const newComponents = {
+    ...scene.components,
+    [transform.id]: {
+      ...transform,
+      data: {
+        ...transform.data,
+        rotation: { x: 0, y: 0, z: 0, w: 1 }
+      }
+    }
+  }
+
+  yield put(provisionScene(scene.id, newComponents, scene.entities))
+}
+
+function* handleDuplicateItem(_: DuplicateItemAction) {
+  const scene: SceneDefinition = yield select(getCurrentScene)
+  if (!scene) return
+
+  const selectedEntityId: string | null = yield select(getSelectedEntityId)
+  if (!selectedEntityId) return
+
+  const newComponents = { ...scene.components }
+
+  const gltfShape: ComponentDefinition<ComponentType.Transform> | null = yield select(
+    getEntityComponentByType(selectedEntityId, ComponentType.GLTFShape)
+  )
+  const transform: ComponentDefinition<ComponentType.Transform> | null = yield select(
+    getEntityComponentByType(selectedEntityId, ComponentType.Transform)
+  )
+
+  if (!gltfShape || !transform) return
+
+  const transformId = uuidv4()
+  newComponents[transformId] = {
+    id: transformId,
+    type: ComponentType.Transform,
+    data: {
+      position: {
+        x: transform.data.position.x + 1,
+        y: transform.data.position.y,
+        z: transform.data.position.z + 1
+      },
+      rotation: { x: 0, y: 0, z: 0, w: 1 }
+    }
+  }
+
+  const newEntities = { ...scene.entities }
+  const entityId = uuidv4()
+  newEntities[entityId] = { id: entityId, components: [gltfShape.id, transformId] }
+
+  yield put(selectEntity(entityId))
+  yield put(provisionScene(scene.id, newComponents, newEntities))
+}
+
+function* handleDeleteItem(_: DeleteItemAction) {
+  const scene: SceneDefinition = yield select(getCurrentScene)
+  if (!scene) return
+
+  const selectedEntityId: string | null = yield select(getSelectedEntityId)
+  if (!selectedEntityId) return
+
+  const entityComponents: Record<string, ComponentDefinition<ComponentType>> = yield select(getEntityComponents(selectedEntityId))
+  const idsToDelete = Object.values(entityComponents)
+    .filter(component => !!component)
+    .map(component => component.id)
+  const newComponents = { ...scene.components }
+
+  for (const componentId of idsToDelete) {
+    delete newComponents[componentId]
+  }
+
+  const newEntities = { ...scene.entities }
+  delete newEntities[selectedEntityId]
+
+  yield put(unselectEntity())
+  yield put(provisionScene(scene.id, newComponents, newEntities))
 }

--- a/src/modules/scene/sagas.ts
+++ b/src/modules/scene/sagas.ts
@@ -156,14 +156,18 @@ function* handleDeleteItem(_: DeleteItemAction) {
   const idsToDelete = Object.values(entityComponents)
     .filter(component => !!component)
     .map(component => component.id)
+
   const newComponents = { ...scene.components }
-
-  for (const componentId of idsToDelete) {
-    delete newComponents[componentId]
-  }
-
   const newEntities = { ...scene.entities }
   delete newEntities[selectedEntityId]
+
+  for (const componentId of idsToDelete) {
+    // check if commponentId is not used by other entities
+    if (Object.values(newEntities).some(entity => entity.components.some(id => componentId === id))) {
+      continue
+    }
+    delete newComponents[componentId]
+  }
 
   yield put(unselectEntity())
   yield put(provisionScene(scene.id, newComponents, newEntities))

--- a/src/modules/scene/selectors.ts
+++ b/src/modules/scene/selectors.ts
@@ -47,6 +47,23 @@ export const getEntityComponents = (entityId: string) =>
     }
   )
 
+export const getEntityComponentByType = <T extends ComponentType>(entityId: string, type: T) =>
+  createSelector<RootState, SceneDefinition['entities'], SceneDefinition['components'], ComponentDefinition<T> | null>(
+    getEntities,
+    getComponents,
+    (entities, components) => {
+      if (entityId && entities && entityId in entities) {
+        const componentReferences = entities[entityId].components
+        for (const componentId of componentReferences) {
+          if (components && componentId in components && components[componentId].type === type) {
+            return components[componentId] as ComponentDefinition<T>
+          }
+        }
+      }
+      return null
+    }
+  )
+
 export const getComponentByType = <T extends ComponentType>(type: T) => (state: RootState) => {
   const components = getCurrentScene(state).components
   const out: ComponentDefinition<T>[] = []

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -53,8 +53,8 @@
     },
     "edit_controls": {
       "title": "Edit controls",
-      "move": "Move object",
-      "rotate": "Rotate object"
+      "move": "Move item",
+      "rotate": "Rotate item"
     }
   }
 }

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -44,8 +44,9 @@
       "title": "Basic Controls",
       "undo": "Undo",
       "redo": "Redo",
-      "duplicate": "Duplicate object",
-      "delete": "Delete object",
+      "reset": "Reset item",
+      "duplicate": "Duplicate item",
+      "delete": "Delete item",
       "reset_camera": "Reset camera",
       "zoom_in": "Zoom in",
       "zoom_out": "Zoom out"

--- a/src/scenarios/MetricsOutOfBounds.ts
+++ b/src/scenarios/MetricsOutOfBounds.ts
@@ -2,7 +2,7 @@ import { Store } from 'redux'
 import { EventEmitter } from 'events'
 import { RootState } from 'modules/common/types'
 import { LOAD_ASSET_PACKS_SUCCESS, LoadAssetPacksSuccessAction } from 'modules/assetPack/actions'
-import { addAsset } from 'modules/scene/actions'
+import { addItem } from 'modules/scene/actions'
 import { Asset } from 'modules/asset/types'
 import { getRandomPosition } from 'modules/scene/utils'
 
@@ -24,14 +24,14 @@ export function run(store: Store<RootState>, evt: EventEmitter) {
 
       for (let index = 0; index < assetAmount - 2; index++) {
         const asset = getRandomAsset(assets)
-        store.dispatch(addAsset(asset, getRandomPosition()))
+        store.dispatch(addItem(asset, getRandomPosition()))
       }
 
       // Add an asset too high
-      store.dispatch(addAsset(assets[0], getRandomPosition({ y: 50 })))
+      store.dispatch(addItem(assets[0], getRandomPosition({ y: 50 })))
 
       // Add an asset outside the scene bounds
-      store.dispatch(addAsset(assets[0], getRandomPosition({ x: 20, z: 10 })))
+      store.dispatch(addItem(assets[0], getRandomPosition({ x: 20, z: 10 })))
     })
   })
 }

--- a/src/themes/theme.css
+++ b/src/themes/theme.css
@@ -30,7 +30,7 @@
 
   /* Preview */
   --preview-background: #38333f;
-  --prewiew-z-index: 1000;
+  --preview-z-index: 2000;
 }
 
 /* Erase separation line from navbar */


### PR DESCRIPTION
Closes #46 
Closes #57 
Closes #58 
Closes #99 

I refactored the scene actions so they are all handled by sagas and in the end they dispatch a `provisionScene` action with the whole scene. I did this so in order to have a single action that writes the scene to the app state (this is useful for undo/redo since we just have to track one action) also it makes it easier to listen for changes and send them to the `ecsScene`, we don't have to listen to several actions.

I also did some renaming: 

+ Set Mode -> Set Gizmo

+ Add Asset -> Add Item (to match all the other item-related actions like reset/duplicate/delete, also it feels more accurate since adding an asset would be adding a new model to the available ones, rather than adding an instance of that model to the scene)