### PR TITLE
fix: smart item system deps

### DIFF
--- a/src/components/AssetImporter/utils.ts
+++ b/src/components/AssetImporter/utils.ts
@@ -88,9 +88,9 @@ export async function prepareScript(scriptPath: string, namespace: string, conte
      * Into this:
      * ["require", "exports", "namespace/myDependency"]
      */
-    text = text.replace(/\[\\?\"require\\?\", \\?\"exports\\?\", ([\w|\\|\/|\"|,|\s]*)/g, (match, dependencies) => {
+    text = text.replace(/\[\\?\"require\\?\", \\?\"exports\\?\", ([\w|\\|\/|\"|,|\s|@]*)/g, (match, dependencies) => {
       let code = match.slice(0, -dependencies.length) // remove previous dependencies
-      const newDependencies = dependencies.replace(/\\?\"(.*?)\\?\"/g, `\\\"${namespace}/$1\\\"`) // adds the namespace to each dependency
+      const newDependencies = dependencies.replace(/\\?\"(\w.*?)\\?\"/g, `\\\"${namespace}/$1\\\"`) // adds the namespace to each dependency
       return code + newDependencies
     })
 


### PR DESCRIPTION
This PR fixes an issue when importing system dependencies, like `@decentraland/Identity`.

The `@` present in was not matched by the regular expression, preventing dependencies included after them from being namespaced:

This is OK

<img width="662" alt="Screen Shot 2021-05-19 at 3 07 46 PM" src="https://user-images.githubusercontent.com/2781777/118984076-7fa6e400-b953-11eb-8aa7-e26848796af3.png">

This is WRONG:

<img width="654" alt="Screen Shot 2021-05-19 at 3 10 13 PM" src="https://user-images.githubusercontent.com/2781777/118984130-8df50000-b953-11eb-871a-51d812d21581.png">

This error resulted in converting this:

```
["require", "exports", "myFirstDep", "@decentraland/Identity", "mySecondDep"]
```

into:

```
["require", "exports", "smart-item-id/myFirstDep", "@decentraland/Identity", "mySecondDep"]
```

Notice that `mySecondDep` was not namespaced.

So I added `@` to the match regexp to solve this issue.

Then I added a `\w` at the beginning of the namespacing regexp to prevent the system dependencies that now are matched by the first regexp to be namespaced. Otherwise `@decentraland/Identity` would be namespaced into `smart-item-id/@decentraland/Identity`.

Now the result looks like this:

```
["require", "exports", "smart-item-id/myFirstDep", "@decentraland/Identity", "smart-item-id/mySecondDep"]
```

Notice that both user dependencies were namespaced while the system dependency was not.

