### PR TITLE
Add menu item to go to the editor from the collection

### DIFF
--- a/src/components/CollectionDetailPage/CollectionDetailPage.tsx
+++ b/src/components/CollectionDetailPage/CollectionDetailPage.tsx
@@ -7,7 +7,7 @@ import { t, T } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Authorization, AuthorizationType } from 'decentraland-dapps/dist/modules/authorization/types'
 import { hasAuthorization } from 'decentraland-dapps/dist/modules/authorization/utils'
 import { locations } from 'routing/locations'
-import { canMintCollectionItems, canSeeCollection, isOnSale as isCollectionOnSale, isOwner } from 'modules/collection/utils'
+import { canMintCollectionItems, canSeeCollection, getCollectionEditorURL, isOnSale as isCollectionOnSale, isOwner } from 'modules/collection/utils'
 import { isComplete } from 'modules/item/utils'
 import LoggedInDetailPage from 'components/LoggedInDetailPage'
 import Notice from 'components/Notice'
@@ -206,7 +206,7 @@ export default class CollectionDetailPage extends React.PureComponent<Props, Sta
               id="collection_detail_page.notice"
               values={{
                 editor_link: (
-                  <Link to={locations.itemEditor({ collectionId: collection.id, itemId: items.length > 0 ? items[0].id : undefined })}>
+                  <Link to={getCollectionEditorURL(collection, items)}>
                     {t('collection_detail_page.click_here')}
                   </Link>
                 )

--- a/src/components/CollectionDetailPage/CollectionMenu/CollectionMenu.container.ts
+++ b/src/components/CollectionDetailPage/CollectionMenu/CollectionMenu.container.ts
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux'
+import { push } from 'connected-react-router'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 import { getData as getWallet, getChainId } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import { RootState } from 'modules/common/types'
@@ -19,6 +20,7 @@ const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => ({
 })
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
+  onNavigate: path => dispatch(push(path)),
   onOpenModal: (name, metadata) => dispatch(openModal(name, metadata)),
   onPostToForum: (collection, forumPost) => dispatch(createCollectionForumPostRequest(collection, forumPost)),
   onDelete: collection => dispatch(deleteCollectionRequest(collection))

--- a/src/components/CollectionDetailPage/CollectionMenu/CollectionMenu.tsx
+++ b/src/components/CollectionDetailPage/CollectionMenu/CollectionMenu.tsx
@@ -4,7 +4,7 @@ import { Dropdown, Button, Icon, Popup, Loader } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { buildCollectionForumPost } from 'modules/forum/utils'
 import { RoleType } from 'modules/collection/types'
-import { getExplorerURL, isOwner as isCollectionOwner } from 'modules/collection/utils'
+import { getCollectionEditorURL, getExplorerURL, isOwner as isCollectionOwner } from 'modules/collection/utils'
 import ConfirmDelete from 'components/ConfirmDelete'
 import { Props } from './CollectionMenu.types'
 import './CollectionMenu.css'
@@ -22,6 +22,11 @@ export default class CollectionMenu extends React.PureComponent<Props> {
     if (chainId) {
       this.navigateTo(getExplorerURL(collection, chainId), '_blank')
     }
+  }
+
+  handleNavigateToEditor = () => {
+    const { collection, items, onNavigate } = this.props
+    onNavigate(getCollectionEditorURL(collection, items))
   }
 
   handlePostToForum = () => {
@@ -74,6 +79,7 @@ export default class CollectionMenu extends React.PureComponent<Props> {
       >
         <Dropdown.Menu>
           <Dropdown.Item text={t('collection_menu.see_in_world')} onClick={this.handleNavigateToExplorer} />
+          <Dropdown.Item text={t('collection_menu.open_in_editor')} onClick={this.handleNavigateToEditor} />
 
           {collection.isPublished ? (
             isOwner ? (

--- a/src/components/CollectionDetailPage/CollectionMenu/CollectionMenu.types.ts
+++ b/src/components/CollectionDetailPage/CollectionMenu/CollectionMenu.types.ts
@@ -1,4 +1,5 @@
 import { Dispatch } from 'redux'
+import { CallHistoryMethodAction } from 'connected-react-router'
 import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 import { ChainId } from '@dcl/schemas'
 import { deleteCollectionRequest, DeleteCollectionRequestAction } from 'modules/collection/actions'
@@ -17,9 +18,10 @@ export type Props = {
   onOpenModal: typeof openModal
   onPostToForum: typeof createCollectionForumPostRequest
   onDelete: typeof deleteCollectionRequest
+  onNavigate: (path: string) => void
 }
 
 export type OwnProps = Pick<Props, 'collection'>
 export type MapStateProps = Pick<Props, 'wallet' | 'items' | 'name' | 'isForumPostLoading' | 'chainId'>
-export type MapDispatchProps = Pick<Props, 'onOpenModal' | 'onPostToForum' | 'onDelete'>
-export type MapDispatch = Dispatch<OpenModalAction | CreateCollectionForumPostRequestAction | DeleteCollectionRequestAction>
+export type MapDispatchProps = Pick<Props, 'onNavigate' | 'onOpenModal' | 'onPostToForum' | 'onDelete'>
+export type MapDispatch = Dispatch<CallHistoryMethodAction | OpenModalAction | CreateCollectionForumPostRequestAction | DeleteCollectionRequestAction>

--- a/src/modules/collection/utils.ts
+++ b/src/modules/collection/utils.ts
@@ -9,6 +9,7 @@ import { Item } from 'modules/item/types'
 import { getMetadata } from 'modules/item/utils'
 import { isEqual, includes } from 'lib/address'
 import { InitializeItem, Collection, Access } from './types'
+import { locations } from 'routing/locations'
 
 export function setOnSale(collection: Collection, wallet: Wallet, isOnSale: boolean): Access[] {
   const address = getSaleAddress(wallet.networks.MATIC.chainId)
@@ -22,6 +23,10 @@ export function isOnSale(collection: Collection, wallet: Wallet) {
 
 export function getSaleAddress(chainId: ChainId) {
   return getContract(ContractName.CollectionStore, chainId).address.toLowerCase()
+}
+
+export function getCollectionEditorURL(collection: Collection, items: Item[]): string {
+  return locations.itemEditor({ collectionId: collection.id, itemId: items.length > 0 ? items[0].id : undefined })
 }
 
 export function getExplorerURL(collection: Collection, chainId: ChainId) {

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -931,7 +931,8 @@
     "minters": "Minters",
     "post_to_forum": "Post to forum",
     "posting": "Posting",
-    "not_posted": "The collection wasn't posted to the forum. You can retry here"
+    "not_posted": "The collection wasn't posted to the forum. You can retry here",
+    "open_in_editor": "Open in editor"
   },
   "collection_item": {
     "set_price": "set price",

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -942,7 +942,8 @@
     "minters": "Emisores",
     "post_to_forum": "Post al foro",
     "posting": "Posteando",
-    "not_posted": "La colección no tiene un post asociado. Puedes intentar crearlo aquí"
+    "not_posted": "La colección no tiene un post asociado. Puedes intentar crearlo aquí",
+    "open_in_editor": "Abrir en el editor"
   },
   "collection_item": {
     "set_price": "agregar precio",

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -921,7 +921,8 @@
     "minters": "铸币厂",
     "post_to_forum": "发布到论坛",
     "posting": "过帐",
-    "not_posted": "该收藏集尚未发布到论坛。 您可以在这里重试"
+    "not_posted": "该收藏集尚未发布到论坛。 您可以在这里重试",
+    "open_in_editor": "在编辑器中打开"
   },
   "collection_item": {
     "set_price": "设定价格",


### PR DESCRIPTION
This PR adds a "Open in editor" menu item to the collections option menu.
![Screen Shot 2021-07-07 at 16 41 38](https://user-images.githubusercontent.com/1120791/124819129-3c73f500-df42-11eb-9c64-8bde9584ace5.png)

Closes #1313