### PR TITLE
fix: prevent gizmos from being added to grounds

### DIFF
--- a/src/ecsScene/scene.ts
+++ b/src/ecsScene/scene.ts
@@ -1,10 +1,15 @@
-import { engine, GLTFShape, Transform, Entity, Gizmos, OnGizmoEvent } from 'decentraland-ecs'
+import { engine, GLTFShape, Transform, Entity, Gizmos, OnGizmoEvent, Component } from 'decentraland-ecs'
 import { DecentralandInterface } from 'decentraland-ecs/dist/decentraland/Types'
 import { EntityDefinition, AnyComponent, ComponentData, ComponentType } from 'modules/scene/types'
 
 declare var dcl: DecentralandInterface
 
+@Component('staticEntity')
+// @ts-ignore
+export class StaticEntity {}
+
 const editorComponents: Record<string, any> = {}
+const staticEntity = new StaticEntity()
 
 const gizmo = new Gizmos()
 gizmo.position = true
@@ -44,7 +49,10 @@ function handleExternalAction(message: { type: string; payload: Record<string, a
         if (message.payload.enabled) {
           entity.remove(Gizmos)
         } else {
-          entity.set(gizmo)
+          const staticEntities = engine.getComponentGroup(StaticEntity)
+          if (!staticEntities.hasEntity(entity.uuid)) {
+            entity.set(gizmo)
+          }
         }
       }
     }
@@ -93,6 +101,8 @@ function createEntities(entities: Record<string, EntityDefinition>) {
       if (!builderEntity.disableGizmos) {
         entity.set(gizmoEvent)
         entity.set(gizmo)
+      } else {
+        entity.set(staticEntity)
       }
 
       engine.addEntity(entity)


### PR DESCRIPTION
**Problem:**

When toggling the preview mode, gizmos are re-added to all entities, this makes grounds pickable and movable

**Solution:**

Create a component that marks entities as static, prevent those entities from ever getting gizmos

Closes #187 