### PR TITLE
fix: names limit

### DIFF
--- a/src/lib/api/marketplace.ts
+++ b/src/lib/api/marketplace.ts
@@ -31,11 +31,26 @@ export class MarketplaceAPI {
       return []
     }
     const owner = address.toLowerCase()
-    const { data } = await graphClient.query<SubdomainQueryResult>({
-      query: getSubdomainQuery(),
-      variables: { owner }
-    })
-    return data.nfts.map(ntf => `${ntf.ens.subdomain}`)
+    let results: string[] = []
+    let page: string[] = []
+    let offset = 0
+    let nextPage = true
+    while (nextPage) {
+      const { data } = await graphClient.query<SubdomainQueryResult>({
+        query: getSubdomainQuery(),
+        variables: { owner, offset }
+      })
+      console.log(data.nfts.length)
+      page = data.nfts.map(ntf => `${ntf.ens.subdomain}`)
+      if (page.length > 0) {
+        results = [...results, ...page]
+        offset += 1000
+      } else {
+        nextPage = false
+      }
+    }
+    console.log(results.length)
+    return results
   }
 }
 

--- a/src/lib/api/marketplace.ts
+++ b/src/lib/api/marketplace.ts
@@ -5,9 +5,11 @@ import { createClient } from './graph'
 export const MARKETPLACE_URL = env.get('REACT_APP_MARKETPLACE_GRAPH_URL', '')
 const graphClient = createClient(MARKETPLACE_URL)
 
+const BATCH_SIZE = 1000
+
 const getSubdomainQuery = () => gql`
   query getUserNames($owner: String, $offset: Int) {
-    nfts(first: 1000, skip: $offset, where: { owner: $owner, category: ens }) {
+    nfts(first: ${BATCH_SIZE}, skip: $offset, where: { owner: $owner, category: ens }) {
       ens {
         subdomain
       }
@@ -41,9 +43,9 @@ export class MarketplaceAPI {
         variables: { owner, offset }
       })
       page = data.nfts.map(ntf => `${ntf.ens.subdomain}`)
-      if (page.length > 0) {
-        results = [...results, ...page]
-        offset += 1000
+      results = [...results, ...page]
+      if (page.length === BATCH_SIZE) {
+        offset += BATCH_SIZE
       } else {
         nextPage = false
       }

--- a/src/lib/api/marketplace.ts
+++ b/src/lib/api/marketplace.ts
@@ -40,7 +40,6 @@ export class MarketplaceAPI {
         query: getSubdomainQuery(),
         variables: { owner, offset }
       })
-      console.log(data.nfts.length)
       page = data.nfts.map(ntf => `${ntf.ens.subdomain}`)
       if (page.length > 0) {
         results = [...results, ...page]
@@ -49,7 +48,6 @@ export class MarketplaceAPI {
         nextPage = false
       }
     }
-    console.log(results.length)
     return results
   }
 }

--- a/src/lib/api/marketplace.ts
+++ b/src/lib/api/marketplace.ts
@@ -6,8 +6,8 @@ export const MARKETPLACE_URL = env.get('REACT_APP_MARKETPLACE_GRAPH_URL', '')
 const graphClient = createClient(MARKETPLACE_URL)
 
 const getSubdomainQuery = () => gql`
-  query getUserNames($owner: String) {
-    nfts(where: { owner: $owner, category: ens }) {
+  query getUserNames($owner: String, $offset: Int) {
+    nfts(first: 1000, skip: $offset, where: { owner: $owner, category: ens }) {
       ens {
         subdomain
       }


### PR DESCRIPTION
Currently the builder loads a maximum of 100 names, this PR makes it so it loads as many as the user has. Also I changed a bit the saga so the names are loaded in parallel, which is way faster for users with many names (1000 names took me 5 minutes to load before, and now 20 seconds).