### PR TITLE
fix: edit project modal

### DIFF
--- a/src/components/Modals/EditProjectModal/EditProjectModal.tsx
+++ b/src/components/Modals/EditProjectModal/EditProjectModal.tsx
@@ -12,6 +12,13 @@ export default class EditProjectModal extends React.PureComponent<Props, State> 
     description: this.props.currentProject.description
   }
 
+  componentWillReceiveProps(nextProps: Props) {
+    if (!this.props.modal.open && nextProps.modal.open) {
+      const { title, description } = nextProps.currentProject
+      this.setState({ title, description })
+    }
+  }
+
   handleOnClose = () => {
     const { modal, onClose } = this.props
     onClose(modal.name)

--- a/src/components/TopBar/TopBar.css
+++ b/src/components/TopBar/TopBar.css
@@ -71,11 +71,19 @@
 .TopBar .project-title {
   user-select: none;
   cursor: pointer;
+  display: flex;
+  align-items: center;
 }
 
 .TopBar .edit-project-icon {
   margin-left: 12px;
 }
+
+.TopBar .project-title:hover .edit-project-icon {
+  opacity: 1;
+  filter: none;
+}
+
 .TopBar .edit-project-icon:not(:hover) {
   margin-left: 12px;
   filter: saturate(0.1);

--- a/src/components/TopBar/TopBar.css
+++ b/src/components/TopBar/TopBar.css
@@ -70,6 +70,7 @@
 
 .TopBar .project-title {
   user-select: none;
+  cursor: pointer;
 }
 
 .TopBar .edit-project-icon {

--- a/src/components/TopBar/TopBar.css
+++ b/src/components/TopBar/TopBar.css
@@ -70,7 +70,6 @@
 
 .TopBar .project-title {
   user-select: none;
-  cursor: pointer;
 }
 
 .TopBar .edit-project-icon {

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -50,7 +50,9 @@ export default class TopBar extends React.PureComponent<Props> {
             </Link>
             {currentProject ? (
               <>
-                <span className="project-title">{currentProject.title}</span>
+                <span className="project-title" onClick={this.handleTitleClick}>
+                  {currentProject.title}
+                </span>
                 <OwnIcon name="edit" className="edit-project-icon" onClick={this.handleTitleClick} />
               </>
             ) : null}

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -52,8 +52,8 @@ export default class TopBar extends React.PureComponent<Props> {
               <>
                 <span className="project-title" onClick={this.handleTitleClick}>
                   {currentProject.title}
+                  <OwnIcon name="edit" className="edit-project-icon" />
                 </span>
-                <OwnIcon name="edit" className="edit-project-icon" onClick={this.handleTitleClick} />
               </>
             ) : null}
           </Header>


### PR DESCRIPTION
![kapture 2019-02-07 at 17 28 52](https://user-images.githubusercontent.com/1307029/52440820-e34bd100-2afd-11e9-920d-59cb2d3a335d.gif)

Fixes bug where props are not updated when switching projects and re-entering the modal.

Makes title clickable to open modal.