### PR TITLE
fix: handle multiple files in smart items

### DIFF
--- a/src/components/AssetImporter/utils.ts
+++ b/src/components/AssetImporter/utils.ts
@@ -9,7 +9,7 @@ export const ASSET_MANIFEST = 'asset.json'
   This RegEx searches for the beginning of the smart item's bundle, it's a comment that contains '! "src/game.ts" <commit-hash>'
   We split the code and take everything that comes AFTER this comment
 */
-export const CODE_SEPARATOR = /\/\*! \"src\/game\.ts\" [a-f0-9]+ \*\//
+export const CODE_SEPARATOR = /\/\*! \"src\/([A-z0-9|\/|\\|\-|_])*\.ts\" [a-f0-9]+ \*\//
 
 /* 
   This separator searches for the end of the smart item's bundle, before the source maps start.
@@ -64,14 +64,12 @@ export async function prepareScript(scriptPath: string, namespace: string, conte
     // remove source maps
     if (text.includes(SOURCE_MAPS_SEPARATOR)) {
       const padding = text.trim().endsWith(';') ? 3 : 2
-      text =
-        text
-          .trim()
-          .slice(0, -padding)
-          .split(SOURCE_MAPS_SEPARATOR)
-          .shift()! + text.slice(-padding)
+      const parts = text
+        .trim()
+        .slice(0, -padding)
+        .split(SOURCE_MAPS_SEPARATOR)
+      text = parts.shift()! + text.slice(-padding)
     }
-
     /** Namespace module definitions
      * It converts this:
      * define("myModule", ...


### PR DESCRIPTION
This PR fixes an issue when a smart items is composed of multiple files, the CODE_SEPARATOR was looking for `src/game.ts` as the start of the smart item's code, but when a smart item has multiple files sometimes that separator is incorrect. The fix I applkied is looking for the first  `.ts` file within `src/` directory and take that as the beginning of the code.