### PR TITLE
fix: Copy button in Share Modal

### DIFF
--- a/src/components/Modals/ShareModal/ShareModal.css
+++ b/src/components/Modals/ShareModal/ShareModal.css
@@ -69,7 +69,7 @@
 }
 
 .ShareModal .share-modal .button.facebook {
-  background: var(--facebook)
+  background: var(--facebook);
 }
 .ShareModal .share-modal .button.twitter {
   background: var(--twitter);
@@ -77,7 +77,7 @@
 
 .ShareModal .share-modal .button .Icon {
   vertical-align: middle;
-  margin-right: .5rem;
+  margin-right: 0.5rem;
 }
 
 .ShareModal .share-modal .button-group,
@@ -100,6 +100,8 @@
 .ShareModal .share-modal .copy-group .copy-button {
   background: var(--innocence);
   border-radius: 0 8px 8px 0;
+  border-left: 1px solid;
+  border-color: var(--modal);
   font-weight: 600;
   font-size: 12px;
   padding: 12px 0;
@@ -108,6 +110,7 @@
   text-transform: uppercase;
   text-align: center;
   width: 120px;
+  color: var(--primary);
 }
 
 .ShareModal .error {

--- a/src/components/Modals/ShareModal/ShareModal.tsx
+++ b/src/components/Modals/ShareModal/ShareModal.tsx
@@ -38,6 +38,13 @@ export default class ShareModal extends React.PureComponent<Props, State> {
     }
   }
 
+  componentWillUnmount() {
+    const { copiedTimer } = this.state
+    if (copiedTimer !== undefined) {
+      clearTimeout(copiedTimer)
+    }
+  }
+
   handleClose = () => {
     return this.props.onClose()
   }
@@ -50,10 +57,12 @@ export default class ShareModal extends React.PureComponent<Props, State> {
 
   handleCopyLink = () => {
     const { copiedTimer } = this.state
-    if (copiedTimer === undefined) {
-      const newCopiedTimer = setTimeout(() => this.setState({ copied: false, copiedTimer: undefined }), 2000)
-      this.setState({ copied: true, copiedTimer: newCopiedTimer })
+    if (copiedTimer !== undefined) {
+      clearTimeout(copiedTimer)
     }
+
+    const newCopiedTimer = setTimeout(() => this.setState({ copied: false, copiedTimer: undefined }), 2000)
+    this.setState({ copied: true, copiedTimer: newCopiedTimer })
   }
 
   handleShare = (e: React.MouseEvent<HTMLAnchorElement>, target: ShareTarget) => {

--- a/src/components/Modals/ShareModal/ShareModal.tsx
+++ b/src/components/Modals/ShareModal/ShareModal.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { env } from 'decentraland-commons'
+import CopyToClipboard from 'react-copy-to-clipboard'
 import { Loader, ModalNavigation } from 'decentraland-ui'
 import { ProviderType } from 'decentraland-connect'
 import Modal from 'decentraland-dapps/dist/containers/Modal'
@@ -16,6 +17,7 @@ const SHARE_SCENE_URL = env.get('REACT_APP_SHARE_SCENE_URL', '')
 export default class ShareModal extends React.PureComponent<Props, State> {
   state: State = {
     copied: false,
+    copiedTimer: undefined,
     type: ShareModalType.PROJECT,
     id: null
   }
@@ -46,19 +48,11 @@ export default class ShareModal extends React.PureComponent<Props, State> {
     }
   }
 
-  handleCopyLink = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault()
-    if (this.input.current) {
-      const input = this.input.current
-      input.select()
-      document.execCommand('copy')
-      const selection = document.getSelection()
-      if (selection) {
-        selection.removeAllRanges()
-        input.blur()
-        this.setState({ copied: true })
-      }
-      this.props.onShare(ShareTarget.LINK)
+  handleCopyLink = () => {
+    const { copiedTimer } = this.state
+    if (copiedTimer === undefined) {
+      const newCopiedTimer = setTimeout(() => this.setState({ copied: false, copiedTimer: undefined }), 2000)
+      this.setState({ copied: true, copiedTimer: newCopiedTimer })
     }
   }
 
@@ -158,9 +152,9 @@ export default class ShareModal extends React.PureComponent<Props, State> {
           </div>
           <div className="copy-group">
             <input ref={this.input} className="copy-input" readOnly={true} value={this.getShareLink()} onFocus={this.handleFocusLink} />
-            <a className="copy-button" onClick={this.handleCopyLink} href={this.getShareLink()}>
-              {copied ? t(`share_modal.copied`) : t(`share_modal.copy`)}
-            </a>
+            <CopyToClipboard text={this.getShareLink()} onCopy={this.handleCopyLink}>
+              <span className="copy-button">{copied ? t(`share_modal.copied`) : t(`share_modal.copy`)}</span>
+            </CopyToClipboard>
           </div>
         </div>
       </Modal>

--- a/src/components/Modals/ShareModal/ShareModal.types.ts
+++ b/src/components/Modals/ShareModal/ShareModal.types.ts
@@ -17,6 +17,7 @@ export type Props = ModalProps & {
 
 export type State = {
   copied: boolean
+  copiedTimer: ReturnType<typeof setTimeout> | undefined
   type: ShareModalType
   id: string | null
 }


### PR DESCRIPTION
This PR fixes the copy button by using the `CopyToClipboard` component. It also adds a simple border to the button so it doesn't merge with the input next to it.
![copy-share](https://user-images.githubusercontent.com/1120791/130478617-7cbceeed-69c7-4e71-9dc3-6cd714d76824.gif)

Closes #1483
