### PR TITLE
fix: restore gizmos after exiting preview mode

### DIFF
--- a/src/ecsScene/scene.ts
+++ b/src/ecsScene/scene.ts
@@ -50,7 +50,7 @@ function handleExternalAction(message: { type: string; payload: Record<string, a
           entity.remove(Gizmos)
         } else {
           const staticEntities = engine.getComponentGroup(StaticEntity)
-          if (!staticEntities.hasEntity(entity.uuid)) {
+          if (!staticEntities.hasEntity(entity)) {
             entity.set(gizmo)
           }
         }

--- a/src/modules/editor/sagas.ts
+++ b/src/modules/editor/sagas.ts
@@ -26,7 +26,8 @@ import {
   takeScreenshot,
   unbindEditorKeyboardShortcuts,
   bindEditorKeyboardShortcuts,
-  SET_EDITOR_READY
+  SET_EDITOR_READY,
+  resetCamera
 } from 'modules/editor/actions'
 import { store } from 'modules/common/store'
 import { PROVISION_SCENE, updateMetrics, updateTransform, DUPLICATE_ITEM, DROP_ITEM, DropItemAction, addItem } from 'modules/scene/actions'
@@ -204,8 +205,12 @@ function* handleTooglePreview(action: TogglePreviewAction) {
     editor.selectGizmo(enabled ? Gizmo.NONE : gizmo)
     resizeEditor()
   })
-
-  yield put(enabled ? unbindEditorKeyboardShortcuts() : bindEditorKeyboardShortcuts())
+  if (enabled) {
+    yield put(unbindEditorKeyboardShortcuts())
+  } else {
+    yield put(bindEditorKeyboardShortcuts())
+    yield put(resetCamera())
+  }
 }
 
 function* handleToggleSidebar(_: ToggleSidebarAction) {


### PR DESCRIPTION
Closes #196