### PR TITLE
Fix: When asset pack creation failed, the modal could not be closed

### DIFF
--- a/src/components/Modals/CreateAssetPackModal/CreateAssetPackModal.tsx
+++ b/src/components/Modals/CreateAssetPackModal/CreateAssetPackModal.tsx
@@ -63,7 +63,7 @@ export default class CreateAssetPackModal extends React.PureComponent<Props, Sta
       view = CreateAssetPackView.SUCCESS
     } else if (progress.stage !== ProgressStage.NONE && !error) {
       view = CreateAssetPackView.PROGRESS
-    } else if (error) {
+    } else if (view !== CreateAssetPackView.EXIT && error) {
       view = CreateAssetPackView.EDIT_ASSET_PACK
     }
 

--- a/src/modules/assetPack/reducer.ts
+++ b/src/modules/assetPack/reducer.ts
@@ -104,7 +104,8 @@ export const assetPackReducer = (state = INITIAL_STATE, action: AssetPackReducer
     case SAVE_ASSET_PACK_FAILURE: {
       return {
         ...state,
-        error: action.payload.error
+        error: action.payload.error,
+        loading: loadingReducer(state.loading, action)
       }
     }
     case DELETE_ASSET_PACK_SUCCESS: {


### PR DESCRIPTION
Closes #1511 

This was because on fail, the close button looped between different states of the modal view, going back to the same one every time.