### PR TITLE
fix: prevent fetching empty coords

### DIFF
--- a/src/modules/deployment/sagas.ts
+++ b/src/modules/deployment/sagas.ts
@@ -260,7 +260,7 @@ function* handleFetchDeploymentsRequest(action: FetchDeploymentsRequestAction) {
     const catalyst = new CatalystClient(PEER_URL, 'builder')
 
     const entities: DeploymentWithMetadataContentAndPointers[] = yield call(() =>
-      catalyst.fetchAllDeployments({ pointers: coords, onlyCurrentlyPointed: true })
+      coords.length > 0 ? catalyst.fetchAllDeployments({ pointers: coords, onlyCurrentlyPointed: true }) : []
     )
     const deployments = new Map<string, Deployment>()
     for (const entity of entities


### PR DESCRIPTION
Sending an empty `pointers` array causes the catalyst to return _all_ the entities, degrading the peer's performance and returning unexpected results. It will be fixed on the catalyst, but also we'll release this patch to prevent builder users from stressing the peers until then.