### PR TITLE
fix: editor back button

### DIFF
--- a/src/components/TopBar/TopBar.container.ts
+++ b/src/components/TopBar/TopBar.container.ts
@@ -11,6 +11,8 @@ import { getCurrentMetrics } from 'modules/scene/selectors'
 import { isSavingCurrentProject } from 'modules/sync/selectors'
 import { MapStateProps, MapDispatchProps, MapDispatch } from './TopBar.types'
 import TopBar from './TopBar'
+import { hasHistory } from 'modules/location/selectors'
+import { goBack, push } from 'connected-react-router'
 
 const mapState = (state: RootState): MapStateProps => {
   const selectedEntityIds = getSelectedEntityIds(state)
@@ -24,7 +26,8 @@ const mapState = (state: RootState): MapStateProps => {
     isPreviewing: isPreviewing(state),
     isUploading: isSavingCurrentProject(state),
     isSidebarOpen: isSidebarOpen(state),
-    enabledTools: getEnabledTools(state)
+    enabledTools: getEnabledTools(state),
+    hasHistory: hasHistory(state)
   }
 }
 
@@ -35,7 +38,9 @@ const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
   onReset: () => dispatch(resetItem()),
   onDuplicate: () => dispatch(duplicateItem()),
   onDelete: () => dispatch(deleteItem()),
-  onOpenModal: (name, metadata) => dispatch(openModal(name, metadata))
+  onOpenModal: (name, metadata) => dispatch(openModal(name, metadata)),
+  onBack: () => dispatch(goBack()),
+  onNavigate: path => dispatch(push(path))
 })
 
 export default connect(mapState, mapDispatch)(TopBar)

--- a/src/components/TopBar/TopBar.css
+++ b/src/components/TopBar/TopBar.css
@@ -46,6 +46,11 @@
   align-items: center;
 }
 
+.TopBar .project-title-header .go-back:hover {
+  cursor: pointer;
+  color: var(--primary);
+}
+
 .TopBar .project-title {
   user-select: none;
   cursor: pointer;

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { Link } from 'react-router-dom'
 import { Header, Grid, Icon } from 'decentraland-ui'
 import { IntercomWidget } from 'decentraland-dapps/dist/components/Intercom/IntercomWidget'
 
@@ -53,6 +52,15 @@ export default class TopBar extends React.PureComponent<Props> {
     }
   }
 
+  handleGoBack = () => {
+    const { currentProject, onNavigate, onBack, hasHistory } = this.props
+    if (hasHistory) {
+      onBack()
+    } else {
+      onNavigate(currentProject ? locations.sceneDetail(currentProject.id) : locations.root())
+    }
+  }
+
   handleExport = () => {
     this.props.onOpenModal('ExportModal', { project: this.props.currentProject })
   }
@@ -82,9 +90,9 @@ export default class TopBar extends React.PureComponent<Props> {
       <Grid className="TopBar">
         <Grid.Column mobile={4} tablet={4} computer={4} className="left-column" verticalAlign="middle">
           <Header size="medium" className="project-title-header">
-            <Link className="text" to={currentProject ? locations.sceneDetail(currentProject.id) : locations.root()}>
+            <div className="go-back" onClick={this.handleGoBack}>
               <Icon name="chevron left" />
-            </Link>
+            </div>
             {currentProject ? (
               <>
                 <DeploymentStatus projectId={currentProject.id} />

--- a/src/components/TopBar/TopBar.types.ts
+++ b/src/components/TopBar/TopBar.types.ts
@@ -15,6 +15,7 @@ import { ModelMetrics } from 'modules/scene/types'
 import { Project } from 'modules/project/types'
 import { Gizmo } from 'modules/editor/types'
 import { PoolGroup } from 'modules/poolGroup/types'
+import { CallHistoryMethodAction, goBack } from 'connected-react-router'
 
 export type Props = {
   gizmo: Gizmo
@@ -34,6 +35,9 @@ export type Props = {
   onDuplicate: typeof duplicateItem
   onDelete: typeof deleteItem
   onOpenModal: typeof openModal
+  hasHistory: boolean
+  onBack: typeof goBack
+  onNavigate: (path: string) => void
 }
 
 export type MapStateProps = Pick<
@@ -48,11 +52,12 @@ export type MapStateProps = Pick<
   | 'isSidebarOpen'
   | 'selectedEntityIds'
   | 'enabledTools'
+  | 'hasHistory'
 >
 
 export type MapDispatchProps = Pick<
   Props,
-  'onSetGizmo' | 'onTogglePreview' | 'onToggleSidebar' | 'onReset' | 'onDuplicate' | 'onDelete' | 'onOpenModal'
+  'onSetGizmo' | 'onTogglePreview' | 'onToggleSidebar' | 'onReset' | 'onDuplicate' | 'onDelete' | 'onOpenModal' | 'onBack' | 'onNavigate'
 >
 export type MapDispatch = Dispatch<
   | SetGizmoAction
@@ -63,4 +68,5 @@ export type MapDispatch = Dispatch<
   | DuplicateItemAction
   | DeleteItemAction
   | OpenModalAction
+  | CallHistoryMethodAction
 >


### PR DESCRIPTION
This fixes an error intruduced by #1146 that causes the "back" button in the scene editor and the "back" button in the scene detail page to loop when clicking them (because the one in the editor does a push, and the one in the detail page does a pop). This PR fixes that.