### PR TITLE
fix: Disable claim name confirm button when loading

### DIFF
--- a/src/components/Modals/ClaimNameFatFingerModal/ClaimNameFatFingerModal.tsx
+++ b/src/components/Modals/ClaimNameFatFingerModal/ClaimNameFatFingerModal.tsx
@@ -53,7 +53,7 @@ export default class ClaimNameFatFingerModal extends React.PureComponent<Props, 
             <Button secondary onClick={this.handleClose} type="button">
               {t('global.cancel')}
             </Button>
-            <Button primary type="submit" disabled={areNamesDifferent} loading={isLoading}>
+            <Button primary type="submit" disabled={areNamesDifferent || isLoading} loading={isLoading}>
               {t('global.confirm')}
             </Button>
           </Modal.Actions>

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -611,7 +611,7 @@
   },
   "claim_name_fat_finger_modal": {
     "title": "Por favor, confirme su nuevo nombre",
-    "description": "Has elegido {nombre}. Vuelva a ingresar su nombre para confirmar su selección.",
+    "description": "Has elegido {name}. Vuelva a ingresar su nombre para confirmar su selección.",
     "ok_message": "Felicidades el nombre {name} es tuyo.",
     "name_placeholder": "Tu nombre único",
     "names_different": "Los nombres no son iguales"


### PR DESCRIPTION
Closes #1532 

![Sep-02-2021 12-11-55](https://user-images.githubusercontent.com/24811313/131869634-032084ee-9a27-45f8-bb0b-7eb2488e38c7.gif)

Also fixes text in spanish on the ClaimNameFatFingerModal that was not being correctly replaced.

![Screen Shot 2021-09-02 at 12 08 42](https://user-images.githubusercontent.com/24811313/131869082-ba91ca72-ce22-4697-8d57-f472843e430f.png)
