### PR TITLE
fix: Change the name of the column showing when the collection was created

### DIFF
--- a/src/components/CurationPage/CollectionRow/CollectionRow.tsx
+++ b/src/components/CurationPage/CollectionRow/CollectionRow.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { format } from 'date-fns'
 import { Grid, Icon as UIIcon } from 'decentraland-ui'
 import { Link } from 'react-router-dom'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
@@ -20,6 +21,7 @@ export default class CollectionRow extends React.PureComponent<Props> {
 
   render() {
     const { collection, items } = this.props
+    const createdAtDate = new Date(collection.createdAt)
 
     return (
       <Link className="CollectionRow" to={locations.itemEditor({ collectionId: collection.id, isReviewing: 'true' })}>
@@ -52,9 +54,11 @@ export default class CollectionRow extends React.PureComponent<Props> {
                 )}
               </div>
             </Grid.Column>
-            <Grid.Column width={2}>
-              <div className="title">{t('collection_row.published_time_title')}</div>
-              <div className="subtitle">{formatDistanceToNow(new Date(collection.createdAt))}</div>
+            <Grid.Column width={3}>
+              <div className="title">{t('collection_row.publication_date')}</div>
+              <div className="subtitle" title={format(createdAtDate, 'd MMMM yyyy HH:mm')}>
+                {formatDistanceToNow(createdAtDate, { addSuffix: true })}
+              </div>
             </Grid.Column>
             <Grid.Column width={3}>
               <div className="actions">

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -904,7 +904,7 @@
     "items": "{count} {count, plural, one {item} other {items}}",
     "owner": "Owner",
     "visit": "Visit",
-    "published_time_title": "Time since published",
+    "publication_date": "Publication date",
     "forum_post": "Forum Post",
     "no_forum_post": "Not posted",
     "approved": "Approved",

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -915,7 +915,7 @@
     "items": "{count} {count, plural, one {item} other {items}}",
     "owner": "Dueño",
     "visit": "Visitar",
-    "published_time_title": "Tiempo desde su publicación",
+    "publication_date": "Fecha de publicación",
     "forum_post": "Post en el foro",
     "no_forum_post": "No hay post",
     "approved": "Aprobada",

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -894,7 +894,7 @@
     "items": "{count} 项",
     "owner": "所有者",
     "visit": "访问",
-    "published_time_title": "自收藏出版以来的时间",
+    "publication_date": "出版日期",
     "forum_post": "论坛帖子",
     "no_forum_post": "尚未发布到论坛",
     "approved": "已批准",


### PR DESCRIPTION
Changes the column name from `Time since published` for `Publication name`.
It also adds a title tag with the full date of publication.

![Screen Shot 2021-08-14 at 13 47 14](https://user-images.githubusercontent.com/1120791/129458727-0c8ebfe6-c421-4e7f-9bf3-178ace189fc2.png)
