### PR TITLE
fix: bust cache using updateAt to prevent blinking

### DIFF
--- a/src/components/AvatarFace/AvatarFace.tsx
+++ b/src/components/AvatarFace/AvatarFace.tsx
@@ -1,18 +1,21 @@
 import * as React from 'react'
 
-import { bustCache } from './utils'
 import { Props } from './AvatarFace.types'
 
 import './AvatarFace.css'
 
 export default class AvatarFace extends React.PureComponent<Props> {
   render() {
-    const hasFace = this.props.face && this.props.face.length > 0
+    const { user } = this.props
 
-    return (
-      <div className={`AvatarFace ${this.props.size}`}>
-        {hasFace ? <img src={bustCache(this.props.face!)} alt="" /> : <div className="guest-face" />}
-      </div>
-    )
+    let face
+    if (user) {
+      const url = user.snapshots.face + '?updated_at=' + user.updatedAt
+      face = <img src={url} alt="" />
+    } else {
+      face = <div className="guest-face" />
+    }
+
+    return <div className={`AvatarFace ${this.props.size}`}>{face}</div>
   }
 }

--- a/src/components/AvatarFace/AvatarFace.types.ts
+++ b/src/components/AvatarFace/AvatarFace.types.ts
@@ -1,4 +1,6 @@
+import { User } from 'modules/auth/types'
+
 export type Props = {
-  face?: string | null
+  user?: User | null
   size: 'small' | 'medium' | 'large' | 'responsive'
 }

--- a/src/components/AvatarFace/utils.ts
+++ b/src/components/AvatarFace/utils.ts
@@ -1,3 +1,0 @@
-export function bustCache(url?: string) {
-  return url ? `${url}?${Date.now()}` : ''
-}

--- a/src/components/UserMenu/UserMenu.container.ts
+++ b/src/components/UserMenu/UserMenu.container.ts
@@ -2,15 +2,13 @@ import { connect } from 'react-redux'
 
 import { RootState } from 'modules/common/types'
 import { logout, login } from 'modules/auth/actions'
-import { isLoggedIn, getEmail, getFace, getName, isLoggingIn } from 'modules/auth/selectors'
+import { isLoggedIn, isLoggingIn, getUser } from 'modules/auth/selectors'
 import { MapStateProps, MapDispatch, MapDispatchProps } from './UserMenu.types'
 import UserMenu from './UserMenu'
 
 const mapState = (state: RootState): MapStateProps => {
   return {
-    email: getEmail(state),
-    name: getName(state),
-    face: getFace(state),
+    user: getUser(state),
     isLoggedIn: isLoggedIn(state),
     isLoggingIn: isLoggingIn(state)
   }

--- a/src/components/UserMenu/UserMenu.tsx
+++ b/src/components/UserMenu/UserMenu.tsx
@@ -33,7 +33,7 @@ export default class UserMenu extends React.Component<Props, State> {
   }
 
   render() {
-    const { face, name, email, isLoggedIn, isLoggingIn, onLogout } = this.props
+    const { user, isLoggedIn, isLoggingIn, onLogout } = this.props
     const { isOpen } = this.state
 
     let classes = 'UserMenu'
@@ -41,17 +41,24 @@ export default class UserMenu extends React.Component<Props, State> {
       classes += ' authed'
     }
 
+    let name = null
+    let email = null
+    if (user) {
+      name = user.profile.name
+      email = user.email
+    }
+
     return (
       <div className={classes} onBlur={this.handleClose} tabIndex={0}>
         {isLoggedIn && (
           <>
             <div className="toggle" onClick={this.handleToggle}>
-              <AvatarFace size="medium" face={face} />
+              <AvatarFace size="medium" user={user} />
             </div>
             <div className={`menu ${isOpen ? 'open' : ''}`}>
               <div className="info" onClick={this.handleProfileClick}>
                 <div className="image">
-                  <AvatarFace size="small" face={face} />
+                  <AvatarFace size="small" user={user} />
                 </div>
                 <div>
                   <div className="name">{name || t('user_menu.guest')}</div>

--- a/src/components/UserMenu/UserMenu.types.ts
+++ b/src/components/UserMenu/UserMenu.types.ts
@@ -1,13 +1,12 @@
 import { Dispatch } from 'redux'
 
 import { logout, LogoutAction, login, LoginAction } from 'modules/auth/actions'
+import { User } from 'modules/auth/types'
 
 export type Props = {
   isLoggedIn: boolean
   isLoggingIn: boolean
-  email: string | null
-  name: string | null
-  face: string | null
+  user: User | null
   onLogout: typeof logout
   onLogin: typeof login
 }
@@ -16,6 +15,6 @@ export type State = {
   isOpen: boolean
 }
 
-export type MapStateProps = Pick<Props, 'isLoggedIn' | 'isLoggingIn' | 'email' | 'name' | 'face'>
+export type MapStateProps = Pick<Props, 'isLoggedIn' | 'isLoggingIn' | 'user'>
 export type MapDispatchProps = Pick<Props, 'onLogin' | 'onLogout'>
 export type MapDispatch = Dispatch<LoginAction | LogoutAction>


### PR DESCRIPTION
Use the `updateAt` prop to bust the avatar face cache to prevent the blinking on every render.

Before:

![avatar-blink](https://user-images.githubusercontent.com/2781777/63454296-eb77b800-c420-11e9-916d-a6ca755b9d9f.gif)

After:

![avatar-not-blink](https://user-images.githubusercontent.com/2781777/63454300-efa3d580-c420-11e9-99d4-4042c136fe23.gif)
