### PR TITLE
fix: left panel scroll and item image

### DIFF
--- a/src/components/ItemEditorPage/LeftPanel/LeftPanel.css
+++ b/src/components/ItemEditorPage/LeftPanel/LeftPanel.css
@@ -3,4 +3,5 @@
   flex: none;
   background-color: var(--void);
   position: relative;
+  overflow: auto;
 }

--- a/src/components/ItemImage/ItemImage.css
+++ b/src/components/ItemImage/ItemImage.css
@@ -7,7 +7,7 @@
 }
 
 .ItemImage.image-wrapper .image {
-  width: 100%;
+  width: auto;
 }
 
 .ItemImage .ItemBadge {

--- a/src/components/ItemImage/ItemImage.css
+++ b/src/components/ItemImage/ItemImage.css
@@ -8,6 +8,7 @@
 
 .ItemImage.image-wrapper .image {
   width: auto;
+  max-width: 100%;
 }
 
 .ItemImage .ItemBadge {


### PR DESCRIPTION
adds scroll to the left panel to prevent this:

<img width="1435" alt="Screen Shot 2020-10-23 at 5 30 34 PM" src="https://user-images.githubusercontent.com/2781777/97051551-c10a1900-1555-11eb-8b3e-80a0a7372ebc.png">

Also fixes the item image that looked stretched when there were 3 items:

<img width="323" alt="Screen Shot 2020-10-23 at 5 29 53 PM" src="https://user-images.githubusercontent.com/2781777/97051607-d1ba8f00-1555-11eb-9cad-20adf0be398e.png">

I had to set a max-width to prevent this:

<img width="1131" alt="Screen Shot 2020-10-23 at 5 34 20 PM" src="https://user-images.githubusercontent.com/2781777/97051825-3f66bb00-1556-11eb-9646-e1919b9d69c7.png">
