### PR TITLE
feat: Add blockchain id to the items page

### DIFF
--- a/src/components/ItemDetailPage/ItemDetailPage.tsx
+++ b/src/components/ItemDetailPage/ItemDetailPage.tsx
@@ -118,6 +118,12 @@ export default class ItemDetailPage extends React.PureComponent<Props> {
           <div className="item-data">
             <ItemImage item={item} hasBadge={true} />
             <div className="sections">
+              {item.isPublished && (
+                <Section>
+                  <div className="subtitle">{t('item.blockchain_id')}</div>
+                  <div className="value">{item.tokenId}</div>
+                </Section>
+              )}
               {data.category ? (
                 <Section>
                   <div className="subtitle">{t('item.category')}</div>

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -952,6 +952,7 @@
     "open_in_editor": "Open in editor"
   },
   "item": {
+    "blockchain_id": "Blockchain ID",
     "category": "Category",
     "rarity": "Rarity",
     "representation": "Representation",

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -963,6 +963,7 @@
     "open_in_editor": "Abrir en el editor"
   },
   "item": {
+    "blockchain_id": "ID en la Blockchain",
     "category": "Categoría",
     "rarity": "Rareza",
     "representation": "Representación",

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -963,7 +963,7 @@
     "open_in_editor": "Abrir en el editor"
   },
   "item": {
-    "blockchain_id": "ID en la Blockchain",
+    "blockchain_id": "Blockchain ID",
     "category": "Categoría",
     "rarity": "Rareza",
     "representation": "Representación",

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -942,6 +942,7 @@
     "open_in_editor": "在编辑器中打开"
   },
   "item": {
+    "blockchain_id": "区块链ID",
     "category": "类别",
     "rarity": "稀有度",
     "representation": "表示",


### PR DESCRIPTION
This PR adds the blockchain id to the items page.

![Screen Shot 2021-08-18 at 13 37 29](https://user-images.githubusercontent.com/1120791/129937841-e17dfad5-e5e7-4a59-b277-516fe40050a5.png)

Closes #1508