### PR TITLE
fix: ground entity names

### DIFF
--- a/src/modules/project/export.ts
+++ b/src/modules/project/export.ts
@@ -106,7 +106,7 @@ export function createGameFile(args: { project: Project; scene: Scene; rotation:
     rotation: ECS.Quaternion.Euler(0, y, 0)
   })
   sceneEntity.addComponent(transform)
-  writer.addEntity('scene', sceneEntity as any)
+  writer.addEntity('_scene', sceneEntity as any)
 
   // Map component ids to entity ids
   const componentToEntity = new Map<string, string>()

--- a/src/modules/scene/sagas.ts
+++ b/src/modules/scene/sagas.ts
@@ -539,9 +539,9 @@ function* handleApplyLayout(action: ApplyLayoutAction) {
 
 function* applyGround(scene: Scene, rows: number, cols: number, asset: Asset) {
   let components = { ...scene.components }
+  let assets = { ...scene.assets }
   let entities = cloneEntities(scene)
   let gltfId: string = uuidv4()
-
   if (asset) {
     const gltfs: ReturnType<typeof getGLTFsBySrc> = yield select(getGLTFsBySrc)
     const gltf = gltfs[asset.model]
@@ -586,7 +586,7 @@ function* applyGround(scene: Scene, rows: number, cols: number, asset: Asset) {
           id: entityId,
           components: newComponents,
           disableGizmos: true,
-          name: getEntityName(scene, newComponents)
+          name: getEntityName({ ...scene, entities }, newComponents)
         }
       }
     }
@@ -603,7 +603,15 @@ function* applyGround(scene: Scene, rows: number, cols: number, asset: Asset) {
     }
   }
 
-  yield put(provisionScene({ ...scene, components, entities, ground }))
+  // update assets removing the old ground and adding the new one
+  if (scene.ground) {
+    delete assets[scene.ground.assetId]
+  }
+  if (ground) {
+    assets[ground.assetId] = asset
+  }
+
+  yield put(provisionScene({ ...scene, components, entities, ground, assets }))
 }
 
 function* handleSetScriptParameters(action: SetScriptValuesAction) {

--- a/src/modules/scene/utils.ts
+++ b/src/modules/scene/utils.ts
@@ -139,7 +139,7 @@ export function getUniqueName(components: AnyComponent[], takenNames: Readonly<S
       if (component.type === ComponentType.GLTFShape) {
         const asset = assets[(component as ComponentDefinition<ComponentType.GLTFShape>).data.assetId]
         if (asset) {
-          rawName = asset.name
+          rawName = convertToCamelCase(asset.name.replace(/\s/g, '_'))
         }
       } else if (component.type === ComponentType.NFTShape) {
         rawName = 'nft'

--- a/src/modules/scene/utils.ts
+++ b/src/modules/scene/utils.ts
@@ -127,17 +127,20 @@ export function getEntityName(scene: Scene, entityComponents: EntityDefinition['
     const entity = scene.entities[entityId]
     takenNames.add(entity.name)
   }
-  return getUniqueName(components, takenNames)
+  return getUniqueName(components, takenNames, scene.assets)
 }
 
-export function getUniqueName(components: AnyComponent[], takenNames: Readonly<Set<string>>) {
+export function getUniqueName(components: AnyComponent[], takenNames: Readonly<Set<string>>, assets: Record<string, Asset>) {
   let attempts = 1
   let rawName = 'entity'
 
   for (let component of components) {
     try {
       if (component.type === ComponentType.GLTFShape) {
-        rawName = getGLTFShapeName(component as ComponentDefinition<ComponentType.GLTFShape>)
+        const asset = assets[(component as ComponentDefinition<ComponentType.GLTFShape>).data.assetId]
+        if (asset) {
+          rawName = asset.name
+        }
       } else if (component.type === ComponentType.NFTShape) {
         rawName = 'nft'
       }


### PR DESCRIPTION
Properly generate ground entity names (entity{N})
Get unique names from assets rather than GLTFShapes (fixes case where there's an scene.gltf model that conflicts with the scene entity wrapper on export)
Keep old naming system for legacy purposes/migration

Closes #882 

