### PR TITLE
fix: deselect before screenshot

### DIFF
--- a/src/modules/media/sagas.ts
+++ b/src/modules/media/sagas.ts
@@ -1,11 +1,12 @@
 import { select, delay, put, call, takeLatest } from 'redux-saga/effects'
+import { Omit } from 'decentraland-dapps/dist/lib/types'
 import { getCurrentProject } from 'modules/project/selectors'
 import { dataURLToBlob } from 'modules/media/utils'
 import { PARCEL_SIZE } from 'modules/project/utils'
 import { Project } from 'modules/project/types'
 import { EditorWindow } from 'components/Preview/Preview.types'
+import { deselectEntity } from 'modules/editor/actions'
 import { RECORD_MEDIA_REQUEST, recordMediaProgress, recordMediaSuccess } from './actions'
-import { Omit } from 'decentraland-dapps/dist/lib/types'
 import { RawMedia } from './types'
 
 const editorWindow = window as EditorWindow
@@ -26,6 +27,8 @@ export function* handleTakePictures() {
   if (!project) return
 
   const { rows, cols } = project.layout
+
+  yield put(deselectEntity())
 
   const side = Math.max(cols, rows)
   const zoom = (side - 1) * 32


### PR DESCRIPTION
Deselect the entity before taking pictures, so the gizmos and outlines don't show up