### PR TITLE
fix: prevent reporting each time props are received when more than one metric is exceeded

### DIFF
--- a/src/components/EditorPage/Metrics/Metrics.tsx
+++ b/src/components/EditorPage/Metrics/Metrics.tsx
@@ -15,7 +15,7 @@ export default class Metrics extends React.PureComponent<Props, State> {
   }
 
   analytics = getAnalytics()
-  metricExceeded: keyof SceneMetrics | null = null
+  metricsExceeded: (keyof SceneMetrics)[] = []
 
   componentWillMount() {
     document.addEventListener('click', this.handleClose)
@@ -26,19 +26,16 @@ export default class Metrics extends React.PureComponent<Props, State> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    let isMetricExceeded = false
     for (let key in nextProps.metrics) {
       const metric = key as keyof SceneMetrics
       if (nextProps.metrics[metric] > nextProps.limits[metric]) {
-        if (!this.metricExceeded || this.metricExceeded !== metric) {
-          this.metricExceeded = metric
+        if (!this.metricsExceeded.includes(metric)) {
+          this.metricsExceeded.push(metric)
           this.analytics.track('Metrics exceeded', { metric })
         }
-        isMetricExceeded = true
+      } else {
+        this.metricsExceeded = this.metricsExceeded.filter(exceeded => exceeded !== metric)
       }
-    }
-    if (!isMetricExceeded) {
-      this.metricExceeded = null
     }
   }
 


### PR DESCRIPTION
When two or more metrics where exceeded (say, `triangles` and `terxtures`) this component would report a `Metric exceeded` event on every call to `componentWillReceiveProps` (that's a lot) and it was polluting the analytics on segment.

This PR fixes that.