### PR TITLE
refactor: remove nested collections and items

### DIFF
--- a/src/components/CollectionProvider/CollectionProvider.container.ts
+++ b/src/components/CollectionProvider/CollectionProvider.container.ts
@@ -6,7 +6,6 @@ import { getCollectionId } from 'modules/location/selectors'
 import { isLoggingIn } from 'modules/identity/selectors'
 import { getLoading, getCollection, getCollectionItems } from 'modules/collection/selectors'
 import { FETCH_COLLECTION_REQUEST, fetchCollectionRequest } from 'modules/collection/actions'
-import { fetchCollectionItemsRequest } from 'modules/item/actions'
 import { MapStateProps, MapDispatchProps, MapDispatch, OwnProps } from './CollectionProvider.types'
 import CollectionProvider from './CollectionProvider'
 
@@ -23,8 +22,7 @@ const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
 }
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
-  onFetchCollection: id => dispatch(fetchCollectionRequest(id)),
-  onFetchCollectionItems: id => dispatch(fetchCollectionItemsRequest(id))
+  onFetchCollection: id => dispatch(fetchCollectionRequest(id))
 })
 
 export default connect(mapState, mapDispatch)(CollectionProvider)

--- a/src/components/CollectionProvider/CollectionProvider.container.ts
+++ b/src/components/CollectionProvider/CollectionProvider.container.ts
@@ -6,6 +6,7 @@ import { getCollectionId } from 'modules/location/selectors'
 import { isLoggingIn } from 'modules/identity/selectors'
 import { getLoading, getCollection, getCollectionItems } from 'modules/collection/selectors'
 import { FETCH_COLLECTION_REQUEST, fetchCollectionRequest } from 'modules/collection/actions'
+import { fetchCollectionItemsRequest } from 'modules/item/actions'
 import { MapStateProps, MapDispatchProps, MapDispatch, OwnProps } from './CollectionProvider.types'
 import CollectionProvider from './CollectionProvider'
 
@@ -22,7 +23,8 @@ const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
 }
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
-  onFetchCollection: id => dispatch(fetchCollectionRequest(id))
+  onFetchCollection: id => dispatch(fetchCollectionRequest(id)),
+  onFetchCollectionItems: id => dispatch(fetchCollectionItemsRequest(id))
 })
 
 export default connect(mapState, mapDispatch)(CollectionProvider)

--- a/src/components/CollectionProvider/CollectionProvider.tsx
+++ b/src/components/CollectionProvider/CollectionProvider.tsx
@@ -3,23 +3,17 @@ import { Props } from './CollectionProvider.types'
 
 export default class CollectionProvider extends React.PureComponent<Props> {
   componentDidMount() {
-    const { id, collection } = this.props
+    const { id, collection, onFetchCollection } = this.props
     if (id && !collection) {
-      this.fetchCollection(id)
+      onFetchCollection(id)
     }
   }
 
   componentDidUpdate(prevProps: Props) {
-    const { id, collection } = this.props
+    const { id, collection, onFetchCollection } = this.props
     if (id && id !== prevProps.id && !collection) {
-      this.fetchCollection(id)
+      onFetchCollection(id)
     }
-  }
-
-  fetchCollection(id: string) {
-    const { onFetchCollection, onFetchCollectionItems } = this.props
-    onFetchCollection(id)
-    onFetchCollectionItems(id)
   }
 
   render() {

--- a/src/components/CollectionProvider/CollectionProvider.tsx
+++ b/src/components/CollectionProvider/CollectionProvider.tsx
@@ -3,17 +3,23 @@ import { Props } from './CollectionProvider.types'
 
 export default class CollectionProvider extends React.PureComponent<Props> {
   componentDidMount() {
-    const { id, collection, onFetchCollection } = this.props
+    const { id, collection } = this.props
     if (id && !collection) {
-      onFetchCollection(id)
+      this.fetchCollection(id)
     }
   }
 
   componentDidUpdate(prevProps: Props) {
-    const { id, onFetchCollection } = this.props
-    if (id && id !== prevProps.id) {
-      onFetchCollection(id)
+    const { id, collection } = this.props
+    if (id && id !== prevProps.id && !collection) {
+      this.fetchCollection(id)
     }
+  }
+
+  fetchCollection(id: string) {
+    const { onFetchCollection, onFetchCollectionItems } = this.props
+    onFetchCollection(id)
+    onFetchCollectionItems(id)
   }
 
   render() {

--- a/src/components/CollectionProvider/CollectionProvider.types.ts
+++ b/src/components/CollectionProvider/CollectionProvider.types.ts
@@ -2,6 +2,7 @@ import { Dispatch } from 'redux'
 import { Collection } from 'modules/collection/types'
 import { fetchCollectionRequest, FetchCollectionRequestAction } from 'modules/collection/actions'
 import { Item } from 'modules/item/types'
+import { fetchCollectionItemsRequest, FetchCollectionItemsRequestAction } from 'modules/item/actions'
 
 export type Props = {
   id: string | null
@@ -10,9 +11,10 @@ export type Props = {
   isLoading: boolean
   children: (collection: Collection | null, items: Item[], isLoading: boolean) => React.ReactNode
   onFetchCollection: typeof fetchCollectionRequest
+  onFetchCollectionItems: typeof fetchCollectionItemsRequest
 }
 
 export type MapStateProps = Pick<Props, 'id' | 'collection' | 'items' | 'isLoading'>
-export type MapDispatchProps = Pick<Props, 'onFetchCollection'>
-export type MapDispatch = Dispatch<FetchCollectionRequestAction>
+export type MapDispatchProps = Pick<Props, 'onFetchCollection' | 'onFetchCollectionItems'>
+export type MapDispatch = Dispatch<FetchCollectionRequestAction | FetchCollectionItemsRequestAction>
 export type OwnProps = Partial<Pick<Props, 'id'>>

--- a/src/components/CollectionProvider/CollectionProvider.types.ts
+++ b/src/components/CollectionProvider/CollectionProvider.types.ts
@@ -2,7 +2,7 @@ import { Dispatch } from 'redux'
 import { Collection } from 'modules/collection/types'
 import { fetchCollectionRequest, FetchCollectionRequestAction } from 'modules/collection/actions'
 import { Item } from 'modules/item/types'
-import { fetchCollectionItemsRequest, FetchCollectionItemsRequestAction } from 'modules/item/actions'
+import { FetchCollectionItemsRequestAction } from 'modules/item/actions'
 
 export type Props = {
   id: string | null
@@ -11,10 +11,9 @@ export type Props = {
   isLoading: boolean
   children: (collection: Collection | null, items: Item[], isLoading: boolean) => React.ReactNode
   onFetchCollection: typeof fetchCollectionRequest
-  onFetchCollectionItems: typeof fetchCollectionItemsRequest
 }
 
 export type MapStateProps = Pick<Props, 'id' | 'collection' | 'items' | 'isLoading'>
-export type MapDispatchProps = Pick<Props, 'onFetchCollection' | 'onFetchCollectionItems'>
+export type MapDispatchProps = Pick<Props, 'onFetchCollection'>
 export type MapDispatch = Dispatch<FetchCollectionRequestAction | FetchCollectionItemsRequestAction>
 export type OwnProps = Partial<Pick<Props, 'id'>>

--- a/src/components/ItemProvider/ItemProvider.tsx
+++ b/src/components/ItemProvider/ItemProvider.tsx
@@ -10,8 +10,8 @@ export default class ItemProvider extends React.PureComponent<Props> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    const { id, onFetchItem } = this.props
-    if (id && id !== prevProps.id) {
+    const { id, item, onFetchItem } = this.props
+    if (id && id !== prevProps.id && !item) {
       onFetchItem(id)
     }
   }

--- a/src/modules/collection/actions.ts
+++ b/src/modules/collection/actions.ts
@@ -10,8 +10,7 @@ export const FETCH_COLLECTIONS_SUCCESS = '[Success] Fetch Collections'
 export const FETCH_COLLECTIONS_FAILURE = '[Failure] Fetch Collections'
 
 export const fetchCollectionsRequest = () => action(FETCH_COLLECTIONS_REQUEST)
-export const fetchCollectionsSuccess = (collections: Collection[], items: Item[]) =>
-  action(FETCH_COLLECTIONS_SUCCESS, { collections, items })
+export const fetchCollectionsSuccess = (collections: Collection[]) => action(FETCH_COLLECTIONS_SUCCESS, { collections })
 export const fetchCollectionsFailure = (error: string) => action(FETCH_COLLECTIONS_FAILURE, { error })
 
 export type FetchCollectionsRequestAction = ReturnType<typeof fetchCollectionsRequest>
@@ -25,7 +24,7 @@ export const FETCH_COLLECTION_SUCCESS = '[Success] Fetch Collection'
 export const FETCH_COLLECTION_FAILURE = '[Failure] Fetch Collection'
 
 export const fetchCollectionRequest = (id: string) => action(FETCH_COLLECTION_REQUEST, { id })
-export const fetchCollectionSuccess = (collection: Collection, items: Item[]) => action(FETCH_COLLECTION_SUCCESS, { collection, items })
+export const fetchCollectionSuccess = (id: string, collection: Collection) => action(FETCH_COLLECTION_SUCCESS, { id, collection })
 export const fetchCollectionFailure = (id: string, error: string) => action(FETCH_COLLECTION_FAILURE, { id, error })
 
 export type FetchCollectionRequestAction = ReturnType<typeof fetchCollectionRequest>

--- a/src/modules/collection/reducer.ts
+++ b/src/modules/collection/reducer.ts
@@ -1,6 +1,5 @@
 import { LoadingState, loadingReducer } from 'decentraland-dapps/dist/modules/loading/reducer'
 import { FetchTransactionSuccessAction, FETCH_TRANSACTION_SUCCESS } from 'decentraland-dapps/dist/modules/transaction/actions'
-import { FetchItemsSuccessAction, FetchItemSuccessAction, FETCH_ITEMS_SUCCESS, FETCH_ITEM_SUCCESS } from 'modules/item/actions'
 import {
   FetchCollectionsRequestAction,
   FetchCollectionsSuccessAction,
@@ -59,8 +58,6 @@ type CollectionReducerAction =
   | DeleteCollectionSuccessAction
   | DeleteCollectionFailureAction
   | FetchTransactionSuccessAction
-  | FetchItemsSuccessAction
-  | FetchItemSuccessAction
 
 export function collectionReducer(state: CollectionState = INITIAL_STATE, action: CollectionReducerAction) {
   switch (action.type) {
@@ -84,32 +81,6 @@ export function collectionReducer(state: CollectionState = INITIAL_STATE, action
         loading: loadingReducer(state.loading, action),
         error: null
       }
-    }
-    case FETCH_ITEMS_SUCCESS: {
-      const { collections } = action.payload
-      return {
-        ...state,
-        data: {
-          ...state.data,
-          ...toCollectionObject(collections)
-        },
-        loading: loadingReducer(state.loading, action),
-        error: null
-      }
-    }
-    case FETCH_ITEM_SUCCESS: {
-      const { collection } = action.payload
-      return collection
-        ? {
-            ...state,
-            data: {
-              ...state.data,
-              ...toCollectionObject([collection])
-            },
-            loading: loadingReducer(state.loading, action),
-            error: null
-          }
-        : state
     }
     case FETCH_COLLECTION_SUCCESS:
     case SAVE_COLLECTION_SUCCESS: {

--- a/src/modules/collection/reducer.ts
+++ b/src/modules/collection/reducer.ts
@@ -127,6 +127,7 @@ export function collectionReducer(state: CollectionState = INITIAL_STATE, action
           return {
             ...state,
             data: {
+              ...state.data,
               [collection.id]: {
                 ...state.data[collection.id],
                 isPublished: true
@@ -139,6 +140,7 @@ export function collectionReducer(state: CollectionState = INITIAL_STATE, action
           return {
             ...state,
             data: {
+              ...state.data,
               [collection.id]: {
                 ...state.data[collection.id],
                 minters: [...minters]
@@ -151,6 +153,7 @@ export function collectionReducer(state: CollectionState = INITIAL_STATE, action
           return {
             ...state,
             data: {
+              ...state.data,
               [collection.id]: {
                 ...state.data[collection.id],
                 managers: [...managers]

--- a/src/modules/collection/sagas.ts
+++ b/src/modules/collection/sagas.ts
@@ -73,8 +73,8 @@ export function* collectionSaga() {
 
 function* handleFetchCollectionsRequest(_action: FetchCollectionsRequestAction) {
   try {
-    const { collections, items }: { collections: Collection[]; items: Item[] } = yield call(() => builder.fetchCollections())
-    yield put(fetchCollectionsSuccess(collections, items))
+    const collections: Collection[] = yield call(() => builder.fetchCollections())
+    yield put(fetchCollectionsSuccess(collections))
     yield put(closeModal('CreateCollectionModal'))
   } catch (error) {
     yield put(fetchCollectionsFailure(error.message))
@@ -84,8 +84,8 @@ function* handleFetchCollectionsRequest(_action: FetchCollectionsRequestAction) 
 function* handleFetchCollectionRequest(action: FetchCollectionRequestAction) {
   const { id } = action.payload
   try {
-    const { collection, items }: { collection: Collection; items: Item[] } = yield call(() => builder.fetchCollection(id))
-    yield put(fetchCollectionSuccess(collection, items))
+    const collection: Collection = yield call(() => builder.fetchCollection(id))
+    yield put(fetchCollectionSuccess(id, collection))
   } catch (error) {
     yield put(fetchCollectionFailure(id, error.message))
   }

--- a/src/modules/collection/sagas.ts
+++ b/src/modules/collection/sagas.ts
@@ -94,7 +94,7 @@ function* handleFetchCollectionRequest(action: FetchCollectionRequestAction) {
 function* handleSaveCollectionRequest(action: SaveCollectionRequestAction) {
   const { collection } = action.payload
   try {
-    const { collection: remoteCollection }: { collection: Collection; items: Item[] } = yield call(() => builder.saveCollection(collection))
+    const remoteCollection: Collection = yield call(() => builder.saveCollection(collection))
     const newCollection = { ...collection, ...remoteCollection }
     yield put(saveCollectionSuccess(newCollection))
     yield put(closeModal('CreateCollectionModal'))
@@ -127,6 +127,10 @@ function* handlePublishCollectionRequest(action: PublishCollectionRequestAction)
     const implementation = new ERC721CollectionV2(eth, Address.fromString(ERC721_COLLECTION_ADDRESS))
 
     const data = initializeCollection(implementation, collection, items, from)
+
+    if (!collection.salt) {
+      throw new Error('The collection has no salt 🧂')
+    }
 
     const txHash = yield call(() =>
       factory.methods

--- a/src/modules/item/actions.ts
+++ b/src/modules/item/actions.ts
@@ -10,7 +10,7 @@ export const FETCH_ITEMS_SUCCESS = '[Success] Fetch Items'
 export const FETCH_ITEMS_FAILURE = '[Failure] Fetch Items'
 
 export const fetchItemsRequest = () => action(FETCH_ITEMS_REQUEST)
-export const fetchItemsSuccess = (items: Item[], collections: Collection[]) => action(FETCH_ITEMS_SUCCESS, { items, collections })
+export const fetchItemsSuccess = (items: Item[]) => action(FETCH_ITEMS_SUCCESS, { items })
 export const fetchItemsFailure = (error: string) => action(FETCH_ITEMS_FAILURE, { error })
 
 export type FetchItemsRequestAction = ReturnType<typeof fetchItemsRequest>
@@ -24,12 +24,28 @@ export const FETCH_ITEM_SUCCESS = '[Success] Fetch Item'
 export const FETCH_ITEM_FAILURE = '[Failure] Fetch Item'
 
 export const fetchItemRequest = (id: string) => action(FETCH_ITEM_REQUEST, { id })
-export const fetchItemSuccess = (item: Item, collection: Collection | null) => action(FETCH_ITEM_SUCCESS, { item, collection })
+export const fetchItemSuccess = (id: string, item: Item) => action(FETCH_ITEM_SUCCESS, { id, item })
 export const fetchItemFailure = (id: string, error: string) => action(FETCH_ITEM_FAILURE, { id, error })
 
 export type FetchItemRequestAction = ReturnType<typeof fetchItemRequest>
 export type FetchItemSuccessAction = ReturnType<typeof fetchItemSuccess>
 export type FetchItemFailureAction = ReturnType<typeof fetchItemFailure>
+
+// Fetch collection item
+
+export const FETCH_COLLECTION_ITEMS_REQUEST = '[Request] Fetch Collection Items'
+export const FETCH_COLLECTION_ITEMS_SUCCESS = '[Success] Fetch Collection Items'
+export const FETCH_COLLECTION_ITEMS_FAILURE = '[Failure] Fetch Collection Items'
+
+export const fetchCollectionItemsRequest = (collectionId: string) => action(FETCH_COLLECTION_ITEMS_REQUEST, { collectionId })
+export const fetchCollectionItemsSuccess = (collectionId: string, items: Item[]) =>
+  action(FETCH_COLLECTION_ITEMS_SUCCESS, { collectionId, items })
+export const fetchCollectionItemsFailure = (collectionId: string, error: string) =>
+  action(FETCH_COLLECTION_ITEMS_FAILURE, { collectionId, error })
+
+export type FetchCollectionItemsRequestAction = ReturnType<typeof fetchCollectionItemsRequest>
+export type FetchCollectionItemsSuccessAction = ReturnType<typeof fetchCollectionItemsSuccess>
+export type FetchCollectionItemsFailureAction = ReturnType<typeof fetchCollectionItemsFailure>
 
 // Save items
 

--- a/src/modules/item/reducer.ts
+++ b/src/modules/item/reducer.ts
@@ -1,14 +1,7 @@
 import { FetchTransactionSuccessAction, FETCH_TRANSACTION_SUCCESS } from 'decentraland-dapps/dist/modules/transaction/actions'
 import { LoadingState, loadingReducer } from 'decentraland-dapps/dist/modules/loading/reducer'
 import { Mint } from 'modules/collection/types'
-import {
-  FetchCollectionsSuccessAction,
-  FetchCollectionSuccessAction,
-  FETCH_COLLECTIONS_SUCCESS,
-  FETCH_COLLECTION_SUCCESS,
-  PUBLISH_COLLECTION_SUCCESS,
-  MINT_COLLECTION_ITEMS_SUCCESS
-} from 'modules/collection/actions'
+import { PUBLISH_COLLECTION_SUCCESS, MINT_COLLECTION_ITEMS_SUCCESS } from 'modules/collection/actions'
 import {
   FetchItemsRequestAction,
   FetchItemsSuccessAction,
@@ -53,7 +46,13 @@ import {
   DeployItemContentsFailureAction,
   DEPLOY_ITEM_CONTENTS_REQUEST,
   DEPLOY_ITEM_CONTENTS_SUCCESS,
-  DEPLOY_ITEM_CONTENTS_FAILURE
+  DEPLOY_ITEM_CONTENTS_FAILURE,
+  FetchCollectionItemsRequestAction,
+  FetchCollectionItemsSuccessAction,
+  FetchCollectionItemsFailureAction,
+  FETCH_COLLECTION_ITEMS_SUCCESS,
+  FETCH_COLLECTION_ITEMS_REQUEST,
+  FETCH_COLLECTION_ITEMS_FAILURE
 } from './actions'
 import { toItemObject } from './utils'
 import { Item } from './types'
@@ -94,13 +93,15 @@ type ItemReducerAction =
   | DeployItemContentsRequestAction
   | DeployItemContentsSuccessAction
   | DeployItemContentsFailureAction
-  | FetchCollectionsSuccessAction
-  | FetchCollectionSuccessAction
+  | FetchCollectionItemsRequestAction
+  | FetchCollectionItemsSuccessAction
+  | FetchCollectionItemsFailureAction
 
 export function itemReducer(state: ItemState = INITIAL_STATE, action: ItemReducerAction) {
   switch (action.type) {
     case FETCH_ITEMS_REQUEST:
     case FETCH_ITEM_REQUEST:
+    case FETCH_COLLECTION_ITEMS_REQUEST:
     case SET_ITEMS_TOKEN_ID_REQUEST:
     case DEPLOY_ITEM_CONTENTS_REQUEST:
     case SAVE_PUBLISHED_ITEM_REQUEST:
@@ -111,6 +112,7 @@ export function itemReducer(state: ItemState = INITIAL_STATE, action: ItemReduce
         loading: loadingReducer(state.loading, action)
       }
     }
+    case FETCH_COLLECTION_ITEMS_SUCCESS:
     case FETCH_ITEMS_SUCCESS:
     case SET_ITEMS_TOKEN_ID_SUCCESS: {
       const { items } = action.payload
@@ -151,30 +153,6 @@ export function itemReducer(state: ItemState = INITIAL_STATE, action: ItemReduce
         error: null
       }
     }
-    case FETCH_COLLECTIONS_SUCCESS: {
-      const { items } = action.payload
-      return {
-        ...state,
-        data: {
-          ...state.data,
-          ...toItemObject(items)
-        },
-        loading: loadingReducer(state.loading, action),
-        error: null
-      }
-    }
-    case FETCH_COLLECTION_SUCCESS: {
-      const { items } = action.payload
-      return {
-        ...state,
-        data: {
-          ...state.data,
-          ...toItemObject(items)
-        },
-        loading: loadingReducer(state.loading, action),
-        error: null
-      }
-    }
     case DELETE_ITEM_SUCCESS: {
       const { item } = action.payload
       const newState = {
@@ -189,6 +167,7 @@ export function itemReducer(state: ItemState = INITIAL_STATE, action: ItemReduce
     }
     case FETCH_ITEMS_FAILURE:
     case FETCH_ITEM_FAILURE:
+    case FETCH_COLLECTION_ITEMS_FAILURE:
     case SET_ITEMS_TOKEN_ID_FAILURE:
     case SAVE_PUBLISHED_ITEM_FAILURE:
     case SAVE_ITEM_FAILURE:

--- a/src/modules/item/reducer.ts
+++ b/src/modules/item/reducer.ts
@@ -204,13 +204,10 @@ export function itemReducer(state: ItemState = INITIAL_STATE, action: ItemReduce
             ...state,
             data: {
               ...state.data,
-              ...items.reduce(
-                (accum, item) => ({
-                  ...accum,
-                  [item.id]: { ...state.data[item.id], ...item, isPublished: true }
-                }),
-                {}
-              )
+              ...items.reduce((accum, item) => {
+                accum[item.id] = { ...state.data[item.id], ...item, isPublished: true }
+                return accum
+              }, {} as ItemState['data'])
             }
           }
         }
@@ -224,11 +221,22 @@ export function itemReducer(state: ItemState = INITIAL_STATE, action: ItemReduce
               ...mints.reduce((accum, mint) => {
                 const item = state.data[mint.item.id]
                 const totalSupply = (item.totalSupply || 0) + 1
-                return {
-                  ...accum,
-                  [item.id]: { ...state.data[item.id], totalSupply }
-                }
-              }, {})
+                accum[item.id] = { ...state.data[item.id], totalSupply }
+                return accum
+              }, {} as ItemState['data'])
+            }
+          }
+        }
+        case SAVE_PUBLISHED_ITEM_SUCCESS: {
+          const item: Item = transaction.payload.item
+          return {
+            ...state,
+            data: {
+              ...state.data,
+              [item.id]: {
+                ...state.data[item.id],
+                ...item
+              }
             }
           }
         }

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -36,7 +36,11 @@ import {
   DEPLOY_ITEM_CONTENTS_REQUEST,
   deployItemContentsSuccess,
   deployItemContentsFailure,
-  DeployItemContentsRequestAction
+  DeployItemContentsRequestAction,
+  FETCH_COLLECTION_ITEMS_REQUEST,
+  FetchCollectionItemsRequestAction,
+  fetchCollectionItemsSuccess,
+  fetchCollectionItemsFailure
 } from './actions'
 import { getCurrentAddress } from 'modules/wallet/utils'
 import { getIdentity } from 'modules/identity/utils'
@@ -53,6 +57,7 @@ import { Item } from './types'
 export function* itemSaga() {
   yield takeEvery(FETCH_ITEMS_REQUEST, handleFetchItemsRequest)
   yield takeEvery(FETCH_ITEM_REQUEST, handleFetchItemRequest)
+  yield takeEvery(FETCH_COLLECTION_ITEMS_REQUEST, handleFetchCollectionItemsRequest)
   yield takeEvery(SAVE_ITEM_REQUEST, handleSaveItemRequest)
   yield takeEvery(SAVE_PUBLISHED_ITEM_REQUEST, handleSavePublishedItemRequest)
   yield takeEvery(DELETE_ITEM_REQUEST, handleDeleteItemRequest)
@@ -64,8 +69,8 @@ export function* itemSaga() {
 
 function* handleFetchItemsRequest(_action: FetchItemsRequestAction) {
   try {
-    const { items, collections }: { items: Item[]; collections: Collection[] } = yield call(() => builder.fetchItems())
-    yield put(fetchItemsSuccess(items, collections))
+    const items: Item[] = yield call(() => builder.fetchItems())
+    yield put(fetchItemsSuccess(items))
   } catch (error) {
     yield put(fetchItemsFailure(error.message))
   }
@@ -74,10 +79,20 @@ function* handleFetchItemsRequest(_action: FetchItemsRequestAction) {
 function* handleFetchItemRequest(action: FetchItemRequestAction) {
   const { id } = action.payload
   try {
-    const { item, collection }: { item: Item; collection: Collection | null } = yield call(() => builder.fetchItem(id))
-    yield put(fetchItemSuccess(item, collection))
+    const item: Item = yield call(() => builder.fetchItem(id))
+    yield put(fetchItemSuccess(id, item))
   } catch (error) {
     yield put(fetchItemFailure(id, error.message))
+  }
+}
+
+function* handleFetchCollectionItemsRequest(action: FetchCollectionItemsRequestAction) {
+  const { collectionId } = action.payload
+  try {
+    const items: Item[] = yield call(() => builder.fetchCollectionItems(collectionId))
+    yield put(fetchCollectionItemsSuccess(collectionId, items))
+  } catch (error) {
+    yield put(fetchCollectionItemsFailure(collectionId, error.message))
   }
 }
 

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -40,8 +40,10 @@ import {
   FETCH_COLLECTION_ITEMS_REQUEST,
   FetchCollectionItemsRequestAction,
   fetchCollectionItemsSuccess,
-  fetchCollectionItemsFailure
+  fetchCollectionItemsFailure,
+  fetchCollectionItemsRequest
 } from './actions'
+import { FetchCollectionRequestAction, FETCH_COLLECTION_REQUEST } from 'modules/collection/actions'
 import { getCurrentAddress } from 'modules/wallet/utils'
 import { getIdentity } from 'modules/identity/utils'
 import { ERC721CollectionV2 } from 'contracts/ERC721CollectionV2'
@@ -65,6 +67,7 @@ export function* itemSaga() {
   yield takeLatest(SET_COLLECTION, handleSetCollection)
   yield takeLatest(SET_ITEMS_TOKEN_ID_REQUEST, handleSetItemsTokenIdRequest)
   yield takeLatest(DEPLOY_ITEM_CONTENTS_REQUEST, handleDeployItemContentsRequest)
+  yield takeEvery(FETCH_COLLECTION_REQUEST, handleFetchCollectionRequest)
 }
 
 function* handleFetchItemsRequest(_action: FetchItemsRequestAction) {
@@ -207,6 +210,11 @@ function* handleDeployItemContentsRequest(action: DeployItemContentsRequestActio
   } catch (error) {
     yield put(deployItemContentsFailure(collection, item, error.message))
   }
+}
+
+function* handleFetchCollectionRequest(action: FetchCollectionRequestAction) {
+  const { id } = action.payload
+  yield put(fetchCollectionItemsRequest(id))
 }
 
 export function saveItem(item: Item, contents: Record<string, Blob> = {}) {


### PR DESCRIPTION
**Depends on:** https://github.com/decentraland/builder-server/pull/135

This PR makes the necessary changes to use the version of the server that does't return nested items and collections.

Since collections don't come with their items inside, I added an extra endpoint to the server and a corresponding action on the frontend to fetch a collection's items