### PR TITLE
fix: camera pitch rotation angle conversion from BJS to Unity

### DIFF
--- a/src/modules/editor/sagas.ts
+++ b/src/modules/editor/sagas.ts
@@ -340,7 +340,7 @@ function* handleResetCamera() {
 
   editorWindow.editor.resetCameraZoom()
   editorWindow.editor.setCameraPosition({ x, y: 0, z })
-  editorWindow.editor.setCameraRotation(-Math.PI / 4, Math.PI / 3)
+  editorWindow.editor.setCameraRotation(-Math.PI / 4, Math.PI / 6)
 }
 
 function* handleDropItem(action: DropItemAction) {

--- a/src/modules/media/sagas.ts
+++ b/src/modules/media/sagas.ts
@@ -47,7 +47,7 @@ export function* handleTakePictures() {
 
   // Prepare the camera to fit the scene
   editorWindow.editor.setCameraZoomDelta(zoom)
-  editorWindow.editor.setCameraRotation(0, Math.PI / 3)
+  editorWindow.editor.setCameraRotation(0, Math.PI / 6)
   editorWindow.editor.setCameraPosition({ x: (rows * PARCEL_SIZE) / 2, y: 2, z: (cols * PARCEL_SIZE) / 2 })
 
   yield put(recordMediaProgress(0))
@@ -69,7 +69,7 @@ export function* handleTakePictures() {
 }
 
 function* takeEditorScreenshot(angle: number) {
-  editorWindow.editor.setCameraRotation(angle, Math.PI / 3)
+  editorWindow.editor.setCameraRotation(angle, Math.PI / 6)
   const shot = yield call(() => editorWindow.editor.takeScreenshot())
   return dataURLToBlob(shot)
 }


### PR DESCRIPTION
BJS was taking its angle from a vertical axis and Unity is using an horizontal axis. I manually converted rotation angles to fit Unity uses