### PR TITLE
fix: Import model with the same name

### DIFF
--- a/src/components/Modals/CreateItemModal/CreateItemModal.tsx
+++ b/src/components/Modals/CreateItemModal/CreateItemModal.tsx
@@ -106,7 +106,7 @@ export default class CreateItemModal extends React.PureComponent<Props, State> {
    */
   prefixContents(bodyShape: BodyShapeType, contents: Record<string, Blob>): Record<string, Blob> {
     return Object.keys(contents).reduce((newContents: Record<string, Blob>, key: string) => {
-      newContents[`${bodyShape}:${key}`] = contents[key]
+      newContents[`${bodyShape}/${key}`] = contents[key]
       return newContents
     }, {})
   }

--- a/src/components/Modals/CreateItemModal/CreateItemModal.tsx
+++ b/src/components/Modals/CreateItemModal/CreateItemModal.tsx
@@ -473,11 +473,17 @@ export default class CreateItemModal extends React.PureComponent<Props, State> {
     return [thumbnail, model, metrics, contents]
   }
 
+  /**
+   * Updates the item's thumbnail if the user didn't provide a custom one before
+   * (either a thumbnail.png file in the zip file or uploading a custom one via the
+   * edit icon in the UI).
+   *
+   * @param category - The category of the wearable.
+   */
   async updateThumbnail(category: WearableCategory) {
     const { model, contents } = this.state
 
     const isCustom = !!contents && THUMBNAIL_PATH in contents
-    // Only update the thumbnail if the user didn't provide a custom one
     if (!isCustom) {
       let thumbnail
       if (contents && isImageFile(model!)) {

--- a/src/components/Modals/CreateItemModal/CreateItemModal.tsx
+++ b/src/components/Modals/CreateItemModal/CreateItemModal.tsx
@@ -201,7 +201,6 @@ export default class CreateItemModal extends React.PureComponent<Props, State> {
           updatedAt: +new Date()
         }
 
-        // TODO: GetWearableBodyShape
         const wearableBodyShape = bodyShape === BodyShapeType.MALE ? WearableBodyShape.MALE : WearableBodyShape.FEMALE
         const representationIndex = pristineItem.data.representations.findIndex(
           (representation: WearableRepresentation) => representation.bodyShapes[0] === wearableBodyShape

--- a/src/components/Modals/CreateItemModal/CreateItemModal.tsx
+++ b/src/components/Modals/CreateItemModal/CreateItemModal.tsx
@@ -208,7 +208,6 @@ export default class CreateItemModal extends React.PureComponent<Props, State> {
         )
         const pristineBodyShape = getBodyShapeType(pristineItem)
         const representations = this.buildRepresentations(bodyShape, model, prefixedContents)
-        // We can't change only one of its reprentations? This crashes the editor
         if (representations.length === 2 || representationIndex === -1 || pristineBodyShape === BodyShapeType.BOTH) {
           // Unisex or Representation changed
           item.data.representations = representations

--- a/src/components/Modals/CreateItemModal/CreateItemModal.tsx
+++ b/src/components/Modals/CreateItemModal/CreateItemModal.tsx
@@ -477,7 +477,7 @@ export default class CreateItemModal extends React.PureComponent<Props, State> {
     const { model, contents } = this.state
 
     const isCustom = !!contents && THUMBNAIL_PATH in contents
-    // TODO: Only executes if custom? why?
+    // Only update the thumbnail if the user didn't provide a custom one
     if (!isCustom) {
       let thumbnail
       if (contents && isImageFile(model!)) {

--- a/src/components/Modals/CreateItemModal/CreateItemModal.tsx
+++ b/src/components/Modals/CreateItemModal/CreateItemModal.tsx
@@ -106,7 +106,7 @@ export default class CreateItemModal extends React.PureComponent<Props, State> {
    */
   prefixContents = (bodyShape: BodyShapeType, contents: Record<string, Blob>): Record<string, Blob> => {
     return Object.keys(contents).reduce((newContents: Record<string, Blob>, key: string) => {
-      if (key !== THUMBNAIL_PATH) {
+      if (key === THUMBNAIL_PATH) {
         newContents[THUMBNAIL_PATH] = contents[key]
       } else {
         newContents[`${bodyShape.toString()}:${key}`] = contents[key]
@@ -153,17 +153,13 @@ export default class CreateItemModal extends React.PureComponent<Props, State> {
         contents[THUMBNAIL_PATH] = blob
       }
 
-      console.log('Content keys', Object.keys(contents))
       const prefixedContents = this.prefixContents(bodyShape, contents)
-      console.log('Prefixed content keys', Object.keys(prefixedContents))
 
       // compute new contents
       computedHashes = await computeHashes(prefixedContents)
 
       // Add this item as a representation of an existing item
       if ((isRepresentation || addRepresentation) && editedItem) {
-        console.log('Adding a new representation')
-        console.log('Old item', editedItem)
         item = {
           ...editedItem,
           data: {
@@ -190,10 +186,7 @@ export default class CreateItemModal extends React.PureComponent<Props, State> {
         }
 
         delete computedHashes[THUMBNAIL_PATH] // we do not override the old thumbnail with the new one from this representation
-        console.log('New item', item)
       } else if (pristineItem && changeItemFile) {
-        console.log('Changing item file')
-        console.log('Old item', pristineItem)
         item = {
           ...(pristineItem as Item),
           data: {
@@ -225,7 +218,6 @@ export default class CreateItemModal extends React.PureComponent<Props, State> {
         }
 
         delete computedHashes[THUMBNAIL_PATH] // we do not override the old thumbnail with the new one from this representation
-        console.log('New item', item)
       } else {
         // create item to save
         item = {
@@ -253,7 +245,6 @@ export default class CreateItemModal extends React.PureComponent<Props, State> {
           createdAt: +new Date(),
           updatedAt: +new Date()
         }
-        console.log('New item (without the computed hashes)', item)
       }
 
       for (const path in computedHashes) {
@@ -356,7 +347,6 @@ export default class CreateItemModal extends React.PureComponent<Props, State> {
 
       const handler = extension === '.zip' ? this.handleZippedModelFiles : this.handleModelFile
       const [thumbnail, model, metrics, contents] = await handler(file)
-      console.log('Thumbnail generated', thumbnail)
 
       this.setState({
         id: changeItemFile ? item!.id : uuid.v4(),

--- a/src/components/Modals/CreateItemModal/CreateItemModal.types.ts
+++ b/src/components/Modals/CreateItemModal/CreateItemModal.types.ts
@@ -43,6 +43,8 @@ export type CreateItemModalMetadata = {
   changeItemFile?: boolean
 }
 
+export type SortedContent = { male: Record<string, Blob>; female: Record<string, Blob>; all: Record<string, Blob> }
+
 export type MapStateProps = Pick<Props, 'address' | 'error' | 'isLoading'>
 export type MapDispatchProps = Pick<Props, 'onSave' | 'onSavePublished'>
 export type MapDispatch = Dispatch<SaveItemRequestAction | SavePublishedItemRequestAction>

--- a/src/modules/deployment/contentUtils.ts
+++ b/src/modules/deployment/contentUtils.ts
@@ -4,6 +4,7 @@ const toBuffer = require('blob-to-buffer')
 export const FILE_NAME_BLACKLIST = ['.dclignore', 'Dockerfile', 'builder.json', 'src/game.ts']
 
 export async function computeHashes(contents: Record<string, Blob>): Promise<Record<string, string>> {
+  console.log('Going to compute hashes for', contents)
   const contentsAsHashes: Record<string, string> = {}
   for (const path in contents) {
     const blob = contents[path]
@@ -17,7 +18,6 @@ export async function computeHashes(contents: Record<string, Blob>): Promise<Rec
 export async function calculateBufferHash(buffer: Buffer): Promise<string> {
   return Hashing.calculateBufferHash(buffer)
 }
-
 
 export async function makeContentFiles(files: Record<string, string | Blob>): Promise<Map<string, Buffer>> {
   const makeRequests = []

--- a/src/modules/deployment/contentUtils.ts
+++ b/src/modules/deployment/contentUtils.ts
@@ -4,7 +4,6 @@ const toBuffer = require('blob-to-buffer')
 export const FILE_NAME_BLACKLIST = ['.dclignore', 'Dockerfile', 'builder.json', 'src/game.ts']
 
 export async function computeHashes(contents: Record<string, Blob>): Promise<Record<string, string>> {
-  console.log('Going to compute hashes for', contents)
   const contentsAsHashes: Record<string, string> = {}
   for (const path in contents) {
     const blob = contents[path]

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -1002,7 +1002,7 @@
   },
   "sell_collection_modal": {
     "title": "Do you want to sell your items?",
-    "turn_on_description": "By turning this switch on your collection will be available for purchase in in-world vending machines.",
+    "turn_on_description": "By turning this switch on your collection will be available for purchase in the Decentraland Marketplace.",
     "turn_on": "Turn On",
     "turn_off_description": "By turning this switch off your collection will not longer be available for purchase.",
     "turn_off": "Turn Off"

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -1007,7 +1007,7 @@
   },
   "sell_collection_modal": {
     "title": "Quieres vender tus items?",
-    "turn_on_description": "Al activar esta opción tu colección estará en venta dentro del mundo.",
+    "turn_on_description": "Al activar esta opción tu colección estará en venta en el mercado de Decentraland.",
     "turn_on": "Activar",
     "turn_off_description": "Al desactivar esta opción tu colección ya no estará en venta.",
     "turn_off": "Desactivar"

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -986,7 +986,7 @@
   },
   "sell_collection_modal": {
     "title": "您想出售您的物品吗？",
-    "turn_on_description": "通过打开此开关，您的收藏将可以在自动售货机中购买。",
+    "turn_on_description": "通过打开此开关，您的收藏将可以在 Decentraland 市场上购买。",
     "turn_on": "打开",
     "turn_off_description": "关闭此开关后，您的收藏将不再可用。",
     "turn_off": "关掉"


### PR DESCRIPTION
This PR adds a mechanism to prefix the contents so they don't get overwritten by having the same name. This was common if one of the representations (male/female) was added after the other one and had the same name.
The prefix uses the selected body-shape.

Closes #1488