### PR TITLE
chore: mobile header styles

### DIFF
--- a/src/components/MobilePage/MobilePage.css
+++ b/src/components/MobilePage/MobilePage.css
@@ -18,6 +18,11 @@
   margin-top: 3%;
 }
 
+.MobilePage .title {
+  font-size: 64px;
+  user-select: none;
+}
+
 .MobilePage .ui.form .message {
   font-weight: 100;
   font-size: 16px;

--- a/src/components/MobilePage/MobilePage.tsx
+++ b/src/components/MobilePage/MobilePage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Header, Field, Button, Form } from 'decentraland-ui'
+import { Field, Button, Form } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { getLocalStorage } from 'decentraland-dapps/dist/lib/localStorage'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
@@ -48,7 +48,7 @@ export default class MobilePage extends React.PureComponent<Props, State> {
 
     return (
       <div className="MobilePage">
-        <Header size="large">{t('mobile_page.title')}</Header>
+        <h1 className="title">{t('mobile_page.title')}</h1>
         <Form onSubmit={this.handleSubmit}>
           <p className="message">{t('mobile_page.message')}</p>
 


### PR DESCRIPTION
From
<img width="453" alt="Screen Shot 2019-03-18 at 10 49 26" src="https://user-images.githubusercontent.com/1307029/54534640-8ef10800-496b-11e9-9785-af439d964998.png">

To
<img width="584" alt="Screen Shot 2019-03-18 at 10 49 19" src="https://user-images.githubusercontent.com/1307029/54534645-92848f00-496b-11e9-80cc-f2372b8511d9.png">
