### PR TITLE
feat: use asset contents instead of src

### DIFF
--- a/src/ecsScene/scene.ts
+++ b/src/ecsScene/scene.ts
@@ -6,7 +6,7 @@ import { createChannel } from 'decentraland-builder-scripts/channel'
 import { createInventory } from 'decentraland-builder-scripts/inventory'
 
 import { DecentralandInterface } from 'decentraland-ecs/dist/decentraland/Types'
-import { EntityDefinition, AnyComponent, ComponentData, ComponentType } from 'modules/scene/types'
+import { EntityDefinition, AnyComponent, ComponentData, ComponentType, Scene } from 'modules/scene/types'
 import { AssetParameterValues } from 'modules/asset/types'
 const { Gizmos, SmartItem } = require('decentraland-ecs') as any
 declare var dcl: DecentralandInterface
@@ -97,12 +97,11 @@ async function handleExternalAction(message: { type: string; payload: Record<str
       break
     }
     case 'Update editor': {
-      const {
-        scene: { components, entities }
-      } = message.payload
+      const { scene } = message.payload
+      const { components, entities } = scene
 
       for (let id in components) {
-        createComponent(components[id])
+        createComponent(components[id], scene)
         updateComponent(components[id])
       }
 
@@ -180,7 +179,7 @@ async function handleExternalAction(message: { type: string; payload: Record<str
   }
 }
 
-function createComponent(component: AnyComponent) {
+function createComponent(component: AnyComponent, scene: Scene) {
   const { id, type, data } = component
 
   if (!getComponentById(id)) {
@@ -200,7 +199,9 @@ function createComponent(component: AnyComponent) {
         editorComponents[id].isPickable = true
         break
       case ComponentType.Script: {
-        const { assetId, src, values } = data as ComponentData[ComponentType.Script]
+        const { assetId, values } = data as ComponentData[ComponentType.Script]
+        const asset = scene.assets[assetId]
+        const src = asset.contents[asset.script!]
         editorComponents[id] = new Script(assetId, src, values)
         if (!scriptPromises.has(assetId)) {
           const url = `${scriptBaseUrl}/${src}`

--- a/src/modules/migrations/manifest.ts
+++ b/src/modules/migrations/manifest.ts
@@ -1,6 +1,6 @@
 import { Manifest } from 'modules/project/types'
 import { addMappings } from './ISSUE-485'
-import { toProjectCloudSchema, addScale, addEntityName, addAssets } from './utils'
+import { toProjectCloudSchema, addScale, addEntityName, addAssets, removeScriptSrc } from './utils'
 import { Migration } from './types'
 
 export const migrations: Migration<Manifest> = {
@@ -25,6 +25,10 @@ export const migrations: Migration<Manifest> = {
   },
   '6': input => {
     addAssets(input.scene)
+    return input
+  },
+  '7': input => {
+    removeScriptSrc(input.scene)
     return input
   }
 }

--- a/src/modules/migrations/store.ts
+++ b/src/modules/migrations/store.ts
@@ -3,7 +3,7 @@ import { RootState } from 'modules/common/types'
 import { DataByKey } from 'decentraland-dapps/dist/lib/types'
 import { Project } from 'modules/project/types'
 import { Deployment } from 'modules/deployment/types'
-import { toProjectCloudSchema, toDeploymentCloudSchema, addScale, addEntityName, addAssets } from './utils'
+import { toProjectCloudSchema, toDeploymentCloudSchema, addScale, addEntityName, addAssets, removeScriptSrc } from './utils'
 
 export const migrations = {
   '2': (state: RootState) => {
@@ -16,7 +16,7 @@ export const migrations = {
     }
   },
   '3': (state: RootState) => {
-    for (const scene of Object.values(state && state.scene && state.scene.present && state.scene.present.data || {})) {
+    for (const scene of Object.values((state && state.scene && state.scene.present && state.scene.present.data) || {})) {
       // mutation ahead
       addMappings(scene)
     }
@@ -50,7 +50,7 @@ export const migrations = {
     /* tslint:enable */
   },
   '5': (state: RootState) => {
-    for (const scene of Object.values(state && state.scene && state.scene.present && state.scene.present.data || {})) {
+    for (const scene of Object.values((state && state.scene && state.scene.present && state.scene.present.data) || {})) {
       // mutation ahead
       addScale(scene)
     }
@@ -68,6 +68,13 @@ export const migrations = {
     for (let sceneId in state.scene.present.data) {
       const scene = state.scene.present.data[sceneId]
       addAssets(scene)
+    }
+    return state
+  },
+  '8': (state: RootState) => {
+    for (let sceneId in state.scene.present.data) {
+      const scene = state.scene.present.data[sceneId]
+      removeScriptSrc(scene)
     }
     return state
   }

--- a/src/modules/migrations/utils.ts
+++ b/src/modules/migrations/utils.ts
@@ -95,3 +95,10 @@ export function addAssets(scene: Scene) {
     scene.assets = {}
   }
 }
+
+export function removeScriptSrc(scene: Scene) {
+  const scripts = Object.values(scene.components).filter(component => component.type === ComponentType.Script)
+  for (const script of scripts) {
+    delete (script.data as any).src
+  }
+}

--- a/src/modules/project/export.ts
+++ b/src/modules/project/export.ts
@@ -143,7 +143,9 @@ export function createGameFile(args: { project: Project; scene: Scene; rotation:
         break
       }
       case ComponentType.Script: {
-        const { assetId, src, values } = (component as ComponentDefinition<ComponentType.Script>).data
+        const { assetId, values } = (component as ComponentDefinition<ComponentType.Script>).data
+        const asset = scene.assets[assetId]
+        const src = asset.contents[asset.script!]
         scripts.set(assetId, src)
         const entityId = componentToEntity.get(component.id)!
         hosts.add(entityId)

--- a/src/modules/scene/sagas.ts
+++ b/src/modules/scene/sagas.ts
@@ -291,7 +291,7 @@ function* handleDuplicateItem(_: DuplicateItemAction) {
   // copy script
   if (script) {
     const {
-      data: { values: parameters, src, assetId }
+      data: { values: parameters, assetId }
     } = script
     const scriptId = uuidv4()
     const values = JSON.parse(JSON.stringify(parameters))
@@ -303,7 +303,6 @@ function* handleDuplicateItem(_: DuplicateItemAction) {
       type: ComponentType.Script,
       data: {
         values,
-        src,
         assetId
       }
     } as ComponentDefinition<ComponentType.Script>

--- a/src/modules/scene/types.ts
+++ b/src/modules/scene/types.ts
@@ -31,7 +31,6 @@ export type ComponentData = {
   }
   [ComponentType.Script]: {
     assetId: string
-    src: string
     values: AssetParameterValues
   }
 }


### PR DESCRIPTION
This PR deprecates the `src` property in the `Script` components and uses the `assets.contents` to get the url of the script file instead.

This allows us to update the urls by just re-uploading the assets to the builder server.