### PR TITLE
fix: undefined component while export

### DIFF
--- a/src/modules/project/export.ts
+++ b/src/modules/project/export.ts
@@ -180,7 +180,7 @@ export async function createGameFile(args: { project: Project; scene: Scene; rot
       for (const componentId of entity.components) {
         const component = components[componentId]
         // placeholder gltfs and scripts are skipped
-        if (!isScript(componentId, scene) && !isPlaceholder(componentId, scene)) {
+        if (component && !isScript(componentId, scene) && !isPlaceholder(componentId, scene)) {
           ecsEntity.addComponent(component)
         }
       }


### PR DESCRIPTION
fixes builder in world issue: https://github.com/decentraland/unity-renderer/issues/578
builder in world adds several unsupported components to entities.
`component` record is filtered by types but unsupported components in entities are still trying to be added while exporting