### PR TITLE
fix: Avoid counting the thumbnail twice when computing the file sizes

### DIFF
--- a/src/components/Modals/CreateItemModal/CreateItemModal.tsx
+++ b/src/components/Modals/CreateItemModal/CreateItemModal.tsx
@@ -205,6 +205,9 @@ export default class CreateItemModal extends React.PureComponent<Props, State> {
           },
           updatedAt: +new Date()
         }
+
+        // Do not change the thumbnail when adding a new representation
+        delete sortedContents.all[THUMBNAIL_PATH]
       } else if (pristineItem && changeItemFile) {
         item = {
           ...(pristineItem as Item),
@@ -392,7 +395,7 @@ export default class CreateItemModal extends React.PureComponent<Props, State> {
   handleCategoryChange = (_event: React.SyntheticEvent<HTMLElement, Event>, { value }: DropdownProps) => {
     const category = value as WearableCategory
     if (this.state.category !== category) {
-      this.updateThumbnail(category)
+      this.updateThumbnailByCategory(category)
       this.setState({ category })
     }
   }
@@ -454,6 +457,8 @@ export default class CreateItemModal extends React.PureComponent<Props, State> {
         bodies: 1,
         entities: 1
       }
+
+      thumbnail = await this.convertImageIntoWearableThumbnail(contents[THUMBNAIL_PATH] || contents[model], this.state.category)
     } else {
       const url = URL.createObjectURL(contents[model])
       const { image, info } = await getModelData(url, {
@@ -471,28 +476,22 @@ export default class CreateItemModal extends React.PureComponent<Props, State> {
       metrics = info
     }
 
-    if (isImageFile(model)) {
-      thumbnail = await this.generateWearableThumbnail(contents[THUMBNAIL_PATH] || contents[model], this.state.category)
-    }
-
     return [thumbnail, model, metrics, contents]
   }
 
   /**
-   * Updates the item's thumbnail if the user didn't provide a custom one before
-   * (either a thumbnail.png file in the zip file or uploading a custom one via the
-   * edit icon in the UI).
+   * Updates the item's thumbnail if the user changes the category of the item.
    *
    * @param category - The category of the wearable.
    */
-  async updateThumbnail(category: WearableCategory) {
+  async updateThumbnailByCategory(category: WearableCategory) {
     const { model, contents } = this.state
 
     const isCustom = !!contents && THUMBNAIL_PATH in contents
     if (!isCustom) {
       let thumbnail
       if (contents && isImageFile(model!)) {
-        thumbnail = await this.generateWearableThumbnail(contents[THUMBNAIL_PATH] || contents[model!], category)
+        thumbnail = await this.convertImageIntoWearableThumbnail(contents[THUMBNAIL_PATH] || contents[model!], category)
       } else {
         const url = URL.createObjectURL(contents![model!])
         const { image } = await getModelData(url, {
@@ -514,7 +513,7 @@ export default class CreateItemModal extends React.PureComponent<Props, State> {
    * @param blob - The blob of the image.
    * @param category - The category of the wearable.
    */
-  async generateWearableThumbnail(blob: Blob, category: WearableCategory = WearableCategory.EYES) {
+  async convertImageIntoWearableThumbnail(blob: Blob, category: WearableCategory = WearableCategory.EYES) {
     // load blob into image
     const image = new Image()
     const loadFuture = future()

--- a/src/modules/item/export.ts
+++ b/src/modules/item/export.ts
@@ -102,8 +102,9 @@ function getUniqueFiles(hashes: Record<string, string>, blobs: Record<string, Bl
 
 /**
  * Calculates the final size (with the already stored content and the new one) of the contents of an item.
+ * All the files in newContents must also be in the item's contents in both name and hash.
  *
- * @param item - An item that might or not have already uploaded content.
+ * @param item - An item that contains the old and the new hahsed content.
  * @param newContents - The new content that is going to be added to the item.
  */
 export async function calculateFinalSize(item: Item, newContents: Record<string, Blob>): Promise<number> {
@@ -124,8 +125,7 @@ export async function calculateFinalSize(item: Item, newContents: Record<string,
   } catch (error) {}
 
   const uniqueFiles = getUniqueFiles({ ...newHashes, ...filesToDownload }, { ...newContents, ...blobs })
-  const finalSize = imageSize + calculateFilesSize(uniqueFiles)
-  return finalSize
+  return imageSize + calculateFilesSize(uniqueFiles)
 }
 
 /**

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -132,7 +132,7 @@ function* handleSaveItemRequest(action: SaveItemRequestAction) {
     if (item.isPublished) {
       throw new Error(t('sagas.item.cant_save_published'))
     }
-    const finalSize: number = yield call(() => calculateFinalSize(item, contents))
+    const finalSize: number = yield call(calculateFinalSize, item, contents)
     if (finalSize > MAX_FILE_SIZE) {
       throw new ItemTooBigError()
     }
@@ -164,7 +164,7 @@ function* handleSavePublishedItemRequest(action: SavePublishedItemRequestAction)
       throw new Error(t('sagas.item.cant_save_without_collection'))
     }
 
-    const finalSize: number = yield call(() => calculateFinalSize(item, contents))
+    const finalSize: number = yield call(calculateFinalSize, item, contents)
     if (finalSize > MAX_FILE_SIZE) {
       throw new ItemTooBigError()
     }


### PR DESCRIPTION
This PR fixes an issue of calculating the thumbnail size twice when the user added a representation of an item that had a custom thumbnail.
The PR also tidies up a bit of the code.