### PR TITLE
Save screenshots of new projects

### DIFF
--- a/src/lib/api/builder.ts
+++ b/src/lib/api/builder.ts
@@ -160,8 +160,6 @@ export class BuilderAPI extends BaseAPI {
   }
 
   async saveThumbnail(project: Project) {
-    if (!project.thumbnail) return
-
     const blob = dataURLToBlob(project.thumbnail)
     const formData = new FormData()
     if (blob) {

--- a/src/modules/editor/utils.ts
+++ b/src/modules/editor/utils.ts
@@ -5,8 +5,8 @@ import { ASSETS_CONTENT_URL } from 'lib/api/content'
 
 const script = require('raw-loader!../../ecsScene/scene.js')
 
-export const THUMBNAIL_WIDTH = 492
-export const THUMBNAIL_HEIGHT = 364
+export const THUMBNAIL_WIDTH = 984
+export const THUMBNAIL_HEIGHT = 728
 
 export function getNewEditorScene(project: Project): EditorScene {
   const mappings = {

--- a/src/modules/sync/sagas.ts
+++ b/src/modules/sync/sagas.ts
@@ -1,4 +1,4 @@
-import { takeLatest, select, put, call, takeEvery } from 'redux-saga/effects'
+import { takeLatest, select, put, call, takeEvery, take } from 'redux-saga/effects'
 import { DataByKey } from 'decentraland-dapps/dist/lib/types'
 
 import { AUTH_SUCCESS, AuthSuccessAction } from 'modules/auth/actions'
@@ -13,7 +13,9 @@ import {
   SET_PROJECT,
   SetProjectAction,
   DELETE_PROJECT,
-  DeleteProjectAction
+  DeleteProjectAction,
+  EDIT_PROJECT_THUMBNAIL,
+  EditProjectThumbnailAction
 } from 'modules/project/actions'
 import { isLoggedIn } from 'modules/auth/selectors'
 import { PROVISION_SCENE, ProvisionSceneAction } from 'modules/scene/actions'
@@ -119,8 +121,14 @@ function* handleSaveProjectRequest(action: SaveProjectRequestAction) {
 
 function* handleSaveProjectSuccess(action: SaveProjectSuccessAction) {
   const projects: ReturnType<typeof getProjects> = yield select(getProjects)
-  const project = projects[action.payload.project.id]
-
+  let project = projects[action.payload.project.id]
+  if (!project.thumbnail) {
+    const action: EditProjectThumbnailAction = yield take(EDIT_PROJECT_THUMBNAIL)
+    project = {
+      ...project,
+      thumbnail: action.payload.thumbnail
+    }
+  }
   try {
     saveThumbnail(project.id, project)
   } catch (e) {

--- a/src/modules/sync/utils.ts
+++ b/src/modules/sync/utils.ts
@@ -8,7 +8,7 @@ import { debounceByKey, throttle } from 'lib/debounce'
 
 export const SAVE_DEBOUNCE = 4000
 
-export const THUMBNAIL_THROTTLE = 60000
+export const THUMBNAIL_THROTTLE = 30000
 
 export const saveProject = debounceByKey((project: Project, scene: Scene) => api.saveProject(project, scene), SAVE_DEBOUNCE)
 


### PR DESCRIPTION
Fixes #599 

How to reproduce bug in master:

1) Create a new project
2) Wait for the cloud icon to disappear
3) Go back to dashboard (you will see the screenshot, but taken prior to the ground to be loaded)
4) Refresh the page, and the screenshot is not there (it was never sent)

This PR fixes two things:
- Wait for the assets to be loaded before taking the screenshot, fixing the screenshot in step 3.
- Wait for thumbnail to exist before sending it to the server, fixing step 4.

You can do those steps in this branch to confirm the fix

