### PR TITLE
fix: use matic urn protocol

### DIFF
--- a/src/components/CollectionDetailPage/CollectionMenu/CollectionMenu.tsx
+++ b/src/components/CollectionDetailPage/CollectionMenu/CollectionMenu.tsx
@@ -18,10 +18,8 @@ export default class CollectionMenu extends React.PureComponent<Props> {
   }
 
   handleNavigateToExplorer = () => {
-    const { collection, chainId } = this.props
-    if (chainId) {
-      this.navigateTo(getExplorerURL(collection, chainId), '_blank')
-    }
+    const { collection } = this.props
+    this.navigateTo(getExplorerURL(collection), '_blank')
   }
 
   handleNavigateToEditor = () => {
@@ -89,23 +87,23 @@ export default class CollectionMenu extends React.PureComponent<Props> {
               </>
             ) : null
           ) : (
-            <>
-              <Dropdown.Item text={t('collection_menu.add_existing_item')} onClick={this.handleAddExistingItem} />
-              <ConfirmDelete
-                name={collection.name}
-                onDelete={this.handleDeleteItem}
-                trigger={<Dropdown.Item text={t('global.delete')} />}
-              />
-            </>
-          )}
+              <>
+                <Dropdown.Item text={t('collection_menu.add_existing_item')} onClick={this.handleAddExistingItem} />
+                <ConfirmDelete
+                  name={collection.name}
+                  onDelete={this.handleDeleteItem}
+                  trigger={<Dropdown.Item text={t('global.delete')} />}
+                />
+              </>
+            )}
 
           <Popup
             content={
               !collection.isPublished
                 ? t('collection_menu.unpublished')
                 : !collection.forumLink
-                ? t('collection_menu.not_posted')
-                : undefined
+                  ? t('collection_menu.not_posted')
+                  : undefined
             }
             disabled={collection.isPublished || !!collection.forumLink}
             position="right center"
@@ -124,8 +122,8 @@ export default class CollectionMenu extends React.PureComponent<Props> {
                       <Loader size="mini" active inline />
                     </div>
                   ) : (
-                    t('collection_menu.post_to_forum')
-                  )}
+                      t('collection_menu.post_to_forum')
+                    )}
                 </Dropdown.Item>
               ) : null
             }

--- a/src/components/JumpIn/JumpIn.tsx
+++ b/src/components/JumpIn/JumpIn.tsx
@@ -6,12 +6,12 @@ import './JumpIn.css'
 
 export default class JumpIn extends React.PureComponent<Props> {
   render() {
-    const { size = 'medium', land, collection, chainId } = this.props
+    const { size = 'medium', land, collection } = this.props
 
     let url = ''
 
-    if (collection && chainId) {
-      url = getCollectionURL(collection, chainId)
+    if (collection) {
+      url = getCollectionURL(collection)
     } else if (land) {
       const selection = getSelection(land)
       const [x, y] = getCenter(selection)

--- a/src/modules/collection/utils.ts
+++ b/src/modules/collection/utils.ts
@@ -1,7 +1,7 @@
 import { Address } from 'web3x-es/address'
 import { toBN } from 'web3x-es/utils'
 import { env, utils } from 'decentraland-commons'
-import { ChainId, getURNProtocol } from '@dcl/schemas'
+import { ChainId, getURNProtocol, Network } from '@dcl/schemas'
 import { ContractName, getContract } from 'decentraland-transactions'
 import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 import { Item } from 'modules/item/types'
@@ -10,6 +10,7 @@ import { isEqual, includes } from 'lib/address'
 import { sortByCreatedAt } from 'lib/sort'
 import { InitializeItem, Collection, Access } from './types'
 import { locations } from 'routing/locations'
+import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
 
 export function setOnSale(collection: Collection, wallet: Wallet, isOnSale: boolean): Access[] {
   const address = getSaleAddress(wallet.networks.MATIC.chainId)
@@ -29,14 +30,14 @@ export function getCollectionEditorURL(collection: Collection, items: Item[]): s
   return locations.itemEditor({ collectionId: collection.id, itemId: items.length > 0 ? items[0].id : undefined })
 }
 
-export function getExplorerURL(collection: Collection, chainId: ChainId) {
+export function getExplorerURL(collection: Collection) {
   if (!collection.contractAddress) {
     throw new Error('You need the collection and item to be published to get the catalyst urn')
   }
 
   let id = collection.id
   if (collection.isPublished) {
-    id = `urn:decentraland:${getURNProtocol(chainId)}:collections-v2:${collection.contractAddress}`
+    id = `urn:decentraland:${getURNProtocol(getChainIdByNetwork(Network.MATIC))}:collections-v2:${collection.contractAddress}`
   }
 
   // We're replacing org and hardcoding zone here because it only works on that domain for now, to avoid adding new env vars. Also, we use `ropsten` for the NETWORK because it is the only working network for .zone

--- a/src/modules/collection/utils.ts
+++ b/src/modules/collection/utils.ts
@@ -3,6 +3,7 @@ import { toBN } from 'web3x-es/utils'
 import { env, utils } from 'decentraland-commons'
 import { ChainId, getURNProtocol, Network } from '@dcl/schemas'
 import { ContractName, getContract } from 'decentraland-transactions'
+import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
 import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 import { Item } from 'modules/item/types'
 import { getMetadata } from 'modules/item/utils'
@@ -10,7 +11,6 @@ import { isEqual, includes } from 'lib/address'
 import { sortByCreatedAt } from 'lib/sort'
 import { InitializeItem, Collection, Access } from './types'
 import { locations } from 'routing/locations'
-import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
 
 export function setOnSale(collection: Collection, wallet: Wallet, isOnSale: boolean): Access[] {
   const address = getSaleAddress(wallet.networks.MATIC.chainId)

--- a/src/modules/item/export.ts
+++ b/src/modules/item/export.ts
@@ -1,5 +1,4 @@
 import { Authenticator, AuthIdentity } from 'dcl-crypto'
-import { ChainId } from '@dcl/schemas'
 import { CatalystClient } from 'dcl-catalyst-client'
 import { EntityType } from 'dcl-catalyst-commons'
 import { getContentsStorageUrl } from 'lib/api/builder'

--- a/src/modules/item/export.ts
+++ b/src/modules/item/export.ts
@@ -13,11 +13,11 @@ import { generateImage } from './utils'
 
 const ITEM_DEPLOYMENT_DELTA_TIMESTAMP = -5 * 1000 // We use 5 seconds before to let the subgraph index the collection creation
 
-export async function deployContents(identity: AuthIdentity, collection: Collection, item: Item, chainId: ChainId) {
-  const urn = getCatalystItemURN(collection, item, chainId)
+export async function deployContents(identity: AuthIdentity, collection: Collection, item: Item) {
+  const urn = getCatalystItemURN(collection, item)
   const [files, image] = await Promise.all([getFiles(item.contents), generateImage(item)])
   const contentFiles = await makeContentFiles({ ...files, [IMAGE_PATH]: image })
-  const catalystItem = toCatalystItem(collection, item, chainId)
+  const catalystItem = toCatalystItem(collection, item)
   const client = new CatalystClient(PEER_URL, 'Builder')
   const status = await client.fetchContentStatus()
   const { entityId, files: hashedFiles } = await client.buildEntity({
@@ -34,14 +34,14 @@ export async function deployContents(identity: AuthIdentity, collection: Collect
   return { ...item, inCatalyst: true }
 }
 
-function toCatalystItem(collection: Collection, item: Item, chainId: ChainId): CatalystItem {
+function toCatalystItem(collection: Collection, item: Item): CatalystItem {
   // We strip the thumbnail from the representations contents as they're not being used by the Catalyst and just occupy extra space
   const representations = item.data.representations.map(representation => ({
     ...representation,
     contents: representation.contents.filter(fileName => fileName !== THUMBNAIL_PATH)
   }))
   return {
-    id: getCatalystItemURN(collection, item, chainId),
+    id: getCatalystItemURN(collection, item),
     name: item.name,
     description: item.description,
     collectionAddress: collection.contractAddress!,

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -2,13 +2,11 @@ import { Eth } from 'web3x-es/eth'
 import { Address } from 'web3x-es/address'
 import { replace } from 'connected-react-router'
 import { takeEvery, call, put, takeLatest, select, take, delay } from 'redux-saga/effects'
-import { ChainId } from '@dcl/schemas'
 import { AuthIdentity } from 'dcl-crypto'
 import { ContractName, getContract } from 'decentraland-transactions'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { FetchTransactionSuccessAction, FETCH_TRANSACTION_SUCCESS } from 'decentraland-dapps/dist/modules/transaction/actions'
 import { closeModal } from 'decentraland-dapps/dist/modules/modal/actions'
-import { getChainId } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 import {
   FetchItemsRequestAction,

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -260,8 +260,7 @@ function* handleDeployItemContentsRequest(action: DeployItemContentsRequestActio
       throw new Error(t('sagas.item.invalid_identity'))
     }
 
-    const chainId: ChainId = yield select(getChainId)
-    const deployedItem: Item = yield deployContents(identity, collection, item, chainId)
+    const deployedItem: Item = yield deployContents(identity, collection, item)
 
     yield put(deployItemContentsSuccess(collection, deployedItem))
   } catch (error) {

--- a/src/modules/item/utils.ts
+++ b/src/modules/item/utils.ts
@@ -1,5 +1,6 @@
 import { Address } from 'web3x-es/address'
-import { ChainId, getURNProtocol } from '@dcl/schemas'
+import { getURNProtocol, Network } from '@dcl/schemas'
+import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
 import { utils } from 'decentraland-commons'
 import future from 'fp-future'
 import { getContentsStorageUrl } from 'lib/api/builder'
@@ -34,11 +35,13 @@ export function getMaxSupplyForRarity(rarity: ItemRarity) {
   return RARITY_MAX_SUPPLY[rarity]
 }
 
-export function getCatalystItemURN(collection: Collection, item: Item, chainId: ChainId) {
+export function getCatalystItemURN(collection: Collection, item: Item) {
   if (!collection.contractAddress || !item.tokenId) {
     throw new Error('You need the collection and item to be published to get the catalyst urn')
   }
-  return `urn:decentraland:${getURNProtocol(chainId)}:collections-v2:${collection.contractAddress}:${item.tokenId}`
+  return `urn:decentraland:${getURNProtocol(getChainIdByNetwork(Network.MATIC))}:collections-v2:${collection.contractAddress}:${
+    item.tokenId
+  }`
 }
 
 export function getBodyShapeType(item: Item): BodyShapeType {


### PR DESCRIPTION
This PR fixes an issue where the wrong chain id was used to generate the URN protocol (it was using the connected `chainId` (either mainnet or ropsten))