### PR TITLE
chore: add count and limit to metrics exceeded event

### DIFF
--- a/src/components/EditorPage/Metrics/Metrics.tsx
+++ b/src/components/EditorPage/Metrics/Metrics.tsx
@@ -37,7 +37,7 @@ export default class Metrics extends React.PureComponent<Props, State> {
 
     for (const metric of metricsExceeded) {
       if (!this.metricsExceeded.includes(metric)) {
-        this.analytics.track('Metrics exceeded', { metric })
+        this.analytics.track('Metrics exceeded', { metric, count: metrics[metric], limit: limits[metric] })
       }
     }
     this.metricsExceeded = metricsExceeded


### PR DESCRIPTION
Closes #367 

Adds `count` and `limit` to the `Metrics Exceeded` event