### PR TITLE
fix: Don't use cache when fetching contents

### DIFF
--- a/src/modules/item/export.ts
+++ b/src/modules/item/export.ts
@@ -65,7 +65,7 @@ export async function getFiles(contents: Record<string, string>) {
   const promises = Object.keys(contents).map(path => {
     const url = getContentsStorageUrl(contents[path])
 
-    return fetch(url)
+    return fetch(url, { headers: { pragma: 'no-cache', 'cache-control': 'no-cache' } })
       .then(resp => resp.blob())
       .then(blob => ({ path, blob }))
   })


### PR DESCRIPTION
Chrome seems to cache responses that come from non-fetched requests as the same responses that come from fetched requests. This is a big issue because non-fetched requests don't require CORS, but fetched requests might. This cache strategy caused an issue because, when trying to add a new representation of an existing item, the content got cached without CORS headers when we loaded it a preview image before doing the fetch, resulting in a fetch request without headers and a CORS request failing.

This PR adds headers to avoid using cache when requesting the older models when adding new representations to an item.