### PR TITLE
fix: Curator's page columns width

### DIFF
--- a/src/components/CurationPage/CollectionRow/CollectionRow.tsx
+++ b/src/components/CurationPage/CollectionRow/CollectionRow.tsx
@@ -42,7 +42,7 @@ export default class CollectionRow extends React.PureComponent<Props> {
                 <Profile textOnly address={collection.owner} />
               </div>
             </Grid.Column>
-            <Grid.Column width={4}>
+            <Grid.Column width={2}>
               <div className="title">{t('collection_row.forum_post')}</div>
               <div className="subtitle">
                 {collection.forumLink ? (
@@ -60,7 +60,7 @@ export default class CollectionRow extends React.PureComponent<Props> {
                 {formatDistanceToNow(createdAtDate, { addSuffix: true })}
               </div>
             </Grid.Column>
-            <Grid.Column width={3}>
+            <Grid.Column width={2}>
               <div className="actions">
                 {collection.isApproved ? (
                   <div className="approved action">


### PR DESCRIPTION
The width of the new column made the approved or rejected column to move down the row:
![Screen Shot 2021-08-16 at 13 50 41](https://user-images.githubusercontent.com/1120791/129600869-e464a592-d02d-4c2e-9ea2-ddd257eddf5f.png)

By resizing the other columns, we can fit the new column without any issues:
![Screen Shot 2021-08-16 at 13 53 58](https://user-images.githubusercontent.com/1120791/129600872-0cfe822f-b359-4450-928c-b3e2cccbbd9a.png)
