### PR TITLE
fix: homepage actions

### DIFF
--- a/src/modules/project/sagas.ts
+++ b/src/modules/project/sagas.ts
@@ -40,10 +40,10 @@ import { Asset } from 'modules/asset/types'
 import { store } from 'modules/common/store'
 import { closeModal } from 'modules/modal/actions'
 import { AUTH_SUCCESS, AuthSuccessAction } from 'modules/auth/actions'
-import { createFiles } from './export'
-import { didUpdateLayout } from './utils'
 import { getSub } from 'modules/auth/selectors'
 import { getSceneByProjectId } from 'modules/scene/utils'
+import { createFiles } from './export'
+import { didUpdateLayout } from './utils'
 
 const DEFAULT_GROUND_ASSET: Asset = {
   id: 'da1fed3c954172146414a66adfa134f7a5e1cb49c902713481bf2fe94180c2cf',

--- a/src/modules/project/sagas.ts
+++ b/src/modules/project/sagas.ts
@@ -32,7 +32,7 @@ import { api } from 'lib/api'
 import { Project } from 'modules/project/types'
 import { Scene } from 'modules/scene/types'
 import { getData as getProjects } from 'modules/project/selectors'
-import { getData as getScenes, getScene } from 'modules/scene/selectors'
+import { getScene } from 'modules/scene/selectors'
 import { EMPTY_SCENE_METRICS } from 'modules/scene/constants'
 import { createScene, setGround, applyLayout } from 'modules/scene/actions'
 import { SET_EDITOR_READY, setEditorReady, takeScreenshot, setExportProgress, createEditorScene } from 'modules/editor/actions'
@@ -43,6 +43,7 @@ import { AUTH_SUCCESS, AuthSuccessAction } from 'modules/auth/actions'
 import { createFiles } from './export'
 import { didUpdateLayout } from './utils'
 import { getSub } from 'modules/auth/selectors'
+import { getSceneByProjectId } from 'modules/scene/utils'
 
 const DEFAULT_GROUND_ASSET: Asset = {
   id: 'da1fed3c954172146414a66adfa134f7a5e1cb49c902713481bf2fe94180c2cf',
@@ -113,9 +114,7 @@ function* handleCreateProjectFromTemplate(action: CreateProjectFromTemplateActio
 function* handleDuplicateProject(action: DuplicateProjectAction) {
   const { project } = action.payload
 
-  const scenes: ReturnType<typeof getScenes> = yield select(getScenes)
-  const scene = scenes[project.sceneId]
-  if (!scene) return
+  const scene = yield getSceneByProjectId(project.id)
 
   const newScene = { ...scene, id: uuidv4() }
   const newProject = { ...project, sceneId: newScene.id, id: uuidv4(), createdAt: new Date().toISOString() }
@@ -152,7 +151,7 @@ function* handleEditProject(action: EditProjectAction) {
 
 function* handleExportProject(action: ExportProjectRequestAction) {
   const { project } = action.payload
-  const scene: Scene = yield select(getScene(project.sceneId))
+  const scene = yield getSceneByProjectId(project.id)
 
   let zip = new JSZip()
   let sanitizedName = project.title.replace(/\s/g, '_')

--- a/src/modules/scene/utils.ts
+++ b/src/modules/scene/utils.ts
@@ -1,5 +1,15 @@
 import { Vector3 } from 'modules/common/types'
 import { Scene, SceneMetrics } from './types'
+import { select, put, race, take } from 'redux-saga/effects'
+import {
+  loadManifestRequest,
+  LoadManifestFailureAction,
+  LoadManifestSuccessAction,
+  LOAD_MANIFEST_SUCCESS,
+  LOAD_MANIFEST_FAILURE
+} from 'modules/project/actions'
+import { getData as getProjects } from 'modules/project/selectors'
+import { getData as getScenes } from 'modules/scene/selectors'
 
 /**
  * Returns a new random position bound to y: 0
@@ -84,4 +94,27 @@ export function areEqualMappings(mappingsA: Record<string, string> = {}, mapping
     }
   }
   return true
+}
+
+export function* getSceneByProjectId(projectId: string) {
+  const projects: ReturnType<typeof getProjects> = yield select(getProjects)
+  const scenes: ReturnType<typeof getScenes> = yield select(getScenes)
+  let project = projects[projectId]
+  if (!project) {
+    throw new Error(`Project with id "${projectId}" not found in store`)
+  }
+  let scene = scenes[project.sceneId]
+  if (!scene) {
+    yield put(loadManifestRequest(project.id))
+    const result: { success?: LoadManifestSuccessAction; failure?: LoadManifestFailureAction } = yield race({
+      success: take(LOAD_MANIFEST_SUCCESS),
+      failure: take(LOAD_MANIFEST_FAILURE)
+    })
+    if (result.success) {
+      scene = result.success.payload.manifest.scene
+    } else if (result.failure) {
+      throw new Error(result.failure.payload.error)
+    }
+  }
+  return scene
 }


### PR DESCRIPTION
Fixes #582 

I added a helper `getSceneByProjectId` that tries to get the scene from the app state, and if not there, it downloads the manifest and returns it.

I used this helper in the sagas related to `Duplicate project`, `Download project` and `Unpublish` because those were breaking when used from the homepage do to the scene not being in memory.

