### PR TITLE
Don't show delete option on published collections

### DIFF
--- a/src/components/CollectionsPage/CollectionCard/CollectionCard.tsx
+++ b/src/components/CollectionsPage/CollectionCard/CollectionCard.tsx
@@ -27,10 +27,12 @@ const CollectionCard = (props: Props & CollectedProps) => {
     <>
       {connectDropTarget(
         <div className={`CollectionCard is-card ${isOver && canDrop ? 'is-over' : ''}`}>
-          <OptionsDropdown
-            className={classNames({ 'empty-collection-options': items.length === 0 }, 'options-dropdown')}
-            options={[{ text: t('global.delete'), handler: handleDeleteConfirmation }]}
-          />
+          {!collection.isPublished && (
+            <OptionsDropdown
+              className={classNames({ 'empty-collection-options': items.length === 0 }, 'options-dropdown')}
+              options={[{ text: t('global.delete'), handler: handleDeleteConfirmation }]}
+            />
+          )}
           <Link to={locations.collectionDetail(collection.id)}>
             <CollectionImage collection={collection} />
             <Card.Content>


### PR DESCRIPTION
Closing #1517 

As it is the only option for collections, I decided to entirely remove the dropdown in this case so there is not an empty list of options.

![image](https://user-images.githubusercontent.com/24811313/131402919-9e042ce9-ad9f-4313-ae77-9c3faffa75ad.png)
