### PR TITLE
fix: Fix opening the CreateItemModal in the editor

### DIFF
--- a/src/components/ItemEditorPage/LeftPanel/Header/Header.tsx
+++ b/src/components/ItemEditorPage/LeftPanel/Header/Header.tsx
@@ -21,7 +21,7 @@ export default class Header extends React.PureComponent<Props> {
 
   handleNewItem = () => {
     const { onOpenModal } = this.props
-    onOpenModal('CreateItemModal')
+    onOpenModal('CreateItemModal', { changeItemFile: false })
   }
 
   handleNewCollection = () => {


### PR DESCRIPTION
This PR adds a missing property to the CreateItemModal metadata so opening it in the editor doesn't break the UI.
Closes #1521