### PR TITLE
fix: opening editor edge cases

### DIFF
--- a/src/components/ItemDetailPage/ItemDetailPage.tsx
+++ b/src/components/ItemDetailPage/ItemDetailPage.tsx
@@ -34,11 +34,6 @@ export default class ItemDetailPage extends React.PureComponent<Props> {
     onOpenModal('CreateItemModal', { addRepresentationTo: item })
   }
 
-  handleNavigateToEditor = () => {
-    const { onNavigate, item } = this.props
-    onNavigate(locations.itemEditor({ itemId: item!.id }))
-  }
-
   renderPage() {
     const { collection, onNavigate } = this.props
 
@@ -93,7 +88,7 @@ export default class ItemDetailPage extends React.PureComponent<Props> {
                           </Dropdown.Menu>
                         </Dropdown>
 
-                        <Button primary compact onClick={this.handleNavigateToEditor}>
+                        <Button primary compact onClick={this.handleEditItem}>
                           {t('global.edit')}
                         </Button>
                       </>

--- a/src/components/ItemEditorPage/LeftPanel/Collections/SidebarCollection/SidebarCollection.tsx
+++ b/src/components/ItemEditorPage/LeftPanel/Collections/SidebarCollection/SidebarCollection.tsx
@@ -13,18 +13,18 @@ import './SidebarCollection.css'
 class SidebarCollection extends React.PureComponent<Props & CollectedProps> {
   render() {
     const { collection, items, isSelected, connectDropTarget, isOver, canDrop } = this.props
+    const collectionItems = items.filter(item => item.collectionId === collection.id)
+    const itemId = collectionItems.length > 0 ? collectionItems[0].id : undefined
     return connectDropTarget(
       <div className={`SidebarCollection ${isSelected ? 'is-selected' : ''} ${isOver ? (canDrop ? 'is-over' : 'no-drop') : ''}`}>
-        <Link to={locations.itemEditor({ collectionId: collection.id })}>
+        <Link to={locations.itemEditor({ collectionId: collection.id, itemId })}>
           <CollectionImage collection={collection} />
           <div className="wrapper">
             <div className="name">
               {collection.name}
               <CollectionBadge collection={collection} />
             </div>
-            <div className="count">
-              {t('item_editor.left_panel.items_count', { count: items.filter(item => item.collectionId === collection.id).length })}
-            </div>
+            <div className="count">{t('item_editor.left_panel.items_count', { count: collectionItems.length })}</div>
           </div>
         </Link>
       </div>

--- a/src/components/ItemEditorPage/LeftPanel/LeftPanel.tsx
+++ b/src/components/ItemEditorPage/LeftPanel/LeftPanel.tsx
@@ -24,9 +24,9 @@ export default class LeftPanel extends React.PureComponent<Props> {
     return (
       <div className="LeftPanel">
         <CollectionProvider id={selectedCollectionId}>
-          {(_collection, collectionItems, isLoading) => {
+          {(collection, collectionItems, isLoading) => {
             const listItems = selectedCollectionId ? collectionItems : orphanItems
-            return isLoading ? (
+            return !collection && isLoading ? (
               <Loader size="massive" active />
             ) : listItems.length === 0 && collections.length === 0 ? (
               <>

--- a/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
@@ -65,7 +65,7 @@ export default class RightPanel extends React.PureComponent<Props> {
       <div className="RightPanel">
         <ItemProvider id={selectedItemId}>
           {(item, _collection, isLoading) =>
-            isLoading ? (
+            !item && isLoading ? (
               <Loader size="massive" active />
             ) : (
               <>

--- a/src/modules/editor/sagas.ts
+++ b/src/modules/editor/sagas.ts
@@ -52,7 +52,8 @@ import {
   SetBodyShapeAction,
   SET_AVATAR_ANIMATION,
   SetAvatarAnimationAction,
-  SetItemsAction
+  SetItemsAction,
+  setBodyShape
 } from 'modules/editor/actions'
 import {
   PROVISION_SCENE,
@@ -127,6 +128,7 @@ import femaleAvatar from './wearables/female.json'
 import { Wearable } from 'decentraland-ecs'
 import { SAVE_ITEM_SUCCESS } from 'modules/item/actions'
 import { AssetPackState } from 'modules/assetPack/reducer'
+import { getBodyShapes, hasBodyShape } from 'modules/item/utils'
 
 const editorWindow = window as EditorWindow
 
@@ -349,8 +351,22 @@ function* handleOpenEditor(action: OpenEditorAction) {
       editorWindow.editor.setCameraRotation(Math.PI, Math.PI / 16)
     })
 
-    // render selected items
-    yield put(setItems(item ? [item] : []))
+    if (item) {
+      // select a valid body shape for the selected item
+      const currentBodyShape: ReturnType<typeof getBodyShape> = yield select(getBodyShape)
+      if (!hasBodyShape(item, currentBodyShape)) {
+        const bodyShapes = getBodyShapes(item)
+        if (bodyShapes.length > 0) {
+          yield put(setBodyShape(bodyShapes[0]))
+        }
+      }
+
+      // render avatar with selected item
+      yield put(setItems([item]))
+    } else {
+      // render avatar without any selected items
+      yield put(setItems([]))
+    }
   } else {
     // Creates a new scene in the dcl client's side
     const project: Project | Pool | null = yield type === PreviewType.POOL ? select(getCurrentPool) : select(getCurrentProject)

--- a/src/modules/item/utils.ts
+++ b/src/modules/item/utils.ts
@@ -55,7 +55,7 @@ export function getBodyShapeType(item: Item) {
 }
 
 export function getBodyShapes(item: Item) {
-  const bodyShapes = new Set()
+  const bodyShapes = new Set<WearableBodyShape>()
   for (const representation of item.data.representations) {
     for (const bodyShape of representation.bodyShape) {
       bodyShapes.add(bodyShape)


### PR DESCRIPTION
Few fixes:

+ Select a valid body shape for the selected item when opening the editor
+ Auto select the collection when opening an item that's inside a collection
+ Auto select the first item of the collection when opening a collection 
+ Show the loading spinners in the sidebars only the first load (when there's still no data in the store)