### PR TITLE
feat: support for server with multiple asset packs

### DIFF
--- a/src/components/EditorPage/EditorPage.tsx
+++ b/src/components/EditorPage/EditorPage.tsx
@@ -40,6 +40,7 @@ export default class EditorPage extends React.PureComponent<Props, State> {
     }
 
     document.body.scrollTop = 0
+    document.body.classList.add('lock-scroll')
     document.body.addEventListener('mousewheel', this.handleMouseWheel)
   }
 

--- a/src/components/SideBar/ItemDrawer/ItemDrawer.css
+++ b/src/components/SideBar/ItemDrawer/ItemDrawer.css
@@ -81,6 +81,7 @@
 .ItemDrawer .ui.icon.input > i.icon.close {
   cursor: pointer;
   pointer-events: inherit;
+  color: var(--bluish-steel);
 }
 
 .ItemDrawer .search.icon {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -18,8 +18,14 @@ export class API extends BaseAPI {
     return this.request('post', `${CONTEST_URL}/entry`, { entry })
   }
 
+  async fetchAssetPacks() {
+    const data = await this.request('get', `${ASSETS_URL}`, {})
+    return data.packs // TODO: remove the .map once the server returns `title`
+      .map((assetPack: any) => ({ title: assetPack.name, ...assetPack }))
+  }
+
   fetchAssetPack(id: string) {
-    return this.request('get', `${ASSETS_URL}/${id}`, {})
+    return this.request('get', `${ASSETS_URL}/${id}.json`, {})
   }
 
   reportEmail(email: string, interest: EMAIL_INTEREST) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -20,8 +20,7 @@ export class API extends BaseAPI {
 
   async fetchAssetPacks() {
     const data = await this.request('get', `${ASSETS_URL}`, {})
-    return data.packs // TODO: remove the .map once the server returns `title`
-      .map((assetPack: any) => ({ title: assetPack.name, ...assetPack }))
+    return data.packs
   }
 
   fetchAssetPack(id: string) {

--- a/src/modules/assetPack/sagas.ts
+++ b/src/modules/assetPack/sagas.ts
@@ -1,4 +1,4 @@
-import { call, put, takeLatest } from 'redux-saga/effects'
+import { call, put, takeLatest, select } from 'redux-saga/effects'
 
 import {
   LOAD_ASSET_PACKS_REQUEST,
@@ -6,8 +6,12 @@ import {
   loadAssetPacksFailure,
   LoadAssetPacksRequestAction
 } from 'modules/assetPack/actions'
-import { RemoteAssetPack, FullAssetPack } from 'modules/assetPack/types'
+import { getData as getAssetPacks } from 'modules/assetPack/selectors'
+import { getData as getAssets } from 'modules/asset/selectors'
+import { getSelectedAssetPackIds, getAvailableAssetPackIds } from 'modules/ui/sidebar/selectors'
+import { BaseAssetPack, FullAssetPack } from 'modules/assetPack/types'
 import { api } from 'lib/api'
+import { setAvailableAssetPacks } from 'modules/ui/sidebar/actions'
 
 export function* assetPackSaga() {
   yield takeLatest(LOAD_ASSET_PACKS_REQUEST, handleLoadAssetPacks)
@@ -15,25 +19,69 @@ export function* assetPackSaga() {
 
 function* handleLoadAssetPacks(_: LoadAssetPacksRequestAction) {
   try {
-    // TODO: This should fetch a list of asset packs in the future, this is just a mock for now
-    const remoteAssetPack: RemoteAssetPack = yield call(() => api.fetchAssetPack('default-pack.json'))
-    const remoteAssetPacks = [remoteAssetPack]
+    const remoteAssetPacks: BaseAssetPack[] = yield call(() => api.fetchAssetPacks())
+
+    // Asset pack ids available last time the user visited
+    const previousAvailableAssetPackIds: ReturnType<typeof getAvailableAssetPackIds> = yield select(getAvailableAssetPackIds)
+
+    // Fresh available asset packs
+    const newAvailableAssetPackIds = remoteAssetPacks.map(assetPack => assetPack.id)
+
+    // Update the available asset packs in state
+    yield put(setAvailableAssetPacks(newAvailableAssetPackIds))
+
+    // Get user selection of asset packs
+    const selectedAssetPackIds: ReturnType<typeof getSelectedAssetPackIds> = yield select(getSelectedAssetPackIds)
+    const assetPackSelection = new Set(selectedAssetPackIds)
 
     const assetPacks: FullAssetPack[] = []
-
-    // Generate unique uuids for internal use
     for (const remoteAssetPack of remoteAssetPacks) {
-      const assetPack: FullAssetPack = {
-        ...remoteAssetPack,
-        assets: remoteAssetPack.assets.map(asset => ({
-          ...asset,
-          url: `${remoteAssetPack.id}/${asset.url}`,
-          assetPackId: remoteAssetPack.id,
-          id: asset.id
-        }))
+      // Check if the asset pack is selected
+      if (assetPackSelection.has(remoteAssetPack.id)) {
+        const assetPacksInState: ReturnType<typeof getAssetPacks> = yield select(getAssetPacks)
+        const assetPackInState = assetPacksInState[remoteAssetPack.id]
+        // Check if the asset pack not in the state or is not loaded and if so, fetch it
+        if (!assetPackInState || !assetPackInState.isLoaded) {
+          const assetPack: FullAssetPack = yield call(() => api.fetchAssetPack(remoteAssetPack.id))
+          assetPacks.push({
+            // Add the fetched asset pack and mark it as loaded
+            ...remoteAssetPack, // TODO: we can remove this once the `thumbnail` and `url` are added to the individual asset packs
+            ...assetPack,
+            isNew: false,
+            isLoaded: true,
+            assets: assetPack.assets.map(asset => ({
+              ...asset,
+              url: `${remoteAssetPack.id}/${asset.url}`,
+              assetPackId: remoteAssetPack.id,
+              id: asset.id
+            }))
+          })
+        } else {
+          // If the asset pack is already loaded use the data from state
+          const assetsInState: ReturnType<typeof getAssets> = yield select(getAssets)
+          assetPacks.push({
+            ...assetPackInState,
+            assets: assetPackInState.assets.map(assetId => assetsInState[assetId])
+          })
+        }
+      } else {
+        // If the asset pack is not selected then just add the remote asset pack and mark is as not loaded
+        assetPacks.push({
+          ...remoteAssetPack,
+          isNew: false,
+          isLoaded: false,
+          assets: []
+        })
       }
+    }
 
-      assetPacks.push(assetPack)
+    // Mark new asset packs as new
+    if (previousAvailableAssetPackIds.length > 0) {
+      // This are the asset packs the user has seen already
+      const oldAssetPacks = new Set(previousAvailableAssetPackIds)
+      for (const assetPack of assetPacks) {
+        assetPack.isNew = !oldAssetPacks.has(assetPack.id)
+      }
     }
 
     yield put(loadAssetPacksSuccess(assetPacks))

--- a/src/modules/assetPack/sagas.ts
+++ b/src/modules/assetPack/sagas.ts
@@ -14,7 +14,7 @@ import { setAvailableAssetPacks, setNewAssetPacks } from 'modules/ui/sidebar/act
 import { getCurrentProject } from 'modules/project/selectors'
 import { toggleAssetPack } from 'modules/project/actions'
 import { api } from 'lib/api'
-import { getDefualtSelection } from './utils'
+import { getDefaultSelection } from './utils'
 
 export function* assetPackSaga() {
   yield takeLatest(LOAD_ASSET_PACKS_REQUEST, handleLoadAssetPacks)
@@ -50,9 +50,9 @@ function* handleLoadAssetPacks(_: LoadAssetPacksRequestAction) {
     if (!project) {
       selectedAssetPackIds = new Set()
     } else if (project.assetPackIds && project.assetPackIds.length > 0) {
-      selectedAssetPackIds = new Set(project!.assetPackIds)
+      selectedAssetPackIds = new Set(project.assetPackIds)
     } else {
-      const defaultSelection = getDefualtSelection(remoteAssetPacks)
+      const defaultSelection = getDefaultSelection(remoteAssetPacks)
       yield put(toggleAssetPack(project, defaultSelection, true))
       selectedAssetPackIds = new Set(defaultSelection)
     }

--- a/src/modules/assetPack/types.ts
+++ b/src/modules/assetPack/types.ts
@@ -1,19 +1,18 @@
-import { Asset, BaseAsset } from 'modules/asset/types'
+import { Asset } from 'modules/asset/types'
 
-export type AssetPack = BaseAssetPack & {
-  assets: string[] // asset ids
-}
-
-export type RemoteAssetPack = BaseAssetPack & {
-  assets: BaseAsset[]
+export type BaseAssetPack = {
+  id: string
+  title: string
+  thumbnail: string
+  url: string
+  isNew: boolean
+  isLoaded: boolean
 }
 
 export type FullAssetPack = BaseAssetPack & {
   assets: Asset[]
 }
 
-type BaseAssetPack = {
-  id: string
-  version: number
-  title: string
+export type AssetPack = BaseAssetPack & {
+  assets: string[] // asset ids
 }

--- a/src/modules/assetPack/types.ts
+++ b/src/modules/assetPack/types.ts
@@ -5,7 +5,6 @@ export type BaseAssetPack = {
   title: string
   thumbnail: string
   url: string
-  isNew: boolean
   isLoaded: boolean
 }
 

--- a/src/modules/assetPack/utils.ts
+++ b/src/modules/assetPack/utils.ts
@@ -1,5 +1,5 @@
 import { BaseAssetPack } from './types'
 
-export function getDefualtSelection(assetPacks: BaseAssetPack[]) {
+export function getDefaultSelection(assetPacks: BaseAssetPack[]) {
   return assetPacks.map(assetPack => assetPack.id)
 }

--- a/src/modules/assetPack/utils.ts
+++ b/src/modules/assetPack/utils.ts
@@ -1,0 +1,5 @@
+import { BaseAssetPack } from './types'
+
+export function getDefualtSelection(assetPacks: BaseAssetPack[]) {
+  return assetPacks.map(assetPack => assetPack.id)
+}

--- a/src/modules/common/store.ts
+++ b/src/modules/common/store.ts
@@ -33,7 +33,14 @@ const loggerMiddleware = createLogger({
 const { storageMiddleware, loadStorageMiddleware } = createStorageMiddleware({
   migrations,
   storageKey: env.get('REACT_APP_LOCAL_STORAGE_KEY'),
-  paths: ['project', ['scene', 'present'], 'contest', 'user'],
+  paths: [
+    'project',
+    ['scene', 'present'],
+    'contest',
+    'user',
+    ['ui', 'sidebar', 'selectedAssetPackIds'],
+    ['ui', 'sidebar', 'availableAssetPackIds']
+  ],
   actions: [
     CREATE_PROJECT,
     CREATE_SCENE,

--- a/src/modules/common/store.ts
+++ b/src/modules/common/store.ts
@@ -34,14 +34,7 @@ const loggerMiddleware = createLogger({
 const { storageMiddleware, loadStorageMiddleware } = createStorageMiddleware({
   migrations,
   storageKey: env.get('REACT_APP_LOCAL_STORAGE_KEY'),
-  paths: [
-    'project',
-    ['scene', 'present'],
-    'contest',
-    'user',
-    ['ui', 'sidebar', 'selectedAssetPackIds'],
-    ['ui', 'sidebar', 'availableAssetPackIds']
-  ],
+  paths: ['project', ['scene', 'present'], 'contest', 'user', ['ui', 'sidebar', 'availableAssetPackIds']],
   actions: [
     CREATE_PROJECT,
     CREATE_SCENE,

--- a/src/modules/common/store.ts
+++ b/src/modules/common/store.ts
@@ -10,10 +10,11 @@ import { createAnalyticsMiddleware } from 'decentraland-dapps/dist/modules/analy
 
 import { scenarioMiddleware, eventEmitter } from 'scenarios/helpers/middleware'
 import { PROVISION_SCENE, CREATE_SCENE } from 'modules/scene/actions'
-import { CREATE_PROJECT, DELETE_PROJECT, EDIT_PROJECT_SUCCESS } from 'modules/project/actions'
+import { CREATE_PROJECT, DELETE_PROJECT, EDIT_PROJECT_SUCCESS, TOGGLE_ASSET_PACK } from 'modules/project/actions'
 import { EDITOR_UNDO, EDITOR_REDO } from 'modules/editor/actions'
 import { ACCEPT_TERMS, SUBMIT_PROJECT_SUCCESS } from 'modules/contest/actions'
 import { SET_USER_ID, SET_USER_EMAIL } from 'modules/user/actions'
+import { SET_AVAILABLE_ASSET_PACKS } from 'modules/ui/sidebar/actions'
 import { createRootReducer } from './reducer'
 import { rootSaga } from './sagas'
 import { migrations } from './migrations'
@@ -52,7 +53,9 @@ const { storageMiddleware, loadStorageMiddleware } = createStorageMiddleware({
     ACCEPT_TERMS,
     SUBMIT_PROJECT_SUCCESS,
     SET_USER_ID,
-    SET_USER_EMAIL
+    SET_USER_EMAIL,
+    TOGGLE_ASSET_PACK,
+    SET_AVAILABLE_ASSET_PACKS
   ]
 })
 const analyticsMiddleware = createAnalyticsMiddleware(env.get('REACT_APP_SEGMENT_API_KEY'))

--- a/src/modules/project/actions.ts
+++ b/src/modules/project/actions.ts
@@ -78,3 +78,12 @@ export const IMPORT_PROJECT = 'Import project'
 export const importProject = (projects: SaveFile[]) => action(IMPORT_PROJECT, { projects })
 
 export type ImportProjectAction = ReturnType<typeof importProject>
+
+// Toggle Asset Pack
+
+export const TOGGLE_ASSET_PACK = 'Toggle asset pack'
+
+export const toggleAssetPack = (project: Project, idOrArray: string | string[], enabled: boolean) =>
+  action(TOGGLE_ASSET_PACK, { project, assetPackIds: typeof idOrArray === 'string' ? [idOrArray] : idOrArray, enabled })
+
+export type ToggleAssetPackAction = ReturnType<typeof toggleAssetPack>

--- a/src/modules/project/reducer.ts
+++ b/src/modules/project/reducer.ts
@@ -102,7 +102,8 @@ export const projectReducer = (state = INITIAL_STATE, action: ProjectReducerActi
     case TOGGLE_ASSET_PACK: {
       const { project, assetPackIds, enabled } = action.payload
       // remove toggled asset packs
-      let newAssetPackIds = (project.assetPackIds || []).filter(id => !assetPackIds.includes(id))
+      const oldAssetPackIds = project.assetPackIds || []
+      let newAssetPackIds = oldAssetPackIds.filter(id => assetPackIds.indexOf(id) === -1) // !includes
       if (enabled) {
         // if enabled, add the new ones
         newAssetPackIds = [...newAssetPackIds, ...assetPackIds]

--- a/src/modules/project/reducer.ts
+++ b/src/modules/project/reducer.ts
@@ -13,7 +13,9 @@ import {
   DeleteProjectAction,
   DELETE_PROJECT,
   EDIT_PROJECT_THUMBNAIL,
-  EditProjectThumbnailAction
+  EditProjectThumbnailAction,
+  ToggleAssetPackAction,
+  TOGGLE_ASSET_PACK
 } from 'modules/project/actions'
 
 export type ProjectState = {
@@ -35,6 +37,7 @@ export type ProjectReducerAction =
   | EditProjectFailureAction
   | EditProjectThumbnailAction
   | DeleteProjectAction
+  | ToggleAssetPackAction
 
 export const projectReducer = (state = INITIAL_STATE, action: ProjectReducerAction): ProjectState => {
   switch (action.type) {
@@ -95,6 +98,25 @@ export const projectReducer = (state = INITIAL_STATE, action: ProjectReducerActi
       }
       delete newState.data[project.id]
       return newState
+    }
+    case TOGGLE_ASSET_PACK: {
+      const { project, assetPackIds, enabled } = action.payload
+      // remove toggled asset packs
+      let newAssetPackIds = (project.assetPackIds || []).filter(id => !assetPackIds.includes(id))
+      if (enabled) {
+        // if enabled, add the new ones
+        newAssetPackIds = [...newAssetPackIds, ...assetPackIds]
+      }
+      return {
+        ...state,
+        data: {
+          ...state.data,
+          [project.id]: {
+            ...state.data[project.id],
+            assetPackIds: newAssetPackIds
+          }
+        }
+      }
     }
     default:
       return state

--- a/src/modules/project/sagas.ts
+++ b/src/modules/project/sagas.ts
@@ -76,6 +76,7 @@ function* handleCreateProjectFromTemplate(action: CreateProjectFromTemplateActio
     title: 'New scene',
     description: '',
     thumbnail: '',
+    assetPackIds: [],
     layout,
     parcels: getBlockchainParcelsFromLayout(layout),
     sceneId: scene.id,

--- a/src/modules/project/types.ts
+++ b/src/modules/project/types.ts
@@ -7,6 +7,7 @@ export type Project = {
   thumbnail: string
   sceneId: string
   layout: Layout
+  assetPackIds: string[]
   parcels?: { x: number; y: number }[] // Blockchain parcels
   ownerEmail?: string
   createdAt: number

--- a/src/modules/ui/sidebar/actions.ts
+++ b/src/modules/ui/sidebar/actions.ts
@@ -1,14 +1,6 @@
 import { action } from 'typesafe-actions'
 import { SidebarView } from './types'
 
-// Select Asset Pack
-
-export const TOGGLE_ASSET_PACK = 'Toggle asset pack'
-
-export const toggleAssetPack = (assetPackId: string, enabled: boolean) => action(TOGGLE_ASSET_PACK, { assetPackId, enabled })
-
-export type ToggleAssetPackAction = ReturnType<typeof toggleAssetPack>
-
 // Search Assets
 
 export const SEARCH_ASSETS = 'Search assets'

--- a/src/modules/ui/sidebar/actions.ts
+++ b/src/modules/ui/sidebar/actions.ts
@@ -3,11 +3,11 @@ import { SidebarView } from './types'
 
 // Select Asset Pack
 
-export const SELECT_ASSET_PACK = 'Select asset pack'
+export const TOGGLE_ASSET_PACK = 'Toggle asset pack'
 
-export const selectAssetPack = (assetPackId: string | null) => action(SELECT_ASSET_PACK, { assetPackId })
+export const toggleAssetPack = (assetPackId: string, enabled: boolean) => action(TOGGLE_ASSET_PACK, { assetPackId, enabled })
 
-export type SelectAssetPackAction = ReturnType<typeof selectAssetPack>
+export type ToggleAssetPackAction = ReturnType<typeof toggleAssetPack>
 
 // Search Assets
 
@@ -32,3 +32,11 @@ export const SET_SIDEBAR_VIEW = 'Set sidebar view'
 export const setSidebarView = (view: SidebarView) => action(SET_SIDEBAR_VIEW, { view })
 
 export type SetSidebarViewAction = ReturnType<typeof setSidebarView>
+
+// Set available asset packs
+
+export const SET_AVAILABLE_ASSET_PACKS = 'Set available asset packs'
+
+export const setAvailableAssetPacks = (assetPackIds: string[]) => action(SET_AVAILABLE_ASSET_PACKS, { assetPackIds })
+
+export type setAvailableAssetPacksAction = ReturnType<typeof setAvailableAssetPacks>

--- a/src/modules/ui/sidebar/actions.ts
+++ b/src/modules/ui/sidebar/actions.ts
@@ -40,3 +40,11 @@ export const SET_AVAILABLE_ASSET_PACKS = 'Set available asset packs'
 export const setAvailableAssetPacks = (assetPackIds: string[]) => action(SET_AVAILABLE_ASSET_PACKS, { assetPackIds })
 
 export type setAvailableAssetPacksAction = ReturnType<typeof setAvailableAssetPacks>
+
+// Set new asset packs
+
+export const SET_NEW_ASSET_PACKS = 'Set new asset packs'
+
+export const setNewAssetPacks = (assetPackIds: string[]) => action(SET_NEW_ASSET_PACKS, { assetPackIds })
+
+export type setNewAssetPacksAction = ReturnType<typeof setNewAssetPacks>

--- a/src/modules/ui/sidebar/reducer.ts
+++ b/src/modules/ui/sidebar/reducer.ts
@@ -1,8 +1,6 @@
 import { OPEN_EDITOR, OpenEditorAction } from 'modules/editor/actions'
 import {
-  ToggleAssetPackAction,
   SearchAssetsAction,
-  TOGGLE_ASSET_PACK,
   SEARCH_ASSETS,
   SetSidebarViewAction,
   SET_SIDEBAR_VIEW,
@@ -32,7 +30,6 @@ const INITIAL_STATE: SidebarState = {
 }
 
 export type SidebarReducerAction =
-  | ToggleAssetPackAction
   | SearchAssetsAction
   | OpenEditorAction
   | SetSidebarViewAction
@@ -41,14 +38,6 @@ export type SidebarReducerAction =
 
 export const sidebarReducer = (state = INITIAL_STATE, action: SidebarReducerAction): SidebarState => {
   switch (action.type) {
-    case TOGGLE_ASSET_PACK: {
-      const { assetPackId, enabled } = action.payload
-      const selectedAssetPackIds = state.selectedAssetPackIds.filter(id => id !== assetPackId)
-      return {
-        ...state,
-        selectedAssetPackIds: enabled ? [...selectedAssetPackIds, assetPackId] : selectedAssetPackIds
-      }
-    }
     case SEARCH_ASSETS: {
       return {
         ...state,

--- a/src/modules/ui/sidebar/reducer.ts
+++ b/src/modules/ui/sidebar/reducer.ts
@@ -1,43 +1,50 @@
 import { OPEN_EDITOR, OpenEditorAction } from 'modules/editor/actions'
 import {
-  SelectAssetPackAction,
+  ToggleAssetPackAction,
   SearchAssetsAction,
-  SELECT_ASSET_PACK,
+  TOGGLE_ASSET_PACK,
   SEARCH_ASSETS,
   SetSidebarViewAction,
   SET_SIDEBAR_VIEW,
   SELECT_CATEGORY,
-  SelectCategoryAction
+  SelectCategoryAction,
+  SET_AVAILABLE_ASSET_PACKS,
+  setAvailableAssetPacksAction
 } from './actions'
 import { SidebarView } from './types'
 
 export type SidebarState = {
-  selectedAssetPackId: string | null
+  selectedAssetPackIds: string[]
+  availableAssetPackIds: string[]
   selectedCategory: string | null
   search: string
   view: SidebarView
 }
 
 const INITIAL_STATE: SidebarState = {
-  selectedAssetPackId: null,
+  selectedAssetPackIds: [],
+  availableAssetPackIds: [],
   selectedCategory: null,
   search: '',
   view: SidebarView.GRID
 }
 
 export type SidebarReducerAction =
-  | SelectAssetPackAction
+  | ToggleAssetPackAction
   | SearchAssetsAction
   | OpenEditorAction
   | SetSidebarViewAction
   | SelectCategoryAction
+  | setAvailableAssetPacksAction
 
 export const sidebarReducer = (state = INITIAL_STATE, action: SidebarReducerAction): SidebarState => {
   switch (action.type) {
-    case SELECT_ASSET_PACK: {
+    case TOGGLE_ASSET_PACK: {
+      const { assetPackId, enabled } = action.payload
+      const selectedAssetPackIds = state.selectedAssetPackIds.filter(id => id !== assetPackId)
       return {
         ...state,
-        selectedAssetPackId: action.payload.assetPackId
+        selectedAssetPackIds: enabled ? [...selectedAssetPackIds, assetPackId] : selectedAssetPackIds
       }
     }
     case SEARCH_ASSETS: {
@@ -62,6 +69,13 @@ export const sidebarReducer = (state = INITIAL_STATE, action: SidebarReducerActi
     }
     case OPEN_EDITOR: {
       return INITIAL_STATE
+    }
+
+    case SET_AVAILABLE_ASSET_PACKS: {
+      return {
+        ...state,
+        availableAssetPackIds: action.payload.assetPackIds
+      }
     }
 
     default:

--- a/src/modules/ui/sidebar/reducer.ts
+++ b/src/modules/ui/sidebar/reducer.ts
@@ -16,6 +16,7 @@ import { SidebarView } from './types'
 export type SidebarState = {
   selectedAssetPackIds: string[]
   availableAssetPackIds: string[]
+  newAssetPackIds: string[]
   selectedCategory: string | null
   search: string
   view: SidebarView
@@ -24,6 +25,7 @@ export type SidebarState = {
 const INITIAL_STATE: SidebarState = {
   selectedAssetPackIds: [],
   availableAssetPackIds: [],
+  newAssetPackIds: [],
   selectedCategory: null,
   search: '',
   view: SidebarView.GRID
@@ -68,7 +70,10 @@ export const sidebarReducer = (state = INITIAL_STATE, action: SidebarReducerActi
       }
     }
     case OPEN_EDITOR: {
-      return INITIAL_STATE
+      return {
+        ...INITIAL_STATE,
+        availableAssetPackIds: state.availableAssetPackIds
+      }
     }
 
     case SET_AVAILABLE_ASSET_PACKS: {

--- a/src/modules/ui/sidebar/selectors.ts
+++ b/src/modules/ui/sidebar/selectors.ts
@@ -7,6 +7,8 @@ import { getData as getAssets } from 'modules/asset/selectors'
 import { AssetState } from 'modules/asset/reducer'
 import { AssetPackState } from 'modules/assetPack/reducer'
 import { Asset } from 'modules/asset/types'
+import { getCurrentProject } from 'modules/project/selectors'
+import { Project } from 'modules/project/types'
 import { SIDEBAR_CATEGORIES } from './utils'
 
 export const getState: (state: RootState) => SidebarState = state => state.ui.sidebar
@@ -53,15 +55,23 @@ export const getSelectedAssetPackIds = createSelector<RootState, SidebarState, A
   }
 )
 
-export const getSideBarCategories = createSelector<RootState, string[], string, string | null, SidebarView, AssetState['data'], Category[]>(
-  getSelectedAssetPackIds,
+export const getSideBarCategories = createSelector<
+  RootState,
+  Project | null,
+  string,
+  string | null,
+  SidebarView,
+  AssetState['data'],
+  Category[]
+>(
+  getCurrentProject,
   getSearch,
   getSelectedCategory,
   getSidebarView,
   getAssets,
-  (selectedAssetPackId, search, category, view, assets) => {
+  (project, search, category, view, assets) => {
     const categories: { [categoryName: string]: Category } = {}
-
+    const selectedAssetPackId = project ? project.assetPackIds || [] : []
     Object.values(assets)
       // filter by selected asset pack
       .filter(asset => selectedAssetPackId.length === 0 || selectedAssetPackId.includes(asset.assetPackId))

--- a/src/modules/ui/sidebar/selectors.ts
+++ b/src/modules/ui/sidebar/selectors.ts
@@ -36,6 +36,8 @@ const isSearchResult = (asset: Asset, search: string) => {
 
 export const getAvailableAssetPackIds = (state: RootState) => getState(state).availableAssetPackIds
 
+export const getNewAssetPackIds = (state: RootState) => getState(state).newAssetPackIds
+
 export const getSelectedAssetPackIds = createSelector<RootState, SidebarState, AssetPackState['data'], string[]>(
   getState,
   getAssetPacks,
@@ -95,6 +97,6 @@ export const getSideBarCategories = createSelector<RootState, string[], string, 
       }
     })
 
-    return [...categoryArray]
+    return categoryArray
   }
 )

--- a/src/modules/ui/sidebar/selectors.ts
+++ b/src/modules/ui/sidebar/selectors.ts
@@ -11,8 +11,6 @@ import { SIDEBAR_CATEGORIES } from './utils'
 
 export const getState: (state: RootState) => SidebarState = state => state.ui.sidebar
 
-export const getSelectedAssetPackId = (state: RootState) => getState(state).selectedAssetPackId
-
 export const getSearch = (state: RootState) => getState(state).search
 
 export const getSelectedCategory = (state: RootState) => getState(state).selectedCategory
@@ -36,54 +34,50 @@ const isSearchResult = (asset: Asset, search: string) => {
   return false
 }
 
-export const getSideBarCategories = createSelector<
-  RootState,
-  string | null,
-  string,
-  string | null,
-  SidebarView,
-  AssetPackState['data'],
-  AssetState['data'],
-  Category[]
->(
-  getSelectedAssetPackId,
+export const getAvailableAssetPackIds = (state: RootState) => getState(state).availableAssetPackIds
+
+export const getSelectedAssetPackIds = createSelector<RootState, SidebarState, AssetPackState['data'], string[]>(
+  getState,
+  getAssetPacks,
+  (sidebar, _assetPacks) => {
+    const { selectedAssetPackIds, availableAssetPackIds } = sidebar
+    if (selectedAssetPackIds.length === 0) {
+      // Default selection for first time users
+      return availableAssetPackIds
+    } else {
+      // Selection for existing users
+      return selectedAssetPackIds
+    }
+  }
+)
+
+export const getSideBarCategories = createSelector<RootState, string[], string, string | null, SidebarView, AssetState['data'], Category[]>(
+  getSelectedAssetPackIds,
   getSearch,
   getSelectedCategory,
   getSidebarView,
-  getAssetPacks,
   getAssets,
-  (selectedAssetPackId, search, category, view, assetPacks, assets) => {
+  (selectedAssetPackId, search, category, view, assets) => {
     const categories: { [categoryName: string]: Category } = {}
 
-    // filter by selected asset pack, if none is selected use all asset packs
-    const filteredAssetPacks = Object.keys(assetPacks)
-      .filter(assetPackId => selectedAssetPackId == null || selectedAssetPackId === assetPackId)
-      .map(assetPackId => assetPacks[assetPackId])
-
-    const filteredAssetIds = Object.keys(assets)
-      .filter(assetId => !search || isSearchResult(assets[assetId], search)) // filter assets by search (if any)
-      .filter(assetId => view === SidebarView.LIST || category == null || assets[assetId].category === category) // if sidebar is in not in "list" view, filter by selected category
-      .reduce((ids, assetId) => ({ ...ids, [assetId]: true }), {})
-
-    for (const assetPack of filteredAssetPacks) {
-      for (const assetId of assetPack.assets) {
-        // check if it hasn't been filtered out
-        if (assetId in filteredAssetIds) {
-          const asset = assets[assetId]
-          // check if category already exits, otherwise create it
-          const categoryExists = asset.category in categories
-          if (!categoryExists) {
-            categories[asset.category] = {
-              name: asset.category,
-              assets: [],
-              thumbnail: ''
-            }
+    Object.values(assets)
+      // filter by selected asset pack
+      .filter(asset => selectedAssetPackId.length === 0 || selectedAssetPackId.includes(asset.assetPackId))
+      // filter assets by search (if any)
+      .filter(asset => !search || isSearchResult(asset, search))
+      // if sidebar is in not in "list" view, filter by selected category
+      .filter(asset => view === SidebarView.LIST || category == null || asset.category === category)
+      // populate categories with filtered assets
+      .forEach(asset => {
+        if (!(asset.category in categories)) {
+          categories[asset.category] = {
+            name: asset.category,
+            assets: [],
+            thumbnail: ''
           }
-          // add asset to category
-          categories[asset.category].assets.push(asset)
         }
-      }
-    }
+        categories[asset.category].assets.push(asset)
+      })
 
     // convert map to array
     const categoryArray = SIDEBAR_CATEGORIES.filter(({ name }) => name in categories).map<Category>(({ name, thumbnail }) => ({
@@ -101,6 +95,6 @@ export const getSideBarCategories = createSelector<
       }
     })
 
-    return categoryArray
+    return [...categoryArray]
   }
 )

--- a/src/scenarios/helpers/assetPacks.ts
+++ b/src/scenarios/helpers/assetPacks.ts
@@ -29,7 +29,6 @@ export function makeFakeAssetPack(assetCount: number = 1): FullAssetPack {
     title: 'Default Asset Pack',
     thumbnail: '',
     url: '',
-    isNew: false,
     isLoaded: true,
     assets: []
   }

--- a/src/scenarios/helpers/assetPacks.ts
+++ b/src/scenarios/helpers/assetPacks.ts
@@ -24,10 +24,13 @@ export function makeFakeAssetPack(assetCount: number = 1): FullAssetPack {
   const id = uuid.v4()
   const categories = ['nature', 'furniture', 'items', 'misc']
 
-  let out: { id: string; version: number; title: string; assets: Asset[] } = {
+  let out: FullAssetPack = {
     id,
-    version: 1,
     title: 'Default Asset Pack',
+    thumbnail: '',
+    url: '',
+    isNew: false,
+    isLoaded: true,
     assets: []
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "jsx": "preserve",
     "module": "esnext",


### PR DESCRIPTION
Closes #460 

Use the following variable in your `.env`

```
REACT_APP_ASSETS_URL=https://builder-packs-stg.now.sh
```

This PR changes the logic of loading asset packs to do the following:

1. Load the asset pack manifest

2. Get the user selection of asset packs (by default this is all the available asset packs)

3. For every selected asset pack:

  3.1. Check if the asset pack is not in state and it has not already been loaded

  3.2 If not loaded, it fetches it from the server, otherwise uses the one already in state

4. All the non-selected asset packs are added to the state and marked as not loaded (so we can render a UI for the user to select them)

5. All the asset packs that were not in the available asset pack since last time the user visited are marked as new

The selection of asset packs are stored in each project. 

The record of available asset packs and newly added asset packs is stored under the `sidebar` domain. The available asset packs slice is stored in local storage so we can tell which assets have been added since the last visit.

I also refactored the `SELECT_ASSET_PACK` action into  `TOGGLE_ASSET_PACK` which allows us to enabled/disable them individually and in bulk.