### PR TITLE
fix: Fetch scene content without cache

### DIFF
--- a/src/lib/headers.ts
+++ b/src/lib/headers.ts
@@ -1,0 +1,1 @@
+export const NO_CACHE_HEADERS = { pragma: 'no-cache', 'cache-control': 'no-cache' }

--- a/src/modules/item/export.ts
+++ b/src/modules/item/export.ts
@@ -4,6 +4,7 @@ import { CatalystClient } from 'dcl-catalyst-client'
 import { EntityType } from 'dcl-catalyst-commons'
 import { getContentsStorageUrl } from 'lib/api/builder'
 import { PEER_URL } from 'lib/api/peer'
+import { NO_CACHE_HEADERS } from 'lib/headers'
 import { getCatalystItemURN } from 'modules/item/utils'
 import { makeContentFiles, computeHashes } from 'modules/deployment/contentUtils'
 import { Collection } from 'modules/collection/types'
@@ -71,7 +72,7 @@ export async function getFiles(contents: Record<string, string>): Promise<Record
   const promises = Object.keys(contents).map(path => {
     const url = getContentsStorageUrl(contents[path])
 
-    return fetch(url, { headers: { pragma: 'no-cache', 'cache-control': 'no-cache' } })
+    return fetch(url, { headers: NO_CACHE_HEADERS })
       .then(resp => resp.blob())
       .then(blob => ({ path, blob }))
   })

--- a/src/modules/media/utils.ts
+++ b/src/modules/media/utils.ts
@@ -22,7 +22,7 @@ export function dataURLToBlob(dataUrl: string): Blob | null {
 }
 
 export async function objectURLToBlob(objectURL: string): Promise<Blob> {
-  return fetch(objectURL).then(res => res.blob())
+  return fetch(objectURL, { headers: { pragma: 'no-cache', 'cache-control': 'no-cache' } }).then(res => res.blob())
 }
 
 export async function blobToCID(blob: Blob, path: string) {

--- a/src/modules/media/utils.ts
+++ b/src/modules/media/utils.ts
@@ -1,3 +1,4 @@
+import { NO_CACHE_HEADERS } from 'lib/headers'
 import { makeContentFile, getCID } from 'modules/deployment/utils'
 
 export function isDataUrl(url: string): boolean {
@@ -22,7 +23,7 @@ export function dataURLToBlob(dataUrl: string): Blob | null {
 }
 
 export async function objectURLToBlob(objectURL: string): Promise<Blob> {
-  return fetch(objectURL, { headers: { pragma: 'no-cache', 'cache-control': 'no-cache' } }).then(res => res.blob())
+  return fetch(objectURL, { headers: NO_CACHE_HEADERS }).then(res => res.blob())
 }
 
 export async function blobToCID(blob: Blob, path: string) {

--- a/src/modules/project/export.ts
+++ b/src/modules/project/export.ts
@@ -13,10 +13,11 @@ import { Rotation, Coordinate, SceneDefinition } from 'modules/deployment/types'
 import { Project, Manifest } from 'modules/project/types'
 import { Scene, ComponentType, ComponentDefinition } from 'modules/scene/types'
 import { getContentsStorageUrl } from 'lib/api/builder'
-import { getParcelOrientation } from './utils'
 import { AssetParameterValues } from 'modules/asset/types'
 import { migrations } from 'modules/migrations/manifest'
 import { makeContentFile, calculateBufferHash } from 'modules/deployment/contentUtils'
+import { NO_CACHE_HEADERS } from 'lib/headers'
+import { getParcelOrientation } from './utils'
 
 export const MANIFEST_FILE_VERSION = Math.max(...Object.keys(migrations).map(version => parseInt(version, 10)))
 
@@ -351,7 +352,7 @@ export async function downloadFiles(args: {
     .filter(path => (isDeploy ? !path.endsWith('.ts') : !path.endsWith('.js')))
     .map(path => {
       const url = mappings[path]
-      return fetch(url, { headers: { pragma: 'no-cache', 'cache-control': 'no-cache' } })
+      return fetch(url, { headers: NO_CACHE_HEADERS })
         .then(resp => resp.blob())
         .then(blob => {
           progress++
@@ -520,7 +521,7 @@ export function hasScripts(scene: Scene) {
 async function createThumbnailBlob(thumbnail: string | null) {
   if (thumbnail) {
     try {
-      const resp = await fetch(thumbnail, { headers: { pragma: 'no-cache', 'cache-control': 'no-cache' } })
+      const resp = await fetch(thumbnail, { headers: NO_CACHE_HEADERS })
       const blob = await resp.blob()
       return blob
     } catch (error) {
@@ -536,9 +537,7 @@ export function buildAssetPath(namespace: string, path: string) {
 
 /* Temporary fix until we migrate the Builder to use CID v1 */
 export async function convertToV1(v0: string) {
-  const blob = await fetch(getContentsStorageUrl(v0), { headers: { pragma: 'no-cache', 'cache-control': 'no-cache' } }).then(resp =>
-    resp.blob()
-  )
+  const blob = await fetch(getContentsStorageUrl(v0), { headers: NO_CACHE_HEADERS }).then(resp => resp.blob())
   const file = await makeContentFile(EXPORT_PATH.BUNDLED_GAME_FILE, blob)
   const v1 = await calculateBufferHash(file.content)
   return v1

--- a/src/modules/project/export.ts
+++ b/src/modules/project/export.ts
@@ -351,7 +351,7 @@ export async function downloadFiles(args: {
     .filter(path => (isDeploy ? !path.endsWith('.ts') : !path.endsWith('.js')))
     .map(path => {
       const url = mappings[path]
-      return fetch(url)
+      return fetch(url, { headers: { pragma: 'no-cache', 'cache-control': 'no-cache' } })
         .then(resp => resp.blob())
         .then(blob => {
           progress++
@@ -520,7 +520,7 @@ export function hasScripts(scene: Scene) {
 async function createThumbnailBlob(thumbnail: string | null) {
   if (thumbnail) {
     try {
-      const resp = await fetch(thumbnail)
+      const resp = await fetch(thumbnail, { headers: { pragma: 'no-cache', 'cache-control': 'no-cache' } })
       const blob = await resp.blob()
       return blob
     } catch (error) {
@@ -536,7 +536,9 @@ export function buildAssetPath(namespace: string, path: string) {
 
 /* Temporary fix until we migrate the Builder to use CID v1 */
 export async function convertToV1(v0: string) {
-  const blob = await fetch(getContentsStorageUrl(v0)).then(resp => resp.blob())
+  const blob = await fetch(getContentsStorageUrl(v0), { headers: { pragma: 'no-cache', 'cache-control': 'no-cache' } }).then(resp =>
+    resp.blob()
+  )
   const file = await makeContentFile(EXPORT_PATH.BUNDLED_GAME_FILE, blob)
   const v1 = await calculateBufferHash(file.content)
   return v1


### PR DESCRIPTION
This PR adds headers to avoid cached requests when fetching content to deploy a scene.