### PR TITLE
fix: don't hide category assets after closing search drawer

### DIFF
--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -9,6 +9,12 @@ export default class Drawer extends React.PureComponent<Props, State> {
     isOpen: true
   }
 
+  componentWillReceiveProps(nextProps: Props) {
+    if (!nextProps.hasLabel) {
+      this.setState({ isOpen: true })
+    }
+  }
+
   handleClick = () => {
     this.setState({
       isOpen: !this.state.isOpen


### PR DESCRIPTION
Closes #705 