### PR TITLE
fix: custom smart items

### DIFF
--- a/src/components/AssetImporter/AssetImporter.tsx
+++ b/src/components/AssetImporter/AssetImporter.tsx
@@ -283,8 +283,9 @@ export default class AssetImporter<T extends MixedAssetPack = RawAssetPack> exte
             throw new Error(
               t('asset_pack.import.errors.duplicated_asset', {
                 name: truncateFileName(file.name),
-                model: outFile.asset.model,
-                asset: existingAsset.name
+                id: existingAsset.id,
+                existingAsset: existingAsset.name,
+                newAsset: outFile.asset.name
               })
             )
           }

--- a/src/components/AssetImporter/utils.ts
+++ b/src/components/AssetImporter/utils.ts
@@ -5,8 +5,16 @@ import { ModelMetrics } from 'modules/scene/types'
 
 export const ASSET_MANIFEST = 'asset.json'
 
+/* 
+  This RegEx searches for the beginning of the smart item's bundle, it's a comment that contains '! "src/game.ts" <commit-hash>'
+  We split the code and take everything that comes AFTER this comment
+*/
 export const CODE_SEPARATOR = /\/\*! \"src\/game\.ts\" [a-f0-9]+ \*\//
 
+/* 
+  This separator searches for the end of the smart item's bundle, before the source maps start.
+  We split the code and take everything that comes BEFORE this comment
+*/
 export const SOURCE_MAPS_SEPARATOR = '//# sourceMappingURL'
 
 export function createDefaultImportedFile(id: string, assetPackId: string, file: File): ImportedFile {

--- a/src/components/AssetImporter/utils.ts
+++ b/src/components/AssetImporter/utils.ts
@@ -5,7 +5,8 @@ import { ModelMetrics } from 'modules/scene/types'
 
 export const ASSET_MANIFEST = 'asset.json'
 
-export const CODE_SEPARATOR = 'global.dclamd=loader;'
+export const CODE_SEPARATOR = /\/\*! \"src\/game\.ts\" [a-f0-9]+ \*\//
+
 export const SOURCE_MAPS_SEPARATOR = '//# sourceMappingURL'
 
 export function createDefaultImportedFile(id: string, assetPackId: string, file: File): ImportedFile {
@@ -48,7 +49,7 @@ export async function prepareScript(scriptPath: string, namespace: string, conte
     let text = await new Response(blob).text()
 
     // remove ecs and amd loader
-    if (text.includes(CODE_SEPARATOR)) {
+    if (CODE_SEPARATOR.test(text)) {
       text = text.split(CODE_SEPARATOR).pop()!
     }
 

--- a/src/ecsScene/scene.ts
+++ b/src/ecsScene/scene.ts
@@ -92,7 +92,8 @@ function getScriptInstance(assetId: string) {
           scriptInstances.set(assetId, instance)
           return instance
         })
-        .catch(() => {
+        .catch(error => {
+          console.error(error.message)
           // if something fails, return a dummy script
           console.warn(`Failed to load script for asset id ${assetId}`)
           return {

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -83,7 +83,7 @@
       "description_edit": "Add some more items to your pack",
       "errors": {
         "duplicated": "Duplicated Asset",
-        "duplicated_asset": "{name}: The asset \"{asset}\" already contains a file named \"{model}\"",
+        "duplicated_asset": "{name}: There's already an asset in this asset pack called \"{existingAsset}\" that has the id \"{id}\", please change the id of \"{newAsset}\" to a different one",
         "invalid": "Invalid Asset",
         "max_file_size": "{name}: File size exceeds {max}mb limit",
         "missing_extension": "{name}: Missing file extension",

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -82,7 +82,7 @@
       "description_edit": "Añade algunos assets más a tu pack",
       "errors": {
         "duplicated": "Asset duplicado",
-        "duplicated_asset": "{name}: Este Asset Pack ya contiene un asset \"{asset}\" con un archivo \"{model}\"",
+        "duplicated_asset": "{name}: Ya existe un asset en este asset pack llamado \"{existingAsset}\" que tiene el id \"{id}\", por favor cámbiale el id a \"{newAsset}\" por uno diferente",
         "invalid": "Asset inválido",
         "max_file_size": "{name}: El tamaño del archivo excede el límite de {max}mb",
         "missing_extension": "{name}: Extensión de archivo no encontrada",

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -82,7 +82,7 @@
       "description_edit": "向您添加更多项目Asset Pack",
       "errors": {
         "duplicated": "重复资产",
-        "duplicated_asset": "{name}: 资产 \"{asset}\" 已经包含一个名为 \"{model}\"",
+        "duplicated_asset": "{name}：此资产包中已经有一个名为\"{existingAsset}\"的资产，其ID为\"{id}\"，请将\"{newAsset}\"的ID更改为另一种",
         "invalid": "无效资产",
         "max_file_size": "{name}: 文件大小超过{max}mb的限制"
       },


### PR DESCRIPTION
This PR fixes an issue on prod where users can't import custom smart items. This is due to a change in the way the SDK bundles the JS, we were looking for a piece of code to extract the code of the smart item, but that piece of code doesn't exist anymore, so I updated it to a new regex that matches the way the code is bundled now.

Also I improved the error reporting of duplicated assets because the current one was not clear and caused confusion, now if an item has the id of an already existing item we show the following:

<img width="366" alt="Screen Shot 2020-12-02 at 5 33 42 PM" src="https://user-images.githubusercontent.com/2781777/100932191-432d1c00-34ca-11eb-91db-0729a7292e8f.png">
