### PR TITLE
fix: thumbnails for duplicated scenes

### DIFF
--- a/src/modules/project/sagas.ts
+++ b/src/modules/project/sagas.ts
@@ -118,7 +118,7 @@ function* handleDuplicateProject(action: DuplicateProjectAction) {
 
   let thumbnail = project.thumbnail
 
-  if (thumbnail && !thumbnail.startsWith('data:image/png;')) {
+  if (thumbnail && thumbnail.startsWith('http')) {
     thumbnail = yield call(() => getImageAsDataUrl(project.thumbnail))
   }
 

--- a/src/modules/project/sagas.ts
+++ b/src/modules/project/sagas.ts
@@ -42,8 +42,8 @@ import { closeModal } from 'modules/modal/actions'
 import { AUTH_SUCCESS, AuthSuccessAction } from 'modules/auth/actions'
 import { getSub } from 'modules/auth/selectors'
 import { getSceneByProjectId } from 'modules/scene/utils'
+import { didUpdateLayout, getImageAsDataUrl } from './utils'
 import { createFiles } from './export'
-import { didUpdateLayout } from './utils'
 
 const DEFAULT_GROUND_ASSET: Asset = {
   id: 'da1fed3c954172146414a66adfa134f7a5e1cb49c902713481bf2fe94180c2cf',
@@ -116,8 +116,14 @@ function* handleDuplicateProject(action: DuplicateProjectAction) {
 
   const scene = yield getSceneByProjectId(project.id)
 
+  let thumbnail = project.thumbnail
+
+  if (thumbnail && !thumbnail.startsWith('data:image/png;')) {
+    thumbnail = yield call(() => getImageAsDataUrl(project.thumbnail))
+  }
+
   const newScene = { ...scene, id: uuidv4() }
-  const newProject = { ...project, sceneId: newScene.id, id: uuidv4(), createdAt: new Date().toISOString() }
+  const newProject = { ...project, sceneId: newScene.id, id: uuidv4(), createdAt: new Date().toISOString(), thumbnail }
 
   yield put(createScene(newScene))
   yield put(createProject(newProject))

--- a/src/modules/project/utils.ts
+++ b/src/modules/project/utils.ts
@@ -71,3 +71,18 @@ export function getParcelOrientation(project: Project, point: Coordinate, rotati
 
   return parcels
 }
+
+export async function getImageAsDataUrl(url: string): Promise<string> {
+  const reader = new FileReader()
+  const res = await fetch(url)
+  const blob = await res.blob()
+
+  const out = new Promise<string>((resolve, reject) => {
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = e => reject(e)
+  })
+
+  reader.readAsDataURL(blob)
+
+  return out
+}


### PR DESCRIPTION
Add thumbnail to the duplicated project

If the image is referenced remotely, fetch it and convert it to base64

On project save success the new media should be saved separately

Closes #613 