### PR TITLE
fix: avatar page grid

### DIFF
--- a/src/components/AvatarPage/AvatarPage.css
+++ b/src/components/AvatarPage/AvatarPage.css
@@ -38,6 +38,7 @@
   background-position: 50% 35%;
   cursor: pointer;
 }
+
 .AvatarPage .ui.cards > .empty .create-new:first-child {
   margin-right: 24px;
 }
@@ -114,4 +115,11 @@
 .AvatarPage .is-card .is-image .is-image {
   border-radius: 0px !important;
   box-shadow: none;
+}
+
+@media (max-width: 1200px) {
+  .AvatarPage .is-card .is-image {
+    width: 215px;
+    height: 215px;
+  }
 }

--- a/src/components/AvatarPage/AvatarPage.css
+++ b/src/components/AvatarPage/AvatarPage.css
@@ -1,3 +1,7 @@
+.AvatarPage .ui.cards {
+  margin: 0px;
+}
+
 .AvatarPage .ui.cards > .empty {
   margin-top: 28px;
   padding: 112px 0;
@@ -84,7 +88,11 @@
   box-shadow: none;
   transform: translateY(0px);
   margin-top: 20px;
-  margin-right: 28px;
+  margin-right: 24px;
+}
+
+.AvatarPage .is-card:nth-child(4n) {
+  margin-right: 0px;
 }
 
 .AvatarPage .is-card:hover {

--- a/src/components/HomePage/HomePage.css
+++ b/src/components/HomePage/HomePage.css
@@ -114,10 +114,6 @@
   margin-left: 24px;
 }
 
-.HomePage .dcl.tabs {
-  margin-bottom: 15px;
-}
-
 .HomePage .project-cards.has-pagination .CardList {
   min-height: 606px;
 }


### PR DESCRIPTION
Fixes the avatar page grid alignment, now it fits 4 elements per row:

<img width="1123" alt="Screen Shot 2020-10-27 at 6 39 00 PM" src="https://user-images.githubusercontent.com/2781777/97365188-0b580680-1884-11eb-9ef1-ca076a22bed6.png">

Also a small page in the Scenes page to keep it consistent with Land and Avatar pages