### PR TITLE
fix: long scene names

### DIFF
--- a/src/components/ProjectCard/ProjectCard.css
+++ b/src/components/ProjectCard/ProjectCard.css
@@ -31,6 +31,9 @@
   margin-bottom: 14px;
   font-size: 20px;
   font-weight: 500;
+  max-width: 175px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .ProjectCard .description {


### PR DESCRIPTION
Fixes #601 

✅ Fixes the single-line long names with text ellipsis
✅ Supports multi-line names
✅ Leaves a space for the cloud icon

<img width="875" alt="Screen Shot 2019-08-15 at 12 09 52 PM" src="https://user-images.githubusercontent.com/2781777/63104737-e795f280-bf55-11e9-9cfb-a45fa8cb924b.png">
