### PR TITLE
fix: appove/reject button size on loading

### DIFF
--- a/src/components/ItemEditorPage/TopPanel/ReviewModal/ReviewModal.css
+++ b/src/components/ItemEditorPage/TopPanel/ReviewModal/ReviewModal.css
@@ -2,13 +2,13 @@
   text-align: center;
 }
 
-.ReviewModal .loading {
+.ReviewModal .loading-transaction {
   position: relative;
   min-height: 80px;
   margin-bottom: 40px;
 }
 
-.ReviewModal .loading .ui.loader {
+.ReviewModal .loading-transaction .ui.loader {
   margin-top: 25px;
 }
 

--- a/src/components/ItemEditorPage/TopPanel/ReviewModal/ReviewModal.tsx
+++ b/src/components/ItemEditorPage/TopPanel/ReviewModal/ReviewModal.tsx
@@ -104,7 +104,7 @@ export default class ReviewModal extends React.PureComponent<Props> {
         {hasPendingTransaction ? (
           <>
             <Modal.Header>{t(`${i18nKey}.title`)}</Modal.Header>
-            <div className="loading">
+            <div className="loading-transaction">
               <div className="danger-text">{t(`${i18nKey}.tx_pending`)}</div>
               <Loader active size="large" />
             </div>


### PR DESCRIPTION
Strangely enough, because of how the files get built, this did not happen in development

Closes #1319