### PR TITLE
feat: native polygon transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "decentraland-ad": "^1.4.2",
         "decentraland-builder-scripts": "^0.24.0",
         "decentraland-commons": "^5.1.0",
-        "decentraland-dapps": "^12.25.0",
+        "decentraland-dapps": "^12.25.2",
         "decentraland-ecs": "^6.6.1-20201020183014.commit-bdc29ef",
         "decentraland-experiments": "^1.0.2",
         "decentraland-transactions": "^1.22.2",
@@ -9347,7 +9347,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11574,9 +11574,9 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "12.25.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-12.25.0.tgz",
-      "integrity": "sha512-cY9lVWTARCyIOnPBsebvrSYeIEuxuWWP9nuuQN5WbEyZ9x4Kr945251nzhYO0DQLnetx4ILCg25+x9EhyUCemg==",
+      "version": "12.25.2",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-12.25.2.tgz",
+      "integrity": "sha512-/XhQ+SK0I8wJoaIxtVEWE46560ryWOt5Vhk0XWkcdb7GfQW6xVmDLxeRqbg63YnA0uBjAtJ1YdXYWYegUaQyTg==",
       "dependencies": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
@@ -26584,7 +26584,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -45962,7 +45962,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "devOptional": true
+      "dev": true
     },
     "coinstring": {
       "version": "2.3.0",
@@ -47723,9 +47723,9 @@
       }
     },
     "decentraland-dapps": {
-      "version": "12.25.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-12.25.0.tgz",
-      "integrity": "sha512-cY9lVWTARCyIOnPBsebvrSYeIEuxuWWP9nuuQN5WbEyZ9x4Kr945251nzhYO0DQLnetx4ILCg25+x9EhyUCemg==",
+      "version": "12.25.2",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-12.25.2.tgz",
+      "integrity": "sha512-/XhQ+SK0I8wJoaIxtVEWE46560ryWOt5Vhk0XWkcdb7GfQW6xVmDLxeRqbg63YnA0uBjAtJ1YdXYWYegUaQyTg==",
       "requires": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
@@ -59671,7 +59671,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "devOptional": true
+      "dev": true
     },
     "nwsapi": {
       "version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "builder",
       "version": "2.17.1",
       "hasInstallScript": true,
       "dependencies": {
@@ -43,7 +42,7 @@
         "decentraland-ad": "^1.4.2",
         "decentraland-builder-scripts": "^0.24.0",
         "decentraland-commons": "^5.1.0",
-        "decentraland-dapps": "^12.17.0",
+        "decentraland-dapps": "^12.25.0",
         "decentraland-ecs": "^6.6.1-20201020183014.commit-bdc29ef",
         "decentraland-experiments": "^1.0.2",
         "decentraland-transactions": "^1.22.2",
@@ -114,6 +113,7 @@
         "workbox-webpack-plugin": "3.6.3"
       },
       "devDependencies": {
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
         "@babel/plugin-proposal-optional-chaining": "^7.14.5",
         "@ethersproject/hash": "^5.0.3",
         "@types/auth0-js": "^9.10.2",
@@ -425,6 +425,44 @@
         "lodash": "^4.17.13"
       }
     },
+    "node_modules/@babel/helper-define-polyfill-provider": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz",
+      "integrity": "sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==",
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/traverse": "^7.13.0",
+        "debug": "^4.1.1",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.14.2",
+        "semver": "^6.1.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0-0"
+      }
+    },
+    "node_modules/@babel/helper-define-polyfill-provider/node_modules/resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dependencies": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@babel/helper-define-polyfill-provider/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/helper-explode-assignable-expression": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.4.tgz",
@@ -717,6 +755,22 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-json-strings": "^7.7.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.14.5.tgz",
+      "integrity": "sha512-gun/SOnMqjSb98Nkaq2rTKMwervfdAoz6NphdY0vTfuzMfryj+tDGb2n6UkDKwez+Y8PZDhE3D143v6Gepp4Hg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -1655,9 +1709,9 @@
       }
     },
     "node_modules/@dcl/schemas": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-1.1.0.tgz",
-      "integrity": "sha512-5GosxadKhj3gfkQF87rrCXBuU9i1pDwsq6frj2NQFSNzl14ZsDeorAADXRaPvAXDDLj/mwGmEN6f5TpB8nAifQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-1.6.1.tgz",
+      "integrity": "sha512-wrngSXY3mY/4/4ErIkcgBH7eqbchB/YcDki6ZBIBo4B7zNFO29tEd0k0gfVhD83w+1Mfhiak9+g7fgHrmXfhHg==",
       "dependencies": {
         "ajv": "^7.1.0"
       }
@@ -2542,43 +2596,69 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
       "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
-    "node_modules/@formatjs/intl-displaynames": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-1.2.10.tgz",
-      "integrity": "sha512-GROA2RP6+7Ouu0WnHFF78O5XIU7pBfI19WM1qm93l6MFWibUk67nCfVCK3VAYJkLy8L8ZxjkYT11VIAfvSz8wg==",
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "1.9.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.9.8.tgz",
+      "integrity": "sha512-2U4n11bLmTij/k4ePCEFKJILPYwdMcJTdnKVBi+JMWBgu5O1N+XhCazlE6QXqVO1Agh2Doh0b/9Jf1mSmSVfhA==",
       "dependencies": {
-        "@formatjs/intl-utils": "^2.3.0"
+        "@formatjs/intl-localematcher": "0.2.20",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.0.tgz",
+      "integrity": "sha512-fObitP9Tlc31SKrPHgkPgQpGo4+4yXfQQITTCNH8AZdEqB7Mq4nPrjpUL/tNGN3lEeJcFxDbi0haX8HM7QvQ8w==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.0.11.tgz",
+      "integrity": "sha512-5mWb8U8aulYGwnDZWrr+vdgn5PilvtrqQYQ1pvpgzQes/osi85TwmL2GqTGLlKIvBKD2XNA61kAqXYY95w4LWg==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.9.8",
+        "@formatjs/icu-skeleton-parser": "1.2.12",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.2.12.tgz",
+      "integrity": "sha512-DTFxWmEA02ZNW6fsYjGYSADvtrqqjCYF7DSgCmMfaaE0gLP4pCdAgOPE+lkXXU+jP8iCw/YhMT2Seyk/C5lBWg==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.9.8",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/intl-displaynames": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-5.2.3.tgz",
+      "integrity": "sha512-5BmhSurLbfgdeo0OBcNPPkIS8ikMMYaHe2NclxEQZqcMvrnQzNMNnUE2dDF5vZx+mkvKq77aQYzpc8RfqVsRCQ==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.9.8",
+        "@formatjs/intl-localematcher": "0.2.20",
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@formatjs/intl-listformat": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-1.4.8.tgz",
-      "integrity": "sha512-WNMQlEg0e50VZrGIkgD5n7+DAMGt3boKi1GJALfhFMymslJb5i+5WzWxyj/3a929Z6MAFsmzRIJjKuv+BxKAOQ==",
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-6.3.3.tgz",
+      "integrity": "sha512-3nzAKgVS5rePDa5HiH0OwZgAhqxLtzlMc9Pg4QgajRHSP1TqFiMmQnnn52wd3+xVTb7cjZVm3JBnTv51/MhTOg==",
       "dependencies": {
-        "@formatjs/intl-utils": "^2.3.0"
+        "@formatjs/ecma402-abstract": "1.9.8",
+        "@formatjs/intl-localematcher": "0.2.20",
+        "tslib": "^2.1.0"
       }
     },
-    "node_modules/@formatjs/intl-relativetimeformat": {
-      "version": "4.5.16",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-4.5.16.tgz",
-      "integrity": "sha512-IQ0haY97oHAH5OYUdykNiepdyEWj3SAT+Fp9ZpR85ov2JNiFx+12WWlxlVS8ehdyncC2ZMt/SwFIy2huK2+6/A==",
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.20.tgz",
+      "integrity": "sha512-/Ro85goRZnCojzxOegANFYL0LaDIpdPjAukR7xMTjOtRx+3yyjR0ifGTOW3/Kjhmab3t6GnyHBYWZSudxEOxPA==",
       "dependencies": {
-        "@formatjs/intl-utils": "^2.3.0"
+        "tslib": "^2.1.0"
       }
-    },
-    "node_modules/@formatjs/intl-unified-numberformat": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-3.3.7.tgz",
-      "integrity": "sha512-KnWgLRHzCAgT9eyt3OS34RHoyD7dPDYhRcuKn+/6Kv2knDF8Im43J6vlSW6Hm1w63fNq3ZIT1cFk7RuVO3Psag==",
-      "deprecated": "We have renamed the package to @formatjs/intl-numberformat",
-      "dependencies": {
-        "@formatjs/intl-utils": "^2.3.0"
-      }
-    },
-    "node_modules/@formatjs/intl-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz",
-      "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -4846,6 +4926,34 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@json-rpc-tools/provider": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz",
+      "integrity": "sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==",
+      "dependencies": {
+        "@json-rpc-tools/utils": "^1.7.6",
+        "axios": "^0.21.0",
+        "safe-json-utils": "^1.1.1",
+        "ws": "^7.4.0"
+      }
+    },
+    "node_modules/@json-rpc-tools/types": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
+      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
+      "dependencies": {
+        "keyvaluestorage-interface": "^1.0.0"
+      }
+    },
+    "node_modules/@json-rpc-tools/utils": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
+      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
+      "dependencies": {
+        "@json-rpc-tools/types": "^1.7.6",
+        "@pedrouid/environment": "^1.0.1"
+      }
+    },
     "node_modules/@metamask/safe-event-emitter": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz",
@@ -4902,6 +5010,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@pedrouid/environment": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
+      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "node_modules/@popperjs/core": {
       "version": "2.9.3",
@@ -5176,11 +5289,6 @@
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
       }
-    },
-    "node_modules/@types/invariant": {
-      "version": "2.2.34",
-      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.34.tgz",
-      "integrity": "sha512-lYUtmJ9BqUN688fGY1U1HZoWT1/Jrmgigx2loq4ZcJpICECm/Om3V314BxdzypO0u5PORKGMM6x0OXaljV1YFg=="
     },
     "node_modules/@types/isomorphic-fetch": {
       "version": "0.0.35",
@@ -5511,15 +5619,6 @@
         "@types/react": "*"
       }
     },
-    "node_modules/@types/react-intl": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/react-intl/-/react-intl-3.0.0.tgz",
-      "integrity": "sha512-k8F3d05XQGEqSWIfK97bBjZe4z9RruXU9Wa7OZ2iUC5pdeIpzuQDZe/9C2J3Xir5//ZtAkhcv08Wfx3n5TBTQg==",
-      "deprecated": "This is a stub types definition. react-intl provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "react-intl": "*"
-      }
-    },
     "node_modules/@types/react-lottie": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-lottie/-/react-lottie-1.2.3.tgz",
@@ -5601,22 +5700,6 @@
         "symbol-observable": "^1.0.3"
       }
     },
-    "node_modules/@types/redux-storage": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@types/redux-storage/-/redux-storage-4.1.0.tgz",
-      "integrity": "sha512-O9AeTfS8x5FFBBUCwORZkudLahIYURi4n8hIGyXKfVzik4JOYktI+FIWdNhn1CtGWBKsKg4nyc5gkkpDia/BvQ==",
-      "dependencies": {
-        "redux": "^3.6.0 || ^4.0.0"
-      }
-    },
-    "node_modules/@types/redux-storage-engine-localstorage": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/redux-storage-engine-localstorage/-/redux-storage-engine-localstorage-1.1.1.tgz",
-      "integrity": "sha512-JuX/kPFhLz5iaQOc/ynQaGjSv2DdfiMWsy6Dy3qpO/J3wFEXH170aG0ma4N3DNcwMP4OqnNRK4Y2xaqk57KPrQ==",
-      "dependencies": {
-        "@types/redux-storage": "*"
-      }
-    },
     "node_modules/@types/reselect": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/reselect/-/reselect-2.2.0.tgz",
@@ -5626,6 +5709,11 @@
       "dependencies": {
         "reselect": "*"
       }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "node_modules/@types/secp256k1": {
       "version": "4.0.1",
@@ -6143,36 +6231,36 @@
       }
     },
     "node_modules/@walletconnect/browser-utils": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.5.2.tgz",
-      "integrity": "sha512-nP7ktHwYmvHfXIbq7lGPoig8nO7HYi2dWE8UDxBlgNMs4mvzm2jyN6cm0JZ4xh5gO90/gQwbyuU33zLcZGUPhw==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.6.5.tgz",
+      "integrity": "sha512-HLTysmlCkc2HN2OS6ewMG0v8E9oY2h9zNaDHe0BLN3ZxnsoMCVzkJxy7ryaXCemVdapmr6HgHFexGJoMbWaC4w==",
       "dependencies": {
         "@walletconnect/safe-json": "1.0.0",
-        "@walletconnect/types": "^1.5.2",
+        "@walletconnect/types": "^1.6.5",
         "@walletconnect/window-getters": "1.0.0",
         "@walletconnect/window-metadata": "1.0.0",
         "detect-browser": "5.2.0"
       }
     },
     "node_modules/@walletconnect/client": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/client/-/client-1.5.2.tgz",
-      "integrity": "sha512-dAMK4zqNBZ88YpUQxTMt3RCS2ThTwecPmlq3MK76liLwrsGYRfnQ104GHZGI93rZEdcDWX04p5e3NsCXWMXcNw==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/client/-/client-1.6.5.tgz",
+      "integrity": "sha512-dRq1D3NEGwM2I3CpiwFsWy1rrdMKCMSfDUu3rCCXUE4zInx+pyq7IEFjYiSjtOEZzjRlUTqYwhjnYIezQZgh4w==",
       "dependencies": {
-        "@walletconnect/core": "^1.5.2",
-        "@walletconnect/iso-crypto": "^1.5.2",
-        "@walletconnect/types": "^1.5.2",
-        "@walletconnect/utils": "^1.5.2"
+        "@walletconnect/core": "^1.6.5",
+        "@walletconnect/iso-crypto": "^1.6.5",
+        "@walletconnect/types": "^1.6.5",
+        "@walletconnect/utils": "^1.6.5"
       }
     },
     "node_modules/@walletconnect/core": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.5.2.tgz",
-      "integrity": "sha512-uzrIbjzSHdPPeFSqwPYhp/VhyJKUODDc0STt+5R1A2orE1nh9Rb6XqSkBfLkOlf8pdKUObI95Lr0LH9TbSzF/A==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.6.5.tgz",
+      "integrity": "sha512-mmMTP8nZunjSCAy0ckafvt/JcdzcuSZPaAybqgKwx2rC9cc/3XWrdNsfiKMt8AFoQF87jGHem3905eFZYTqLXw==",
       "dependencies": {
-        "@walletconnect/socket-transport": "^1.5.2",
-        "@walletconnect/types": "^1.5.2",
-        "@walletconnect/utils": "^1.5.2"
+        "@walletconnect/socket-transport": "^1.6.5",
+        "@walletconnect/types": "^1.6.5",
+        "@walletconnect/utils": "^1.6.5"
       }
     },
     "node_modules/@walletconnect/crypto": {
@@ -6206,25 +6294,75 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/environment/-/environment-1.0.0.tgz",
       "integrity": "sha512-4BwqyWy6KpSvkocSaV7WR3BlZfrxLbJSLkg+j7Gl6pTDE+U55lLhJvQaMuDVazXYxcjBsG09k7UlH7cGiUI5vQ=="
     },
-    "node_modules/@walletconnect/http-connection": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/http-connection/-/http-connection-1.5.2.tgz",
-      "integrity": "sha512-drBwFzCHb+A/YAvMYGHs9DglL4NHQn079/dJzJPOC4kG9DA9WPw24CSeOUrqbP+370NwnaHbYtg4cbDgJQRy6g==",
+    "node_modules/@walletconnect/ethereum-provider": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-1.6.5.tgz",
+      "integrity": "sha512-Ezz5QdyvUMv9iJshqFFM+U25eiCjLN/T6PqotTgc7/iK+xCNRoCnUQqExb7sxPS/ibemRfBgIQv4JMvCT06MGw==",
       "dependencies": {
-        "@walletconnect/types": "^1.5.2",
-        "@walletconnect/utils": "^1.5.2",
+        "@walletconnect/client": "^1.6.5",
+        "@walletconnect/jsonrpc-http-connection": "^1.0.0",
+        "@walletconnect/jsonrpc-provider": "^1.0.0",
+        "@walletconnect/signer-connection": "^1.6.5",
+        "@walletconnect/types": "^1.6.5",
+        "@walletconnect/utils": "^1.6.5",
+        "eip1193-provider": "1.0.1",
+        "eventemitter3": "4.0.7"
+      }
+    },
+    "node_modules/@walletconnect/http-connection": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/http-connection/-/http-connection-1.6.5.tgz",
+      "integrity": "sha512-5kr6wZ3DnqaBiwkeA9iKdawvIb3bIJNf8WA8X89YHE5KOzbkAsymjniZWs8asdl9Y9+8ZHJMPXtylyrkpT8wXA==",
+      "dependencies": {
+        "@walletconnect/types": "^1.6.5",
+        "@walletconnect/utils": "^1.6.5",
         "eventemitter3": "4.0.7",
         "xhr2-cookies": "1.1.0"
       }
     },
     "node_modules/@walletconnect/iso-crypto": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.5.2.tgz",
-      "integrity": "sha512-tRd0+AfmOy0nwCqLx7oR3DyrsahgoyOAm/KqKzKu2eawnfG4dSaluUa/PxMjoC5r93K+ka7qmCq4k4m53qYiog==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.6.5.tgz",
+      "integrity": "sha512-145VRX1+gudhHrnT2s81lLW/BEu3QgFMMRCrkxx9Tsl5JiLGcGbWkMxAl8zjGTMqnHeuQngyjvY1mO+3z27a7A==",
       "dependencies": {
         "@walletconnect/crypto": "^1.0.1",
-        "@walletconnect/types": "^1.5.2",
-        "@walletconnect/utils": "^1.5.2"
+        "@walletconnect/types": "^1.6.5",
+        "@walletconnect/utils": "^1.6.5"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-http-connection": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-http-connection/-/jsonrpc-http-connection-1.0.0.tgz",
+      "integrity": "sha512-fmBTox7Zo9Tb8wzKpnOgYl5cYPu+2xXifNMDYMRGkWDAygXBzRzmfdhk7OowCkSXeh8aDhE5eFtMk+u8MOmntg==",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.0",
+        "@walletconnect/safe-json": "^1.0.0",
+        "cross-fetch": "^3.1.4"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-http-connection/node_modules/cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "dependencies": {
+        "node-fetch": "2.6.1"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-http-connection/node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-provider": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.0.tgz",
+      "integrity": "sha512-ZVe23tYT0LdykZ/denBdkKCjBC13fnpj8MiKFuvUl0idBv1PiYKYJR3LVJHy8+7zk0lBbDH3hBNrbMt/K4kjcw==",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.0",
+        "@walletconnect/safe-json": "^1.0.0"
       }
     },
     "node_modules/@walletconnect/jsonrpc-types": {
@@ -6251,13 +6389,13 @@
       "deprecated": "Deprecated in favor of dynamic registry available from: https://github.com/walletconnect/walletconnect-registry"
     },
     "node_modules/@walletconnect/qrcode-modal": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/qrcode-modal/-/qrcode-modal-1.5.2.tgz",
-      "integrity": "sha512-ciWh7kfZQ4qX+YYfF6+qVqw1Z0kyITGnzH7K2jEIxgCI5jsKeKoMcIfucSGIODGrM7OWshB/oA19UFTRdj4GFg==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/qrcode-modal/-/qrcode-modal-1.6.5.tgz",
+      "integrity": "sha512-XII/Pm7zS5pRxrakURuhbWO+SfwgOuLuvOBk/hr1ATK/y7R5p19P62mCSUrvSxHXca27IX1tZJRe9D161R0WgQ==",
       "dependencies": {
-        "@walletconnect/browser-utils": "^1.5.2",
+        "@walletconnect/browser-utils": "^1.6.5",
         "@walletconnect/mobile-registry": "^1.4.0",
-        "@walletconnect/types": "^1.5.2",
+        "@walletconnect/types": "^1.6.5",
         "copy-to-clipboard": "^3.3.1",
         "preact": "10.4.1",
         "qrcode": "1.4.4"
@@ -6278,20 +6416,33 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.0.tgz",
       "integrity": "sha512-QJzp/S/86sUAgWY6eh5MKYmSfZaRpIlmCJdi5uG4DJlKkZrHEF7ye7gA+VtbVzvTtpM/gRwO2plQuiooIeXjfg=="
     },
-    "node_modules/@walletconnect/socket-transport": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.5.2.tgz",
-      "integrity": "sha512-eXafL2STkPocpYo0lDTpsQFIQ5ggCw78dXri9kqNhiSwRdLpjswGxt745V37enOXuFumz18MRXp3Og8yc+HIFQ==",
+    "node_modules/@walletconnect/signer-connection": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/signer-connection/-/signer-connection-1.6.5.tgz",
+      "integrity": "sha512-Tlyh8l7Oe7IJuZkHlUijC+liNpeFAElKd9HkNWWTfMNlPQhkLy+gtar7L0TzXQfigRb6vC6fzO65+oZjDJzJDQ==",
       "dependencies": {
-        "@walletconnect/types": "^1.5.2",
-        "@walletconnect/utils": "^1.5.2",
-        "ws": "7.3.0"
+        "@walletconnect/client": "^1.6.5",
+        "@walletconnect/jsonrpc-types": "^1.0.0",
+        "@walletconnect/jsonrpc-utils": "^1.0.0",
+        "@walletconnect/qrcode-modal": "^1.6.5",
+        "@walletconnect/types": "^1.6.5",
+        "eventemitter3": "4.0.7"
+      }
+    },
+    "node_modules/@walletconnect/socket-transport": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.6.5.tgz",
+      "integrity": "sha512-FRlgBr3EIxD3du5l/tuK6jdiva85YeRG+iZmo/RPnlVw4opy74WXb5JdCK9jXLcBEoDiY9Hz4j69aqnht6gIDQ==",
+      "dependencies": {
+        "@walletconnect/types": "^1.6.5",
+        "@walletconnect/utils": "^1.6.5",
+        "ws": "7.5.3"
       }
     },
     "node_modules/@walletconnect/socket-transport/node_modules/ws": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
-      "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -6309,19 +6460,19 @@
       }
     },
     "node_modules/@walletconnect/types": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.5.2.tgz",
-      "integrity": "sha512-ygUIqrn+IyANuA3OKLX2GzVB18zUvoRTWX0llKeM0unSlrF7oEs8m5+H5NHLB9sDs00Jae7Eb+JvUaGa/VKIPw=="
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.6.5.tgz",
+      "integrity": "sha512-S9DsODI35PbIDuOSkIiF8SzTstqCqX/4+kV7n18vyukEFPlpSSHwZMwJUfzo9yJ0pqsqLNZta+jvb88gJRuAaA=="
     },
     "node_modules/@walletconnect/utils": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.5.2.tgz",
-      "integrity": "sha512-3m7Ty7oe/jb2NbYj7IAli+cyqlpg4XZG1xGrzCcQEEG6bkijCyc4qd51amimyh38wPsXp+kq7C4I+WAPBd9TkA==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.6.5.tgz",
+      "integrity": "sha512-QB5rn/1s0PKVitAQ2/mgWbay2XfN21y3ob+5g6IhxtJRW31bbMoZw5YfO6s4ixLaZZez5LNQXstvQAclRzB7jQ==",
       "dependencies": {
-        "@walletconnect/browser-utils": "^1.5.2",
+        "@walletconnect/browser-utils": "^1.6.5",
         "@walletconnect/encoding": "^1.0.0",
         "@walletconnect/jsonrpc-utils": "^1.0.0",
-        "@walletconnect/types": "^1.5.2",
+        "@walletconnect/types": "^1.6.5",
         "bn.js": "4.11.8",
         "js-sha3": "0.8.0",
         "query-string": "6.13.5"
@@ -6333,15 +6484,15 @@
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "node_modules/@walletconnect/web3-provider": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/web3-provider/-/web3-provider-1.5.2.tgz",
-      "integrity": "sha512-y60fAgobe4SwlVZYU0JQFHD8K3kXLCanGV+j998necBFppY3Ki+0szyROc08ok+PWpC1RbvFbRPibMrfHjnF6g==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/web3-provider/-/web3-provider-1.6.5.tgz",
+      "integrity": "sha512-SeC7+1saHxvFn2wjt/3F0sTkDemHDNDbMkdZ3jtA7vjEw91Q0CmaYIuZk2UxyVM+tC1jL1l4yci/sgaFeAcXpQ==",
       "dependencies": {
-        "@walletconnect/client": "^1.5.2",
-        "@walletconnect/http-connection": "^1.5.2",
-        "@walletconnect/qrcode-modal": "^1.5.2",
-        "@walletconnect/types": "^1.5.2",
-        "@walletconnect/utils": "^1.5.2",
+        "@walletconnect/client": "^1.6.5",
+        "@walletconnect/http-connection": "^1.6.5",
+        "@walletconnect/qrcode-modal": "^1.6.5",
+        "@walletconnect/types": "^1.6.5",
+        "@walletconnect/utils": "^1.6.5",
         "web3-provider-engine": "16.0.1"
       }
     },
@@ -6403,11 +6554,11 @@
       "integrity": "sha512-ofGmfDhxmNT1/P/MgVa8IKSkCStFiyvXe+U5tyZurKdrtTDFU+wJ/LxClPDtFerWpczNFPUSrKcuhfPX1sI6+A=="
     },
     "node_modules/@web3-react/walletconnect-connector": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@web3-react/walletconnect-connector/-/walletconnect-connector-6.2.4.tgz",
-      "integrity": "sha512-IEVjCXrlcfVa6ggUBEyKtLRaLQuZGtT2lGuzOFtdbJJkN84u1++pzzeDrcsVhKAoS5wq33zyJT9baEbG1Aed8g==",
+      "version": "7.0.2-alpha.0",
+      "resolved": "https://registry.npmjs.org/@web3-react/walletconnect-connector/-/walletconnect-connector-7.0.2-alpha.0.tgz",
+      "integrity": "sha512-Qr+AecDt5/gbAb8sFfW5kbMo0nberCAU/6AB9KmmwCm2YGEEqJrj8fW3Kin7SGxv8pgDxgXwPYsW7qMUzayXEQ==",
       "dependencies": {
-        "@walletconnect/web3-provider": "^1.5.0",
+        "@walletconnect/ethereum-provider": "^1.5.4",
         "@web3-react/abstract-connector": "^6.0.7",
         "@web3-react/types": "^6.0.7",
         "tiny-invariant": "^1.0.6"
@@ -7617,36 +7768,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/babel-plugin-polyfill-corejs2/node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz",
-      "integrity": "sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==",
-      "dependencies": {
-        "@babel/helper-compilation-targets": "^7.13.0",
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/traverse": "^7.13.0",
-        "debug": "^4.1.1",
-        "lodash.debounce": "^4.0.8",
-        "resolve": "^1.14.2",
-        "semver": "^6.1.2"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.4.0-0"
-      }
-    },
-    "node_modules/babel-plugin-polyfill-corejs2/node_modules/resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dependencies": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -7667,44 +7788,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/babel-plugin-polyfill-corejs3/node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz",
-      "integrity": "sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==",
-      "dependencies": {
-        "@babel/helper-compilation-targets": "^7.13.0",
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/traverse": "^7.13.0",
-        "debug": "^4.1.1",
-        "lodash.debounce": "^4.0.8",
-        "resolve": "^1.14.2",
-        "semver": "^6.1.2"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.4.0-0"
-      }
-    },
-    "node_modules/babel-plugin-polyfill-corejs3/node_modules/resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dependencies": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/babel-plugin-polyfill-corejs3/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/babel-plugin-polyfill-regenerator": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.2.tgz",
@@ -7714,44 +7797,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/babel-plugin-polyfill-regenerator/node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz",
-      "integrity": "sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==",
-      "dependencies": {
-        "@babel/helper-compilation-targets": "^7.13.0",
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/traverse": "^7.13.0",
-        "debug": "^4.1.1",
-        "lodash.debounce": "^4.0.8",
-        "resolve": "^1.14.2",
-        "semver": "^6.1.2"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.4.0-0"
-      }
-    },
-    "node_modules/babel-plugin-polyfill-regenerator/node_modules/resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dependencies": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/babel-plugin-polyfill-regenerator/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/babel-plugin-syntax-object-rest-spread": {
@@ -11527,71 +11572,99 @@
       }
     },
     "node_modules/decentraland-connect": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-2.18.0.tgz",
-      "integrity": "sha512-Wj1kNIy2xhb7RxzR0r+QN2+HWD26NntGuSBKh/xoR4/wSYMB3jxz/K3VarExJCAGuFeXjO2IdAha67y8Ikog0g==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-2.20.1.tgz",
+      "integrity": "sha512-Iou06ziOD3nwYghhTZpwb34JsVWSS7oAS490VG0V89usM3HZQmJ8LKHExZw4j8aCtMJ/aq6Ic5YAbNhP8kj2wQ==",
       "dependencies": {
         "@dcl/schemas": ">=1.1.0",
         "@types/node": "^10.1.2",
+        "@walletconnect/web3-provider": "^1.6.5",
         "@web3-react/fortmatic-connector": "^6.1.6",
         "@web3-react/injected-connector": "^6.0.7",
         "@web3-react/network-connector": "^6.1.3",
         "@web3-react/types": "^6.0.7",
-        "@web3-react/walletconnect-connector": "^6.1.6"
+        "@web3-react/walletconnect-connector": "^7.0.2-alpha.0"
       },
       "peerDependencies": {
         "@dcl/schemas": ">=1.1.0"
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "12.17.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-12.17.0.tgz",
-      "integrity": "sha512-wSXSiGCsLg6ZhQZI8S1Cf0PBpa4qbuzhbLUIC3YI4NCoTKbHwXw+yt1IMAFW6YC3nQBZ3Al+4Vq21c3s4s+i5Q==",
+      "version": "12.25.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-12.25.0.tgz",
+      "integrity": "sha512-cY9lVWTARCyIOnPBsebvrSYeIEuxuWWP9nuuQN5WbEyZ9x4Kr945251nzhYO0DQLnetx4ILCg25+x9EhyUCemg==",
       "dependencies": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
-        "@dcl/schemas": ">=1.1.0",
+        "@dcl/schemas": "^1.6.1",
         "@types/flat": "0.0.28",
-        "@types/node": "^10.1.2",
-        "@types/react": "^16.4.7",
-        "@types/react-intl": "^3.0.0",
-        "@types/react-redux": "^6.0.4",
-        "@types/redux-storage-engine-localstorage": "^1.1.0",
         "@types/segment-analytics": "0.0.28",
         "@types/uuid": "^3.4.3",
         "axios": "^0.21.1",
         "date-fns": "^1.29.0",
         "dcl-catalyst-client": "^4.0.6",
-        "decentraland-connect": "^2.18.0",
+        "decentraland-connect": "^2.20.1",
         "decentraland-transactions": "^1.22.2",
-        "decentraland-ui": "^3.6.0",
+        "decentraland-ui": "^3.10.0",
         "flat": "^4.1.0",
-        "react-intl": "^3.12.0",
+        "react-intl": "^5.20.7",
         "redux-persistence": "^1.2.0",
         "redux-persistence-engine-localstorage": "^1.0.0",
         "redux-storage-decorator-filter": "^1.1.8",
         "tslint": "^5.7.0",
         "tslint-config-prettier": "^1.10.0",
         "typesafe-actions": "^2.0.3",
-        "typescript": "^4.1.5",
-        "web3x-codegen": "^4.0.6",
-        "web3x-es": "^4.0.6"
+        "web3x": "^4.0.6",
+        "web3x-codegen": "^4.0.6"
+      },
+      "engines": {
+        "npm": "^7.0.0"
       },
       "peerDependencies": {
-        "@dcl/schemas": ">=1.1.0",
+        "@dcl/schemas": "^1.6.1",
         "react": "^17.0.2",
         "react-redux": "^7.2.4",
         "redux": "^4.1.0",
         "redux-saga": "^1.1.3"
       }
     },
-    "node_modules/decentraland-dapps/node_modules/@types/react-redux": {
-      "version": "6.0.14",
-      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-6.0.14.tgz",
-      "integrity": "sha512-bvpWqBOvz2V+EfZ9Qu1d3gFKYCIn/BYoGWAVt1c526tbiI9rtfaBbjutbbapmtEZaEfLuHj3Ljg9qho0SBSwUg==",
+    "node_modules/decentraland-dapps/node_modules/@formatjs/intl": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-1.14.1.tgz",
+      "integrity": "sha512-mtL8oBgFwTu0GHFnxaF93fk/zNzNkPzl+27Fwg5AZ88pWHWb7037dpODzoCBnaIVk4FBO5emUn/6jI9Byj8hOw==",
       "dependencies": {
-        "@types/react": "*",
-        "redux": "^4.0.0"
+        "@formatjs/ecma402-abstract": "1.9.8",
+        "@formatjs/fast-memoize": "1.2.0",
+        "@formatjs/icu-messageformat-parser": "2.0.11",
+        "@formatjs/intl-displaynames": "5.2.3",
+        "@formatjs/intl-listformat": "6.3.3",
+        "intl-messageformat": "9.9.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@types/node": "14 || 16",
+        "typescript": "^4.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decentraland-dapps/node_modules/@types/node": {
+      "version": "16.7.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.13.tgz",
+      "integrity": "sha512-pLUPDn+YG3FYEt/pHI74HmnJOWzeR+tOIQzUx93pi9M7D8OE7PSLr97HboXwk5F+JS+TLtWuzCOW97AHjmOXXA==",
+      "peer": true
+    },
+    "node_modules/decentraland-dapps/node_modules/@types/react": {
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.20.tgz",
+      "integrity": "sha512-wWZrPlihslrPpcKyCSlmIlruakxr57/buQN1RjlIeaaTWDLtJkTtRW429MoQJergvVKc4IWBpRhWw7YNh/7GVA==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/decentraland-dapps/node_modules/acorn": {
@@ -11725,6 +11798,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/decentraland-dapps/node_modules/csstype": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
     },
     "node_modules/decentraland-dapps/node_modules/date-fns": {
       "version": "1.30.1",
@@ -12003,27 +12081,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/decentraland-dapps/node_modules/intl-format-cache": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-4.3.1.tgz",
-      "integrity": "sha512-OEUYNA7D06agqPOYhbTkl0T8HA3QKSuwWh1HiClEnpd9vw7N+3XsQt5iZ0GUEchp5CW1fQk/tary+NsbF3yQ1Q=="
-    },
     "node_modules/decentraland-dapps/node_modules/intl-messageformat": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-7.8.4.tgz",
-      "integrity": "sha512-yS0cLESCKCYjseCOGXuV4pxJm/buTfyCJ1nzQjryHmSehlptbZbn9fnlk1I9peLopZGGbjj46yHHiTAEZ1qOTA==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.9.1.tgz",
+      "integrity": "sha512-cuzS/XKHn//hvKka77JKU2dseiVY2dofQjIOZv6ZFxFt4Z9sPXnZ7KQ9Ak2r+4XBCjI04MqJ1PhKs/3X22AkfA==",
       "dependencies": {
-        "intl-format-cache": "^4.2.21",
-        "intl-messageformat-parser": "^3.6.4"
-      }
-    },
-    "node_modules/decentraland-dapps/node_modules/intl-messageformat-parser": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-3.6.4.tgz",
-      "integrity": "sha512-RgPGwue0mJtoX2Ax8EmMzJzttxjnva7gx0Q7mKJ4oALrTZvtmCeAw5Msz2PcjW4dtCh/h7vN/8GJCxZO1uv+OA==",
-      "deprecated": "We've written a new parser that's 6x faster and is backwards compatible. Please use @formatjs/icu-messageformat-parser",
-      "dependencies": {
-        "@formatjs/intl-unified-numberformat": "^3.2.0"
+        "@formatjs/fast-memoize": "1.2.0",
+        "@formatjs/icu-messageformat-parser": "2.0.11",
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/decentraland-dapps/node_modules/is-fullwidth-code-point": {
@@ -12133,25 +12198,29 @@
       }
     },
     "node_modules/decentraland-dapps/node_modules/react-intl": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-3.12.1.tgz",
-      "integrity": "sha512-cgumW29mwROIqyp8NXStYsoIm27+8FqnxykiLSawWjOxGIBeLuN/+p2srei5SRIumcJefOkOIHP+NDck05RgHg==",
+      "version": "5.20.10",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-5.20.10.tgz",
+      "integrity": "sha512-zy0ZQhpjkGsKcK1BFo2HbGM/q8GBVovzoXZGQ76DowR0yr6UzQuPLkrlIrObL2zxIYiDaxaz+hUJaoa2a1xqOQ==",
       "dependencies": {
-        "@formatjs/intl-displaynames": "^1.2.0",
-        "@formatjs/intl-listformat": "^1.4.1",
-        "@formatjs/intl-relativetimeformat": "^4.5.9",
-        "@formatjs/intl-unified-numberformat": "^3.2.0",
-        "@formatjs/intl-utils": "^2.2.0",
+        "@formatjs/ecma402-abstract": "1.9.8",
+        "@formatjs/icu-messageformat-parser": "2.0.11",
+        "@formatjs/intl": "1.14.1",
+        "@formatjs/intl-displaynames": "5.2.3",
+        "@formatjs/intl-listformat": "6.3.3",
         "@types/hoist-non-react-statics": "^3.3.1",
-        "@types/invariant": "^2.2.31",
+        "@types/react": "17",
         "hoist-non-react-statics": "^3.3.2",
-        "intl-format-cache": "^4.2.21",
-        "intl-messageformat": "^7.8.4",
-        "intl-messageformat-parser": "^3.6.4",
-        "shallow-equal": "^1.2.1"
+        "intl-messageformat": "9.9.1",
+        "tslib": "^2.1.0"
       },
       "peerDependencies": {
-        "react": "^16.3.0"
+        "react": "^16.3.0 || 17",
+        "typescript": "^4.2"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/decentraland-dapps/node_modules/regexpp": {
@@ -12333,9 +12402,11 @@
       }
     },
     "node_modules/decentraland-dapps/node_modules/typescript": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
-      "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
+      "optional": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12495,9 +12566,9 @@
       "integrity": "sha512-E1d3SrhYQga6KAwO6XBvIc7kKpoq9lQR98Ms/VyNj5fOOT8rqJJas05mbsyn6eINP7smzt+ukI4j59ljEF1bdw=="
     },
     "node_modules/decentraland-ui": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.9.0.tgz",
-      "integrity": "sha512-sqyiuxAxesCbFAd42iwwFxHLHOFun+XIUa0gZGrT56NY94lsdS7M2OmyEK82nvbK7tUG1L10a7oVcuC9/YSOqQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.10.0.tgz",
+      "integrity": "sha512-YY9RHGcJV9DI0Um7d5IWhC5iiVNYuScAozz9KmpH/cIpIr2ZemBKTl13zGJQcZUVooXqWNI0RBa7OC/l5ZM46g==",
       "dependencies": {
         "@dcl/schemas": "^0.2.0",
         "balloon-css": "^0.5.0",
@@ -13153,6 +13224,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "node_modules/eip1193-provider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
+      "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
+      "dependencies": {
+        "@json-rpc-tools/provider": "^1.5.5"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.3.728",
@@ -14001,9 +14080,9 @@
       }
     },
     "node_modules/eth-block-tracker/node_modules/@babel/runtime": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz",
-      "integrity": "sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -14174,9 +14253,9 @@
       }
     },
     "node_modules/eth-json-rpc-infura/node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==",
       "engines": {
         "node": "4.x || >=6.0.0"
       }
@@ -14223,9 +14302,9 @@
       }
     },
     "node_modules/eth-json-rpc-middleware/node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==",
       "engines": {
         "node": "4.x || >=6.0.0"
       }
@@ -14275,7 +14354,7 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "dependencies": {
-        "ethereumjs-abi": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git",
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
         "ethereumjs-util": "^5.1.1"
       }
     },
@@ -15236,9 +15315,9 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "node_modules/fast-safe-stringify": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
-      "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fastparse": {
       "version": "1.1.2",
@@ -15710,7 +15789,71 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
       "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
       "bundleDependencies": [
-        "node-pre-gyp"
+        "node-pre-gyp",
+        "abbrev",
+        "ansi-regex",
+        "aproba",
+        "are-we-there-yet",
+        "balanced-match",
+        "brace-expansion",
+        "chownr",
+        "code-point-at",
+        "concat-map",
+        "console-control-strings",
+        "core-util-is",
+        "debug",
+        "deep-extend",
+        "delegates",
+        "detect-libc",
+        "fs-minipass",
+        "fs.realpath",
+        "gauge",
+        "glob",
+        "has-unicode",
+        "iconv-lite",
+        "ignore-walk",
+        "inflight",
+        "inherits",
+        "ini",
+        "is-fullwidth-code-point",
+        "isarray",
+        "minimatch",
+        "minimist",
+        "minipass",
+        "minizlib",
+        "mkdirp",
+        "ms",
+        "needle",
+        "nopt",
+        "npm-bundled",
+        "npm-packlist",
+        "npmlog",
+        "number-is-nan",
+        "object-assign",
+        "once",
+        "os-homedir",
+        "os-tmpdir",
+        "osenv",
+        "path-is-absolute",
+        "process-nextick-args",
+        "rc",
+        "readable-stream",
+        "rimraf",
+        "safe-buffer",
+        "safer-buffer",
+        "sax",
+        "semver",
+        "set-blocking",
+        "signal-exit",
+        "string_decoder",
+        "string-width",
+        "strip-ansi",
+        "strip-json-comments",
+        "tar",
+        "util-deprecate",
+        "wide-align",
+        "wrappy",
+        "yallist"
       ],
       "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
       "hasInstallScript": true,
@@ -34057,6 +34200,11 @@
         "events": "^3.0.0"
       }
     },
+    "node_modules/safe-json-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
+      "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
+    },
     "node_modules/safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
@@ -36579,9 +36727,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-      "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/tslint": {
       "version": "5.20.1",
@@ -39010,6 +39158,37 @@
         "lodash": "^4.17.13"
       }
     },
+    "@babel/helper-define-polyfill-provider": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz",
+      "integrity": "sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==",
+      "requires": {
+        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/traverse": "^7.13.0",
+        "debug": "^4.1.1",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.14.2",
+        "semver": "^6.1.2"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
     "@babel/helper-explode-assignable-expression": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.4.tgz",
@@ -39960,9 +40139,9 @@
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
     },
     "@dcl/schemas": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-1.1.0.tgz",
-      "integrity": "sha512-5GosxadKhj3gfkQF87rrCXBuU9i1pDwsq6frj2NQFSNzl14ZsDeorAADXRaPvAXDDLj/mwGmEN6f5TpB8nAifQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-1.6.1.tgz",
+      "integrity": "sha512-wrngSXY3mY/4/4ErIkcgBH7eqbchB/YcDki6ZBIBo4B7zNFO29tEd0k0gfVhD83w+1Mfhiak9+g7fgHrmXfhHg==",
       "requires": {
         "ajv": "^7.1.0"
       },
@@ -40504,42 +40683,69 @@
         }
       }
     },
-    "@formatjs/intl-displaynames": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-1.2.10.tgz",
-      "integrity": "sha512-GROA2RP6+7Ouu0WnHFF78O5XIU7pBfI19WM1qm93l6MFWibUk67nCfVCK3VAYJkLy8L8ZxjkYT11VIAfvSz8wg==",
+    "@formatjs/ecma402-abstract": {
+      "version": "1.9.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.9.8.tgz",
+      "integrity": "sha512-2U4n11bLmTij/k4ePCEFKJILPYwdMcJTdnKVBi+JMWBgu5O1N+XhCazlE6QXqVO1Agh2Doh0b/9Jf1mSmSVfhA==",
       "requires": {
-        "@formatjs/intl-utils": "^2.3.0"
+        "@formatjs/intl-localematcher": "0.2.20",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@formatjs/fast-memoize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.0.tgz",
+      "integrity": "sha512-fObitP9Tlc31SKrPHgkPgQpGo4+4yXfQQITTCNH8AZdEqB7Mq4nPrjpUL/tNGN3lEeJcFxDbi0haX8HM7QvQ8w==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "@formatjs/icu-messageformat-parser": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.0.11.tgz",
+      "integrity": "sha512-5mWb8U8aulYGwnDZWrr+vdgn5PilvtrqQYQ1pvpgzQes/osi85TwmL2GqTGLlKIvBKD2XNA61kAqXYY95w4LWg==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.9.8",
+        "@formatjs/icu-skeleton-parser": "1.2.12",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@formatjs/icu-skeleton-parser": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.2.12.tgz",
+      "integrity": "sha512-DTFxWmEA02ZNW6fsYjGYSADvtrqqjCYF7DSgCmMfaaE0gLP4pCdAgOPE+lkXXU+jP8iCw/YhMT2Seyk/C5lBWg==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.9.8",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@formatjs/intl-displaynames": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-5.2.3.tgz",
+      "integrity": "sha512-5BmhSurLbfgdeo0OBcNPPkIS8ikMMYaHe2NclxEQZqcMvrnQzNMNnUE2dDF5vZx+mkvKq77aQYzpc8RfqVsRCQ==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.9.8",
+        "@formatjs/intl-localematcher": "0.2.20",
+        "tslib": "^2.1.0"
       }
     },
     "@formatjs/intl-listformat": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-1.4.8.tgz",
-      "integrity": "sha512-WNMQlEg0e50VZrGIkgD5n7+DAMGt3boKi1GJALfhFMymslJb5i+5WzWxyj/3a929Z6MAFsmzRIJjKuv+BxKAOQ==",
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-6.3.3.tgz",
+      "integrity": "sha512-3nzAKgVS5rePDa5HiH0OwZgAhqxLtzlMc9Pg4QgajRHSP1TqFiMmQnnn52wd3+xVTb7cjZVm3JBnTv51/MhTOg==",
       "requires": {
-        "@formatjs/intl-utils": "^2.3.0"
+        "@formatjs/ecma402-abstract": "1.9.8",
+        "@formatjs/intl-localematcher": "0.2.20",
+        "tslib": "^2.1.0"
       }
     },
-    "@formatjs/intl-relativetimeformat": {
-      "version": "4.5.16",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-4.5.16.tgz",
-      "integrity": "sha512-IQ0haY97oHAH5OYUdykNiepdyEWj3SAT+Fp9ZpR85ov2JNiFx+12WWlxlVS8ehdyncC2ZMt/SwFIy2huK2+6/A==",
+    "@formatjs/intl-localematcher": {
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.20.tgz",
+      "integrity": "sha512-/Ro85goRZnCojzxOegANFYL0LaDIpdPjAukR7xMTjOtRx+3yyjR0ifGTOW3/Kjhmab3t6GnyHBYWZSudxEOxPA==",
       "requires": {
-        "@formatjs/intl-utils": "^2.3.0"
+        "tslib": "^2.1.0"
       }
-    },
-    "@formatjs/intl-unified-numberformat": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-3.3.7.tgz",
-      "integrity": "sha512-KnWgLRHzCAgT9eyt3OS34RHoyD7dPDYhRcuKn+/6Kv2knDF8Im43J6vlSW6Hm1w63fNq3ZIT1cFk7RuVO3Psag==",
-      "requires": {
-        "@formatjs/intl-utils": "^2.3.0"
-      }
-    },
-    "@formatjs/intl-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz",
-      "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -42305,6 +42511,34 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@json-rpc-tools/provider": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz",
+      "integrity": "sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==",
+      "requires": {
+        "@json-rpc-tools/utils": "^1.7.6",
+        "axios": "^0.21.0",
+        "safe-json-utils": "^1.1.1",
+        "ws": "^7.4.0"
+      }
+    },
+    "@json-rpc-tools/types": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
+      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
+      "requires": {
+        "keyvaluestorage-interface": "^1.0.0"
+      }
+    },
+    "@json-rpc-tools/utils": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
+      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
+      "requires": {
+        "@json-rpc-tools/types": "^1.7.6",
+        "@pedrouid/environment": "^1.0.1"
+      }
+    },
     "@metamask/safe-event-emitter": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz",
@@ -42348,6 +42582,11 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@pedrouid/environment": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
+      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "@popperjs/core": {
       "version": "2.9.3",
@@ -42602,11 +42841,6 @@
           }
         }
       }
-    },
-    "@types/invariant": {
-      "version": "2.2.34",
-      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.34.tgz",
-      "integrity": "sha512-lYUtmJ9BqUN688fGY1U1HZoWT1/Jrmgigx2loq4ZcJpICECm/Om3V314BxdzypO0u5PORKGMM6x0OXaljV1YFg=="
     },
     "@types/isomorphic-fetch": {
       "version": "0.0.35",
@@ -42899,14 +43133,6 @@
         "@types/react": "*"
       }
     },
-    "@types/react-intl": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/react-intl/-/react-intl-3.0.0.tgz",
-      "integrity": "sha512-k8F3d05XQGEqSWIfK97bBjZe4z9RruXU9Wa7OZ2iUC5pdeIpzuQDZe/9C2J3Xir5//ZtAkhcv08Wfx3n5TBTQg==",
-      "requires": {
-        "react-intl": "*"
-      }
-    },
     "@types/react-lottie": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-lottie/-/react-lottie-1.2.3.tgz",
@@ -42992,22 +43218,6 @@
         }
       }
     },
-    "@types/redux-storage": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@types/redux-storage/-/redux-storage-4.1.0.tgz",
-      "integrity": "sha512-O9AeTfS8x5FFBBUCwORZkudLahIYURi4n8hIGyXKfVzik4JOYktI+FIWdNhn1CtGWBKsKg4nyc5gkkpDia/BvQ==",
-      "requires": {
-        "redux": "^3.6.0 || ^4.0.0"
-      }
-    },
-    "@types/redux-storage-engine-localstorage": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/redux-storage-engine-localstorage/-/redux-storage-engine-localstorage-1.1.1.tgz",
-      "integrity": "sha512-JuX/kPFhLz5iaQOc/ynQaGjSv2DdfiMWsy6Dy3qpO/J3wFEXH170aG0ma4N3DNcwMP4OqnNRK4Y2xaqk57KPrQ==",
-      "requires": {
-        "@types/redux-storage": "*"
-      }
-    },
     "@types/reselect": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/reselect/-/reselect-2.2.0.tgz",
@@ -43016,6 +43226,11 @@
       "requires": {
         "reselect": "*"
       }
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/secp256k1": {
       "version": "4.0.1",
@@ -43368,36 +43583,36 @@
       }
     },
     "@walletconnect/browser-utils": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.5.2.tgz",
-      "integrity": "sha512-nP7ktHwYmvHfXIbq7lGPoig8nO7HYi2dWE8UDxBlgNMs4mvzm2jyN6cm0JZ4xh5gO90/gQwbyuU33zLcZGUPhw==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.6.5.tgz",
+      "integrity": "sha512-HLTysmlCkc2HN2OS6ewMG0v8E9oY2h9zNaDHe0BLN3ZxnsoMCVzkJxy7ryaXCemVdapmr6HgHFexGJoMbWaC4w==",
       "requires": {
         "@walletconnect/safe-json": "1.0.0",
-        "@walletconnect/types": "^1.5.2",
+        "@walletconnect/types": "^1.6.5",
         "@walletconnect/window-getters": "1.0.0",
         "@walletconnect/window-metadata": "1.0.0",
         "detect-browser": "5.2.0"
       }
     },
     "@walletconnect/client": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/client/-/client-1.5.2.tgz",
-      "integrity": "sha512-dAMK4zqNBZ88YpUQxTMt3RCS2ThTwecPmlq3MK76liLwrsGYRfnQ104GHZGI93rZEdcDWX04p5e3NsCXWMXcNw==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/client/-/client-1.6.5.tgz",
+      "integrity": "sha512-dRq1D3NEGwM2I3CpiwFsWy1rrdMKCMSfDUu3rCCXUE4zInx+pyq7IEFjYiSjtOEZzjRlUTqYwhjnYIezQZgh4w==",
       "requires": {
-        "@walletconnect/core": "^1.5.2",
-        "@walletconnect/iso-crypto": "^1.5.2",
-        "@walletconnect/types": "^1.5.2",
-        "@walletconnect/utils": "^1.5.2"
+        "@walletconnect/core": "^1.6.5",
+        "@walletconnect/iso-crypto": "^1.6.5",
+        "@walletconnect/types": "^1.6.5",
+        "@walletconnect/utils": "^1.6.5"
       }
     },
     "@walletconnect/core": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.5.2.tgz",
-      "integrity": "sha512-uzrIbjzSHdPPeFSqwPYhp/VhyJKUODDc0STt+5R1A2orE1nh9Rb6XqSkBfLkOlf8pdKUObI95Lr0LH9TbSzF/A==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.6.5.tgz",
+      "integrity": "sha512-mmMTP8nZunjSCAy0ckafvt/JcdzcuSZPaAybqgKwx2rC9cc/3XWrdNsfiKMt8AFoQF87jGHem3905eFZYTqLXw==",
       "requires": {
-        "@walletconnect/socket-transport": "^1.5.2",
-        "@walletconnect/types": "^1.5.2",
-        "@walletconnect/utils": "^1.5.2"
+        "@walletconnect/socket-transport": "^1.6.5",
+        "@walletconnect/types": "^1.6.5",
+        "@walletconnect/utils": "^1.6.5"
       }
     },
     "@walletconnect/crypto": {
@@ -43433,25 +43648,74 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/environment/-/environment-1.0.0.tgz",
       "integrity": "sha512-4BwqyWy6KpSvkocSaV7WR3BlZfrxLbJSLkg+j7Gl6pTDE+U55lLhJvQaMuDVazXYxcjBsG09k7UlH7cGiUI5vQ=="
     },
-    "@walletconnect/http-connection": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/http-connection/-/http-connection-1.5.2.tgz",
-      "integrity": "sha512-drBwFzCHb+A/YAvMYGHs9DglL4NHQn079/dJzJPOC4kG9DA9WPw24CSeOUrqbP+370NwnaHbYtg4cbDgJQRy6g==",
+    "@walletconnect/ethereum-provider": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-1.6.5.tgz",
+      "integrity": "sha512-Ezz5QdyvUMv9iJshqFFM+U25eiCjLN/T6PqotTgc7/iK+xCNRoCnUQqExb7sxPS/ibemRfBgIQv4JMvCT06MGw==",
       "requires": {
-        "@walletconnect/types": "^1.5.2",
-        "@walletconnect/utils": "^1.5.2",
+        "@walletconnect/client": "^1.6.5",
+        "@walletconnect/jsonrpc-http-connection": "^1.0.0",
+        "@walletconnect/jsonrpc-provider": "^1.0.0",
+        "@walletconnect/signer-connection": "^1.6.5",
+        "@walletconnect/types": "^1.6.5",
+        "@walletconnect/utils": "^1.6.5",
+        "eip1193-provider": "1.0.1",
+        "eventemitter3": "4.0.7"
+      }
+    },
+    "@walletconnect/http-connection": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/http-connection/-/http-connection-1.6.5.tgz",
+      "integrity": "sha512-5kr6wZ3DnqaBiwkeA9iKdawvIb3bIJNf8WA8X89YHE5KOzbkAsymjniZWs8asdl9Y9+8ZHJMPXtylyrkpT8wXA==",
+      "requires": {
+        "@walletconnect/types": "^1.6.5",
+        "@walletconnect/utils": "^1.6.5",
         "eventemitter3": "4.0.7",
         "xhr2-cookies": "1.1.0"
       }
     },
     "@walletconnect/iso-crypto": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.5.2.tgz",
-      "integrity": "sha512-tRd0+AfmOy0nwCqLx7oR3DyrsahgoyOAm/KqKzKu2eawnfG4dSaluUa/PxMjoC5r93K+ka7qmCq4k4m53qYiog==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.6.5.tgz",
+      "integrity": "sha512-145VRX1+gudhHrnT2s81lLW/BEu3QgFMMRCrkxx9Tsl5JiLGcGbWkMxAl8zjGTMqnHeuQngyjvY1mO+3z27a7A==",
       "requires": {
         "@walletconnect/crypto": "^1.0.1",
-        "@walletconnect/types": "^1.5.2",
-        "@walletconnect/utils": "^1.5.2"
+        "@walletconnect/types": "^1.6.5",
+        "@walletconnect/utils": "^1.6.5"
+      }
+    },
+    "@walletconnect/jsonrpc-http-connection": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-http-connection/-/jsonrpc-http-connection-1.0.0.tgz",
+      "integrity": "sha512-fmBTox7Zo9Tb8wzKpnOgYl5cYPu+2xXifNMDYMRGkWDAygXBzRzmfdhk7OowCkSXeh8aDhE5eFtMk+u8MOmntg==",
+      "requires": {
+        "@walletconnect/jsonrpc-utils": "^1.0.0",
+        "@walletconnect/safe-json": "^1.0.0",
+        "cross-fetch": "^3.1.4"
+      },
+      "dependencies": {
+        "cross-fetch": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+          "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+          "requires": {
+            "node-fetch": "2.6.1"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+        }
+      }
+    },
+    "@walletconnect/jsonrpc-provider": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.0.tgz",
+      "integrity": "sha512-ZVe23tYT0LdykZ/denBdkKCjBC13fnpj8MiKFuvUl0idBv1PiYKYJR3LVJHy8+7zk0lBbDH3hBNrbMt/K4kjcw==",
+      "requires": {
+        "@walletconnect/jsonrpc-utils": "^1.0.0",
+        "@walletconnect/safe-json": "^1.0.0"
       }
     },
     "@walletconnect/jsonrpc-types": {
@@ -43477,13 +43741,13 @@
       "integrity": "sha512-ZtKRio4uCZ1JUF7LIdecmZt7FOLnX72RPSY7aUVu7mj7CSfxDwUn6gBuK6WGtH+NZCldBqDl5DenI5fFSvkKYw=="
     },
     "@walletconnect/qrcode-modal": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/qrcode-modal/-/qrcode-modal-1.5.2.tgz",
-      "integrity": "sha512-ciWh7kfZQ4qX+YYfF6+qVqw1Z0kyITGnzH7K2jEIxgCI5jsKeKoMcIfucSGIODGrM7OWshB/oA19UFTRdj4GFg==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/qrcode-modal/-/qrcode-modal-1.6.5.tgz",
+      "integrity": "sha512-XII/Pm7zS5pRxrakURuhbWO+SfwgOuLuvOBk/hr1ATK/y7R5p19P62mCSUrvSxHXca27IX1tZJRe9D161R0WgQ==",
       "requires": {
-        "@walletconnect/browser-utils": "^1.5.2",
+        "@walletconnect/browser-utils": "^1.6.5",
         "@walletconnect/mobile-registry": "^1.4.0",
-        "@walletconnect/types": "^1.5.2",
+        "@walletconnect/types": "^1.6.5",
         "copy-to-clipboard": "^3.3.1",
         "preact": "10.4.1",
         "qrcode": "1.4.4"
@@ -43504,38 +43768,51 @@
       "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.0.tgz",
       "integrity": "sha512-QJzp/S/86sUAgWY6eh5MKYmSfZaRpIlmCJdi5uG4DJlKkZrHEF7ye7gA+VtbVzvTtpM/gRwO2plQuiooIeXjfg=="
     },
-    "@walletconnect/socket-transport": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.5.2.tgz",
-      "integrity": "sha512-eXafL2STkPocpYo0lDTpsQFIQ5ggCw78dXri9kqNhiSwRdLpjswGxt745V37enOXuFumz18MRXp3Og8yc+HIFQ==",
+    "@walletconnect/signer-connection": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/signer-connection/-/signer-connection-1.6.5.tgz",
+      "integrity": "sha512-Tlyh8l7Oe7IJuZkHlUijC+liNpeFAElKd9HkNWWTfMNlPQhkLy+gtar7L0TzXQfigRb6vC6fzO65+oZjDJzJDQ==",
       "requires": {
-        "@walletconnect/types": "^1.5.2",
-        "@walletconnect/utils": "^1.5.2",
-        "ws": "7.3.0"
+        "@walletconnect/client": "^1.6.5",
+        "@walletconnect/jsonrpc-types": "^1.0.0",
+        "@walletconnect/jsonrpc-utils": "^1.0.0",
+        "@walletconnect/qrcode-modal": "^1.6.5",
+        "@walletconnect/types": "^1.6.5",
+        "eventemitter3": "4.0.7"
+      }
+    },
+    "@walletconnect/socket-transport": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.6.5.tgz",
+      "integrity": "sha512-FRlgBr3EIxD3du5l/tuK6jdiva85YeRG+iZmo/RPnlVw4opy74WXb5JdCK9jXLcBEoDiY9Hz4j69aqnht6gIDQ==",
+      "requires": {
+        "@walletconnect/types": "^1.6.5",
+        "@walletconnect/utils": "^1.6.5",
+        "ws": "7.5.3"
       },
       "dependencies": {
         "ws": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
-          "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
+          "version": "7.5.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+          "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
           "requires": {}
         }
       }
     },
     "@walletconnect/types": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.5.2.tgz",
-      "integrity": "sha512-ygUIqrn+IyANuA3OKLX2GzVB18zUvoRTWX0llKeM0unSlrF7oEs8m5+H5NHLB9sDs00Jae7Eb+JvUaGa/VKIPw=="
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.6.5.tgz",
+      "integrity": "sha512-S9DsODI35PbIDuOSkIiF8SzTstqCqX/4+kV7n18vyukEFPlpSSHwZMwJUfzo9yJ0pqsqLNZta+jvb88gJRuAaA=="
     },
     "@walletconnect/utils": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.5.2.tgz",
-      "integrity": "sha512-3m7Ty7oe/jb2NbYj7IAli+cyqlpg4XZG1xGrzCcQEEG6bkijCyc4qd51amimyh38wPsXp+kq7C4I+WAPBd9TkA==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.6.5.tgz",
+      "integrity": "sha512-QB5rn/1s0PKVitAQ2/mgWbay2XfN21y3ob+5g6IhxtJRW31bbMoZw5YfO6s4ixLaZZez5LNQXstvQAclRzB7jQ==",
       "requires": {
-        "@walletconnect/browser-utils": "^1.5.2",
+        "@walletconnect/browser-utils": "^1.6.5",
         "@walletconnect/encoding": "^1.0.0",
         "@walletconnect/jsonrpc-utils": "^1.0.0",
-        "@walletconnect/types": "^1.5.2",
+        "@walletconnect/types": "^1.6.5",
         "bn.js": "4.11.8",
         "js-sha3": "0.8.0",
         "query-string": "6.13.5"
@@ -43549,15 +43826,15 @@
       }
     },
     "@walletconnect/web3-provider": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/web3-provider/-/web3-provider-1.5.2.tgz",
-      "integrity": "sha512-y60fAgobe4SwlVZYU0JQFHD8K3kXLCanGV+j998necBFppY3Ki+0szyROc08ok+PWpC1RbvFbRPibMrfHjnF6g==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@walletconnect/web3-provider/-/web3-provider-1.6.5.tgz",
+      "integrity": "sha512-SeC7+1saHxvFn2wjt/3F0sTkDemHDNDbMkdZ3jtA7vjEw91Q0CmaYIuZk2UxyVM+tC1jL1l4yci/sgaFeAcXpQ==",
       "requires": {
-        "@walletconnect/client": "^1.5.2",
-        "@walletconnect/http-connection": "^1.5.2",
-        "@walletconnect/qrcode-modal": "^1.5.2",
-        "@walletconnect/types": "^1.5.2",
-        "@walletconnect/utils": "^1.5.2",
+        "@walletconnect/client": "^1.6.5",
+        "@walletconnect/http-connection": "^1.6.5",
+        "@walletconnect/qrcode-modal": "^1.6.5",
+        "@walletconnect/types": "^1.6.5",
+        "@walletconnect/utils": "^1.6.5",
         "web3-provider-engine": "16.0.1"
       }
     },
@@ -43619,11 +43896,11 @@
       "integrity": "sha512-ofGmfDhxmNT1/P/MgVa8IKSkCStFiyvXe+U5tyZurKdrtTDFU+wJ/LxClPDtFerWpczNFPUSrKcuhfPX1sI6+A=="
     },
     "@web3-react/walletconnect-connector": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@web3-react/walletconnect-connector/-/walletconnect-connector-6.2.4.tgz",
-      "integrity": "sha512-IEVjCXrlcfVa6ggUBEyKtLRaLQuZGtT2lGuzOFtdbJJkN84u1++pzzeDrcsVhKAoS5wq33zyJT9baEbG1Aed8g==",
+      "version": "7.0.2-alpha.0",
+      "resolved": "https://registry.npmjs.org/@web3-react/walletconnect-connector/-/walletconnect-connector-7.0.2-alpha.0.tgz",
+      "integrity": "sha512-Qr+AecDt5/gbAb8sFfW5kbMo0nberCAU/6AB9KmmwCm2YGEEqJrj8fW3Kin7SGxv8pgDxgXwPYsW7qMUzayXEQ==",
       "requires": {
-        "@walletconnect/web3-provider": "^1.5.0",
+        "@walletconnect/ethereum-provider": "^1.5.4",
         "@web3-react/abstract-connector": "^6.0.7",
         "@web3-react/types": "^6.0.7",
         "tiny-invariant": "^1.0.6"
@@ -44675,30 +44952,6 @@
         "semver": "^6.1.1"
       },
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz",
-          "integrity": "sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==",
-          "requires": {
-            "@babel/helper-compilation-targets": "^7.13.0",
-            "@babel/helper-module-imports": "^7.12.13",
-            "@babel/helper-plugin-utils": "^7.13.0",
-            "@babel/traverse": "^7.13.0",
-            "debug": "^4.1.1",
-            "lodash.debounce": "^4.0.8",
-            "resolve": "^1.14.2",
-            "semver": "^6.1.2"
-          }
-        },
-        "resolve": {
-          "version": "1.20.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-          "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
-          }
-        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -44713,37 +44966,6 @@
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.2.2",
         "core-js-compat": "^3.14.0"
-      },
-      "dependencies": {
-        "@babel/helper-define-polyfill-provider": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz",
-          "integrity": "sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==",
-          "requires": {
-            "@babel/helper-compilation-targets": "^7.13.0",
-            "@babel/helper-module-imports": "^7.12.13",
-            "@babel/helper-plugin-utils": "^7.13.0",
-            "@babel/traverse": "^7.13.0",
-            "debug": "^4.1.1",
-            "lodash.debounce": "^4.0.8",
-            "resolve": "^1.14.2",
-            "semver": "^6.1.2"
-          }
-        },
-        "resolve": {
-          "version": "1.20.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-          "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
       }
     },
     "babel-plugin-polyfill-regenerator": {
@@ -44752,37 +44974,6 @@
       "integrity": "sha512-Goy5ghsc21HgPDFtzRkSirpZVW35meGoTmTOb2bxqdl60ghub4xOidgNTHaZfQ2FaxQsKmwvXtOAkcIS4SMBWg==",
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.2.2"
-      },
-      "dependencies": {
-        "@babel/helper-define-polyfill-provider": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz",
-          "integrity": "sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==",
-          "requires": {
-            "@babel/helper-compilation-targets": "^7.13.0",
-            "@babel/helper-module-imports": "^7.12.13",
-            "@babel/helper-plugin-utils": "^7.13.0",
-            "@babel/traverse": "^7.13.0",
-            "debug": "^4.1.1",
-            "lodash.debounce": "^4.0.8",
-            "resolve": "^1.14.2",
-            "semver": "^6.1.2"
-          }
-        },
-        "resolve": {
-          "version": "1.20.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-          "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
       }
     },
     "babel-plugin-syntax-object-rest-spread": {
@@ -47856,61 +48047,75 @@
       }
     },
     "decentraland-connect": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-2.18.0.tgz",
-      "integrity": "sha512-Wj1kNIy2xhb7RxzR0r+QN2+HWD26NntGuSBKh/xoR4/wSYMB3jxz/K3VarExJCAGuFeXjO2IdAha67y8Ikog0g==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-2.20.1.tgz",
+      "integrity": "sha512-Iou06ziOD3nwYghhTZpwb34JsVWSS7oAS490VG0V89usM3HZQmJ8LKHExZw4j8aCtMJ/aq6Ic5YAbNhP8kj2wQ==",
       "requires": {
-        "@dcl/schemas": ">=1.1.0",
         "@types/node": "^10.1.2",
+        "@walletconnect/web3-provider": "^1.6.5",
         "@web3-react/fortmatic-connector": "^6.1.6",
         "@web3-react/injected-connector": "^6.0.7",
         "@web3-react/network-connector": "^6.1.3",
         "@web3-react/types": "^6.0.7",
-        "@web3-react/walletconnect-connector": "^6.1.6"
+        "@web3-react/walletconnect-connector": "^7.0.2-alpha.0"
       }
     },
     "decentraland-dapps": {
-      "version": "12.17.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-12.17.0.tgz",
-      "integrity": "sha512-wSXSiGCsLg6ZhQZI8S1Cf0PBpa4qbuzhbLUIC3YI4NCoTKbHwXw+yt1IMAFW6YC3nQBZ3Al+4Vq21c3s4s+i5Q==",
+      "version": "12.25.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-12.25.0.tgz",
+      "integrity": "sha512-cY9lVWTARCyIOnPBsebvrSYeIEuxuWWP9nuuQN5WbEyZ9x4Kr945251nzhYO0DQLnetx4ILCg25+x9EhyUCemg==",
       "requires": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
-        "@dcl/schemas": ">=1.1.0",
         "@types/flat": "0.0.28",
-        "@types/node": "^10.1.2",
-        "@types/react": "^16.4.7",
-        "@types/react-intl": "^3.0.0",
-        "@types/react-redux": "^6.0.4",
-        "@types/redux-storage-engine-localstorage": "^1.1.0",
         "@types/segment-analytics": "0.0.28",
         "@types/uuid": "^3.4.3",
         "axios": "^0.21.1",
         "date-fns": "^1.29.0",
         "dcl-catalyst-client": "^4.0.6",
-        "decentraland-connect": "^2.18.0",
+        "decentraland-connect": "^2.20.1",
         "decentraland-transactions": "^1.22.2",
-        "decentraland-ui": "^3.6.0",
+        "decentraland-ui": "^3.10.0",
         "flat": "^4.1.0",
-        "react-intl": "^3.12.0",
+        "react-intl": "^5.20.7",
         "redux-persistence": "^1.2.0",
         "redux-persistence-engine-localstorage": "^1.0.0",
         "redux-storage-decorator-filter": "^1.1.8",
         "tslint": "^5.7.0",
         "tslint-config-prettier": "^1.10.0",
         "typesafe-actions": "^2.0.3",
-        "typescript": "^4.1.5",
-        "web3x-codegen": "^4.0.6",
-        "web3x-es": "^4.0.6"
+        "web3x": "^4.0.6",
+        "web3x-codegen": "^4.0.6"
       },
       "dependencies": {
-        "@types/react-redux": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-6.0.14.tgz",
-          "integrity": "sha512-bvpWqBOvz2V+EfZ9Qu1d3gFKYCIn/BYoGWAVt1c526tbiI9rtfaBbjutbbapmtEZaEfLuHj3Ljg9qho0SBSwUg==",
+        "@formatjs/intl": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-1.14.1.tgz",
+          "integrity": "sha512-mtL8oBgFwTu0GHFnxaF93fk/zNzNkPzl+27Fwg5AZ88pWHWb7037dpODzoCBnaIVk4FBO5emUn/6jI9Byj8hOw==",
           "requires": {
-            "@types/react": "*",
-            "redux": "^4.0.0"
+            "@formatjs/ecma402-abstract": "1.9.8",
+            "@formatjs/fast-memoize": "1.2.0",
+            "@formatjs/icu-messageformat-parser": "2.0.11",
+            "@formatjs/intl-displaynames": "5.2.3",
+            "@formatjs/intl-listformat": "6.3.3",
+            "intl-messageformat": "9.9.1",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@types/node": {
+          "version": "16.7.13",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.13.tgz",
+          "integrity": "sha512-pLUPDn+YG3FYEt/pHI74HmnJOWzeR+tOIQzUx93pi9M7D8OE7PSLr97HboXwk5F+JS+TLtWuzCOW97AHjmOXXA==",
+          "peer": true
+        },
+        "@types/react": {
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.20.tgz",
+          "integrity": "sha512-wWZrPlihslrPpcKyCSlmIlruakxr57/buQN1RjlIeaaTWDLtJkTtRW429MoQJergvVKc4IWBpRhWw7YNh/7GVA==",
+          "requires": {
+            "@types/prop-types": "*",
+            "@types/scheduler": "*",
+            "csstype": "^3.0.2"
           }
         },
         "acorn": {
@@ -47996,6 +48201,11 @@
             "shebang-command": "^2.0.0",
             "which": "^2.0.1"
           }
+        },
+        "csstype": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+          "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
         },
         "date-fns": {
           "version": "1.30.1",
@@ -48204,26 +48414,14 @@
             "resolve-from": "^4.0.0"
           }
         },
-        "intl-format-cache": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-4.3.1.tgz",
-          "integrity": "sha512-OEUYNA7D06agqPOYhbTkl0T8HA3QKSuwWh1HiClEnpd9vw7N+3XsQt5iZ0GUEchp5CW1fQk/tary+NsbF3yQ1Q=="
-        },
         "intl-messageformat": {
-          "version": "7.8.4",
-          "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-7.8.4.tgz",
-          "integrity": "sha512-yS0cLESCKCYjseCOGXuV4pxJm/buTfyCJ1nzQjryHmSehlptbZbn9fnlk1I9peLopZGGbjj46yHHiTAEZ1qOTA==",
+          "version": "9.9.1",
+          "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.9.1.tgz",
+          "integrity": "sha512-cuzS/XKHn//hvKka77JKU2dseiVY2dofQjIOZv6ZFxFt4Z9sPXnZ7KQ9Ak2r+4XBCjI04MqJ1PhKs/3X22AkfA==",
           "requires": {
-            "intl-format-cache": "^4.2.21",
-            "intl-messageformat-parser": "^3.6.4"
-          }
-        },
-        "intl-messageformat-parser": {
-          "version": "3.6.4",
-          "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-3.6.4.tgz",
-          "integrity": "sha512-RgPGwue0mJtoX2Ax8EmMzJzttxjnva7gx0Q7mKJ4oALrTZvtmCeAw5Msz2PcjW4dtCh/h7vN/8GJCxZO1uv+OA==",
-          "requires": {
-            "@formatjs/intl-unified-numberformat": "^3.2.0"
+            "@formatjs/fast-memoize": "1.2.0",
+            "@formatjs/icu-messageformat-parser": "2.0.11",
+            "tslib": "^2.1.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -48301,22 +48499,20 @@
           "integrity": "sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA=="
         },
         "react-intl": {
-          "version": "3.12.1",
-          "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-3.12.1.tgz",
-          "integrity": "sha512-cgumW29mwROIqyp8NXStYsoIm27+8FqnxykiLSawWjOxGIBeLuN/+p2srei5SRIumcJefOkOIHP+NDck05RgHg==",
+          "version": "5.20.10",
+          "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-5.20.10.tgz",
+          "integrity": "sha512-zy0ZQhpjkGsKcK1BFo2HbGM/q8GBVovzoXZGQ76DowR0yr6UzQuPLkrlIrObL2zxIYiDaxaz+hUJaoa2a1xqOQ==",
           "requires": {
-            "@formatjs/intl-displaynames": "^1.2.0",
-            "@formatjs/intl-listformat": "^1.4.1",
-            "@formatjs/intl-relativetimeformat": "^4.5.9",
-            "@formatjs/intl-unified-numberformat": "^3.2.0",
-            "@formatjs/intl-utils": "^2.2.0",
+            "@formatjs/ecma402-abstract": "1.9.8",
+            "@formatjs/icu-messageformat-parser": "2.0.11",
+            "@formatjs/intl": "1.14.1",
+            "@formatjs/intl-displaynames": "5.2.3",
+            "@formatjs/intl-listformat": "6.3.3",
             "@types/hoist-non-react-statics": "^3.3.1",
-            "@types/invariant": "^2.2.31",
+            "@types/react": "17",
             "hoist-non-react-statics": "^3.3.2",
-            "intl-format-cache": "^4.2.21",
-            "intl-messageformat": "^7.8.4",
-            "intl-messageformat-parser": "^3.6.4",
-            "shallow-equal": "^1.2.1"
+            "intl-messageformat": "9.9.1",
+            "tslib": "^2.1.0"
           }
         },
         "regexpp": {
@@ -48439,9 +48635,11 @@
           "integrity": "sha512-qjrFDl6S2yejKEz0M2c3c5D5z8sGJTjma94O9kRHStiqauXP9dKUM0Nbdmn90HCZBZl3jzFNT21bOtxRfCkc0w=="
         },
         "typescript": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
-          "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew=="
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+          "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
+          "optional": true,
+          "peer": true
         },
         "which": {
           "version": "2.0.2",
@@ -48556,16 +48754,14 @@
       "integrity": "sha512-E1d3SrhYQga6KAwO6XBvIc7kKpoq9lQR98Ms/VyNj5fOOT8rqJJas05mbsyn6eINP7smzt+ukI4j59ljEF1bdw=="
     },
     "decentraland-ui": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.9.0.tgz",
-      "integrity": "sha512-sqyiuxAxesCbFAd42iwwFxHLHOFun+XIUa0gZGrT56NY94lsdS7M2OmyEK82nvbK7tUG1L10a7oVcuC9/YSOqQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.10.0.tgz",
+      "integrity": "sha512-YY9RHGcJV9DI0Um7d5IWhC5iiVNYuScAozz9KmpH/cIpIr2ZemBKTl13zGJQcZUVooXqWNI0RBa7OC/l5ZM46g==",
       "requires": {
         "@dcl/schemas": "^0.2.0",
         "balloon-css": "^0.5.0",
         "ethereum-blockies": "^0.1.1",
         "parallax-js": "^3.1.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
         "react-responsive": "^9.0.0-beta.3",
         "react-tile-map": "^0.3.2",
         "semantic-ui-css": "^2.4.1",
@@ -49111,6 +49307,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "eip1193-provider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
+      "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
+      "requires": {
+        "@json-rpc-tools/provider": "^1.5.5"
+      }
     },
     "electron-to-chromium": {
       "version": "1.3.728",
@@ -49762,9 +49966,9 @@
           }
         },
         "@babel/runtime": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz",
-          "integrity": "sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -49924,9 +50128,9 @@
           }
         },
         "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
+          "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA=="
         }
       }
     },
@@ -49972,9 +50176,9 @@
           }
         },
         "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
+          "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA=="
         }
       }
     },
@@ -50025,7 +50229,7 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
-        "ethereumjs-abi": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git",
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
         "ethereumjs-util": "^5.1.1"
       },
       "dependencies": {
@@ -50100,7 +50304,7 @@
     },
     "ethereumjs-abi": {
       "version": "git+https://git@github.com/ethereumjs/ethereumjs-abi.git",
-      "from": "git+https://git@github.com/ethereumjs/ethereumjs-abi.git",
+      "from": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git",
       "requires": {
         "bn.js": "^4.11.8",
         "ethereumjs-util": "^6.0.0"
@@ -50853,9 +51057,9 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-safe-stringify": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
-      "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "fastparse": {
       "version": "1.1.2",
@@ -65731,6 +65935,11 @@
         "events": "^3.0.0"
       }
     },
+    "safe-json-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
+      "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
+    },
     "safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
@@ -67788,9 +67997,9 @@
       }
     },
     "tslib": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-      "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "tslint": {
       "version": "5.20.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "decentraland-ad": "^1.4.2",
     "decentraland-builder-scripts": "^0.24.0",
     "decentraland-commons": "^5.1.0",
-    "decentraland-dapps": "^12.17.0",
+    "decentraland-dapps": "^12.25.0",
     "decentraland-ecs": "^6.6.1-20201020183014.commit-bdc29ef",
     "decentraland-experiments": "^1.0.2",
     "decentraland-transactions": "^1.22.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "decentraland-ad": "^1.4.2",
     "decentraland-builder-scripts": "^0.24.0",
     "decentraland-commons": "^5.1.0",
-    "decentraland-dapps": "^12.25.0",
+    "decentraland-dapps": "^12.25.2",
     "decentraland-ecs": "^6.6.1-20201020183014.commit-bdc29ef",
     "decentraland-experiments": "^1.0.2",
     "decentraland-transactions": "^1.22.2",

--- a/src/components/AuthorizationModal/AuthorizationModal.tsx
+++ b/src/components/AuthorizationModal/AuthorizationModal.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react'
 import { Link } from 'react-router-dom'
 import { Modal, Button, Form, CheckboxProps, Radio, Loader, Popup } from 'decentraland-ui'
 import { getContractName } from 'decentraland-transactions'
-import { TransactionLink } from 'decentraland-dapps/dist/containers'
+import { ChainCheck, TransactionLink } from 'decentraland-dapps/dist/containers'
 import { t, T } from 'decentraland-dapps/dist/modules/translation/utils'
 import { hasAuthorization } from 'decentraland-dapps/dist/modules/authorization/utils'
 import { locations } from 'routing/locations'
@@ -51,7 +51,16 @@ const AuthorizationModal = (props: Props) => {
                 </Link>
               }
             />
-            <Radio checked={isAuthorized} label={tokenSymbol} onClick={handleAuthorizationChange} disabled={isLoading} />
+            <ChainCheck chainId={authorization.chainId}>
+              {isEnabled => (
+                <Radio
+                  checked={isAuthorized}
+                  label={tokenSymbol}
+                  onClick={handleAuthorizationChange}
+                  disabled={isLoading || !isEnabled}
+                />
+              )}
+            </ChainCheck>
             <div className="radio-description secondary-text">
               <T
                 id="authorization_modal.authorize"

--- a/src/components/ClaimENSPage/ClaimENSPage.tsx
+++ b/src/components/ClaimENSPage/ClaimENSPage.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react'
 import { Row, Column, Section, Narrow, InputOnChangeData, Header, Form, Field, Button, Mana, Radio, Popup } from 'decentraland-ui'
+import { Network } from '@dcl/schemas'
+import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
 import { T, t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { getTokenAmountToApprove } from 'decentraland-dapps/dist/modules/authorization/utils'
-import { TransactionLink } from 'decentraland-dapps/dist/containers'
+import { ChainButton, ChainCheck, TransactionLink } from 'decentraland-dapps/dist/containers'
 import Back from 'components/Back'
 import LoggedInDetailPage from 'components/LoggedInDetailPage'
 import { locations } from 'routing/locations'
@@ -142,8 +144,16 @@ export default class ClaimENSPage extends React.PureComponent<Props, State> {
                   />
                 </Section>
                 <Section className="field">
-                  <Header sub={true}>MANA Approved</Header>
-                  <Radio toggle disabled={isLoading} checked={isManaAllowed} onChange={this.handleManaApprove} />
+                  <Header sub={true}>{t('claim_ens_page.radio_label')}</Header>
+                  <ChainCheck chainId={getChainIdByNetwork(Network.ETHEREUM)}>
+                    {isEnabled => (
+                      <Radio
+                        toggle
+                        disabled={isLoading || !isEnabled}
+                        checked={isManaAllowed}
+                        onChange={this.handleManaApprove} />
+                    )}
+                  </ChainCheck>
                   <p className="message">
                     <T
                       id="claim_ens_page.need_mana_message"
@@ -170,9 +180,9 @@ export default class ClaimENSPage extends React.PureComponent<Props, State> {
                       position="top center"
                       trigger={
                         <div className="popup-button">
-                          <Button type="submit" primary disabled={isDisabled} loading={isLoading}>
+                          <ChainButton type="submit" primary disabled={isDisabled} loading={isLoading} chainId={getChainIdByNetwork(Network.ETHEREUM)}>
                             {t('claim_ens_page.claim_button')} <Mana inline>{PRICE.toLocaleString()}</Mana>
-                          </Button>
+                          </ChainButton>
                         </div>
                       }
                       hideOnScroll={true}
@@ -180,10 +190,10 @@ export default class ClaimENSPage extends React.PureComponent<Props, State> {
                       inverted
                     />
                   ) : (
-                    <Button type="submit" primary disabled={isDisabled} loading={isLoading}>
-                      {t('claim_ens_page.claim_button')} <Mana inline>{PRICE.toLocaleString()}</Mana>
-                    </Button>
-                  )}
+                      <Button type="submit" primary disabled={isDisabled} loading={isLoading}>
+                        {t('claim_ens_page.claim_button')} <Mana inline>{PRICE.toLocaleString()}</Mana>
+                      </Button>
+                    )}
                 </Row>
               </Form>
             </Column>

--- a/src/components/CollectionDetailPage/CollectionDetailPage.tsx
+++ b/src/components/CollectionDetailPage/CollectionDetailPage.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react'
 import { Link } from 'react-router-dom'
+import { Network } from '@dcl/schemas'
 import { env } from 'decentraland-commons'
 import { Section, Row, Narrow, Column, Header, Button, Icon, Popup, Radio, CheckboxProps } from 'decentraland-ui'
 import { ContractName, getContract } from 'decentraland-transactions'
+import { ChainButton, ChainCheck } from 'decentraland-dapps/dist/containers'
+import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
 import { t, T } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Authorization, AuthorizationType } from 'decentraland-dapps/dist/modules/authorization/types'
 import { hasAuthorization } from 'decentraland-dapps/dist/modules/authorization/utils'
@@ -138,19 +141,22 @@ export default class CollectionDetailPage extends React.PureComponent<Props, Sta
                               isOnSaleLoading
                                 ? t('global.loading')
                                 : isOnSale
-                                ? t('collection_detail_page.unset_on_sale_popup')
-                                : t('collection_detail_page.set_on_sale_popup')
+                                  ? t('collection_detail_page.unset_on_sale_popup')
+                                  : t('collection_detail_page.set_on_sale_popup')
                             }
                             position="top center"
                             trigger={
-                              <Radio
-                                toggle
-                                className="on-sale"
-                                checked={isOnSale}
-                                onChange={this.handleOnSaleChange}
-                                label={t('collection_detail_page.on_sale')}
-                                disabled={isOnSaleLoading}
-                              />
+                              <ChainCheck chainId={getChainIdByNetwork(Network.MATIC)}>{
+                                isEnabled =>
+                                  <Radio
+                                    toggle
+                                    className="on-sale"
+                                    checked={isOnSale}
+                                    onChange={this.handleOnSaleChange}
+                                    label={t('collection_detail_page.on_sale')}
+                                    disabled={isOnSaleLoading || !isEnabled}
+                                  />
+                              }</ChainCheck>
                             }
                             hideOnScroll={true}
                             on="hover"
@@ -165,11 +171,11 @@ export default class CollectionDetailPage extends React.PureComponent<Props, Sta
                         </Button>
                       </>
                     ) : (
-                      <Button basic className="action-button" onClick={this.handleNewItem}>
-                        <Icon name="plus" />
-                        <span className="text">{t('collection_detail_page.new_item')}</span>
-                      </Button>
-                    )}
+                        <Button basic className="action-button" onClick={this.handleNewItem}>
+                          <Icon name="plus" />
+                          <span className="text">{t('collection_detail_page.new_item')}</span>
+                        </Button>
+                      )}
 
                     {canSeeCollection(collection, wallet.address) ? <CollectionMenu collection={collection} /> : null}
 
@@ -179,27 +185,27 @@ export default class CollectionDetailPage extends React.PureComponent<Props, Sta
                           {t('global.published')}
                         </Button>
                       ) : (
-                        <Popup
-                          content={t('collection_detail_page.cant_mint')}
-                          position="top center"
-                          trigger={
-                            <div className="popup-button">
-                              <Button secondary compact disabled={true}>
-                                {t('collection_detail_page.under_review')}
-                              </Button>
-                            </div>
-                          }
-                          hideOnScroll={true}
-                          on="hover"
-                          inverted
-                          flowing
-                        />
-                      )
+                          <Popup
+                            content={t('collection_detail_page.cant_mint')}
+                            position="top center"
+                            trigger={
+                              <div className="popup-button">
+                                <Button secondary compact disabled={true}>
+                                  {t('collection_detail_page.under_review')}
+                                </Button>
+                              </div>
+                            }
+                            hideOnScroll={true}
+                            on="hover"
+                            inverted
+                            flowing
+                          />
+                        )
                     ) : (
-                      <Button disabled={!this.canPublish()} primary compact onClick={this.handlePublish}>
-                        {t('collection_detail_page.publish')}
-                      </Button>
-                    )}
+                        <ChainButton disabled={!this.canPublish()} primary compact onClick={this.handlePublish} chainId={getChainIdByNetwork(Network.MATIC)}>
+                          {t('collection_detail_page.publish')}
+                        </ChainButton>
+                      )}
                   </Row>
                 </Column>
               </Row>
@@ -223,15 +229,15 @@ export default class CollectionDetailPage extends React.PureComponent<Props, Sta
               ))}
             </div>
           ) : (
-            <div className="empty">
-              <div className="sparkles" />
-              <div>
-                {t('collection_detail_page.start_adding_items')}
-                <br />
-                {t('collection_detail_page.cant_remove')}
+              <div className="empty">
+                <div className="sparkles" />
+                <div>
+                  {t('collection_detail_page.start_adding_items')}
+                  <br />
+                  {t('collection_detail_page.cant_remove')}
+                </div>
               </div>
-            </div>
-          )}
+            )}
         </Narrow>
         {this.renderAuthorizationModal()}
       </>

--- a/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
@@ -2,6 +2,9 @@ import * as React from 'react'
 import equal from 'fast-deep-equal'
 import { utils } from 'decentraland-commons'
 import { Popup, Loader, Dropdown, Button } from 'decentraland-ui'
+import { Network } from '@dcl/schemas'
+import { ChainButton } from 'decentraland-dapps/dist/containers'
+import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import ItemImage from 'components/ItemImage'
 import ItemProvider from 'components/ItemProvider'
@@ -320,8 +323,8 @@ export default class RightPanel extends React.PureComponent<Props, State> {
                             </div>
                           </>
                         ) : (
-                          <ItemImage item={item} src={thumbnail} hasBadge={true} badgeSize="small" />
-                        )}
+                            <ItemImage item={item} src={thumbnail} hasBadge={true} badgeSize="small" />
+                          )}
                         <div className="metrics">
                           <div className="metric triangles">{t('model_metrics.triangles', { count: item.metrics.triangles })}</div>
                           <div className="metric materials">{t('model_metrics.materials', { count: item.metrics.materials })}</div>
@@ -414,9 +417,9 @@ export default class RightPanel extends React.PureComponent<Props, State> {
                       <Button secondary onClick={this.handleOnResetItem}>
                         {t('global.cancel')}
                       </Button>
-                      <Button primary onClick={this.handleOnSaveItem}>
+                      <ChainButton primary onClick={this.handleOnSaveItem} chainId={getChainIdByNetwork(Network.MATIC)}>
                         {t('global.save')}
-                      </Button>
+                      </ChainButton>
                     </div>
                   ) : error && selectedItemId ? (
                     <p className="danger-text">

--- a/src/components/LandAssignENSPage/LandAssignENSForm/LandAssignENSForm.tsx
+++ b/src/components/LandAssignENSPage/LandAssignENSForm/LandAssignENSForm.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react'
 import { Form, Row, Button, Icon } from 'decentraland-ui'
+import { Network } from '@dcl/schemas'
+import { ChainButton } from 'decentraland-dapps/dist/containers'
+import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { locations } from 'routing/locations'
 import { isResolverEmpty, isContentEmpty, isEqualContent } from 'modules/ens/utils'
@@ -54,13 +57,14 @@ export default class LandAssignENSForm extends React.PureComponent<Props> {
             <h3>{t('land_assign_ens_page.set_resolver')}</h3>
             <div className="message-box">
               <p>{t('land_assign_ens_page.set_resolver_explanation')}</p>
-              <Button
+              <ChainButton
                 type="submit"
                 disabled={isSetResolverButtonDisabled}
                 onClick={this.handleSetResolver}
                 className={setResolverButtonClassName}
                 loading={isWaitingTxSetResolver}
                 primary
+                chainId={getChainIdByNetwork(Network.ETHEREUM)}
               >
                 {hasResolverError ? (
                   t('global.retry_tx')
@@ -70,9 +74,9 @@ export default class LandAssignENSForm extends React.PureComponent<Props> {
                     {!isWaitingTxSetResolver ? <Icon name="check" /> : null}
                   </>
                 ) : (
-                  t('global.submit')
-                )}
-              </Button>
+                      t('global.submit')
+                    )}
+              </ChainButton>
             </div>
           </div>
         </Row>
@@ -81,13 +85,14 @@ export default class LandAssignENSForm extends React.PureComponent<Props> {
             <h3>{t('land_assign_ens_page.set_content')}</h3>
             <div className="message-box">
               <p>{t('land_assign_ens_page.set_content_explanation')}</p>
-              <Button
+              <ChainButton
                 type="submit"
                 disabled={isSetContentButtonDisabled}
                 onClick={this.handleSetContent}
                 className={setContentButtonClassName}
                 loading={isWaitingTxSetContent}
                 primary
+                chainId={getChainIdByNetwork(Network.ETHEREUM)}
               >
                 {hasContentError ? (
                   t('global.retry_tx')
@@ -97,9 +102,9 @@ export default class LandAssignENSForm extends React.PureComponent<Props> {
                     {!isWaitingTxSetContent ? <Icon name="check" /> : null}
                   </>
                 ) : (
-                  t('global.submit')
-                )}
-              </Button>
+                      t('global.submit')
+                    )}
+              </ChainButton>
             </div>
           </div>
         </Row>

--- a/src/components/Modals/CollectionManagersModal/CollectionManagersModal.tsx
+++ b/src/components/Modals/CollectionManagersModal/CollectionManagersModal.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react'
-import { ModalNavigation, ModalActions, Button } from 'decentraland-ui'
+import { ModalNavigation, ModalActions } from 'decentraland-ui'
+import { Network } from '@dcl/schemas'
+import { ChainButton } from 'decentraland-dapps/dist/containers'
+import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import Modal from 'decentraland-dapps/dist/containers/Modal'
 
@@ -98,12 +101,12 @@ export default class CollectionManagersModal extends React.PureComponent<Props, 
                     manager ? (
                       <Manager key={index} manager={manager} onRemove={this.handleRemoveManager} />
                     ) : (
-                      <EmptyManager
-                        key={index}
-                        onAdd={(manager: string) => this.handleAddManager(index, manager)}
-                        onCancel={() => this.handleCancelNew(index)}
-                      />
-                    )
+                        <EmptyManager
+                          key={index}
+                          onAdd={(manager: string) => this.handleAddManager(index, manager)}
+                          onCancel={() => this.handleCancelNew(index)}
+                        />
+                      )
                   )}
                 </div>
                 <div className="add-managers link" onClick={this.handleAddNewManager}>
@@ -111,19 +114,19 @@ export default class CollectionManagersModal extends React.PureComponent<Props, 
                 </div>
               </>
             ) : (
-              <div className="empty-managers-list">
-                {t('collection_managers_modal.no_managers')}&nbsp;
-                <span className="link" onClick={this.handleAddNewManager}>
-                  {t('collection_managers_modal.adding_one')}
-                </span>
-              </div>
-            )}
+                <div className="empty-managers-list">
+                  {t('collection_managers_modal.no_managers')}&nbsp;
+                  <span className="link" onClick={this.handleAddNewManager}>
+                    {t('collection_managers_modal.adding_one')}
+                  </span>
+                </div>
+              )}
           </div>
           {managers.length ? (
             <ModalActions>
-              <Button primary onClick={this.handleSubmit} loading={isLoading} disabled={this.isDisabled()}>
+              <ChainButton primary onClick={this.handleSubmit} loading={isLoading} disabled={this.isDisabled()} chainId={getChainIdByNetwork(Network.MATIC)}>
                 {t('global.add')}
-              </Button>
+              </ChainButton>
             </ModalActions>
           ) : null}
         </Modal.Content>

--- a/src/components/Modals/EditPriceAndBeneficiaryModal/EditPriceAndBeneficiaryModal.tsx
+++ b/src/components/Modals/EditPriceAndBeneficiaryModal/EditPriceAndBeneficiaryModal.tsx
@@ -3,6 +3,8 @@ import { Address } from 'web3x-es/address'
 import { fromWei, toWei } from 'web3x-es/utils'
 import { Network } from '@dcl/schemas'
 import { ModalNavigation, ModalContent, ModalActions, Form, Field, Button, InputOnChangeData, FieldProps, Mana } from 'decentraland-ui'
+import { ChainButton } from 'decentraland-dapps/dist/containers'
+import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
 import Modal from 'decentraland-dapps/dist/containers/Modal'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 
@@ -150,9 +152,9 @@ export default class EditPriceAndBeneficiaryModal extends React.PureComponent<Pr
             />
           </ModalContent>
           <ModalActions>
-            <Button primary disabled={this.isDisabled()} loading={isLoading}>
+            <ChainButton primary disabled={this.isDisabled()} loading={isLoading} chainId={getChainIdByNetwork(Network.MATIC)}>
               {t('global.submit')}
-            </Button>
+            </ChainButton>
           </ModalActions>
         </Form>
       </Modal>

--- a/src/components/Modals/ManageCollectionRoleModal/ManageCollectionRoleModal.tsx
+++ b/src/components/Modals/ManageCollectionRoleModal/ManageCollectionRoleModal.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react'
-import { ModalNavigation, ModalActions, Button } from 'decentraland-ui'
+import { ModalNavigation, ModalActions } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import Modal from 'decentraland-dapps/dist/containers/Modal'
+import { ChainButton } from 'decentraland-dapps/dist/containers'
+import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
+import { Network } from '@dcl/schemas'
 import equal from 'fast-deep-equal'
 
 import { isValid } from 'lib/address'
@@ -126,12 +129,12 @@ export default class ManageCollectionRoleModal extends React.PureComponent<Props
                     role ? (
                       <Role key={index} address={role} onRemove={this.handleRemoveRole} />
                     ) : (
-                      <EmptyRole
-                        key={index}
-                        onAdd={(role: string) => this.handleAddRole(index, role)}
-                        onCancel={() => this.handleCancelNew(index)}
-                      />
-                    )
+                        <EmptyRole
+                          key={index}
+                          onAdd={(role: string) => this.handleAddRole(index, role)}
+                          onCancel={() => this.handleCancelNew(index)}
+                        />
+                      )
                   )}
                 </div>
                 <div className="add-roles link" onClick={this.handleAddNewRole}>
@@ -139,18 +142,24 @@ export default class ManageCollectionRoleModal extends React.PureComponent<Props
                 </div>
               </>
             ) : (
-              <div className="empty-roles-list">
-                {t(`manage_collection_role_modal.${type}.empty`)}&nbsp;
-                <span className="link" onClick={this.handleAddNewRole}>
-                  {t(`manage_collection_role_modal.adding_one`)}
-                </span>
-              </div>
-            )}
+                <div className="empty-roles-list">
+                  {t(`manage_collection_role_modal.${type}.empty`)}&nbsp;
+                  <span className="link" onClick={this.handleAddNewRole}>
+                    {t(`manage_collection_role_modal.adding_one`)}
+                  </span>
+                </div>
+              )}
           </div>
           <ModalActions>
-            <Button primary onClick={this.handleSubmit} loading={isLoading} disabled={!this.hasRoleChanged()}>
+            <ChainButton
+              primary
+              onClick={this.handleSubmit}
+              loading={isLoading}
+              disabled={!this.hasRoleChanged()}
+              chainId={getChainIdByNetwork(Network.MATIC)}
+            >
               {t('global.confirm')}
-            </Button>
+            </ChainButton>
           </ModalActions>
         </Modal.Content>
       </Modal>

--- a/src/components/Modals/MintItemsModal/MintItemsModal.tsx
+++ b/src/components/Modals/MintItemsModal/MintItemsModal.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react'
 import { ModalNavigation, ModalActions, Form, Button, Row } from 'decentraland-ui'
+import { Network } from '@dcl/schemas'
+import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
+import { ChainButton } from 'decentraland-dapps/dist/containers'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import Modal from 'decentraland-dapps/dist/containers/Modal'
 
@@ -55,10 +58,10 @@ export default class MintItemsModal extends React.PureComponent<Props, State> {
     }
 
     if (total > MAX_NFTS_PER_MINT) {
-      this.setState({error: t('mint_items_modal.limit_reached', { max: MAX_NFTS_PER_MINT })})
+      this.setState({ error: t('mint_items_modal.limit_reached', { max: MAX_NFTS_PER_MINT }) })
       return
     } else {
-      this.setState({error: null})
+      this.setState({ error: null })
     }
 
     if (mints.length > 0) {
@@ -108,8 +111,8 @@ export default class MintItemsModal extends React.PureComponent<Props, State> {
             {isEmpty ? (
               <div className="empty">{t('mint_items_modal.no_items', { name: collection.name })}</div>
             ) : (
-              items.map(item => <MintableItem key={item.id} item={item} mints={itemMints[item.id]} onChange={this.handleMintsChange} />)
-            )}
+                items.map(item => <MintableItem key={item.id} item={item} mints={itemMints[item.id]} onChange={this.handleMintsChange} />)
+              )}
             {isFull ? null : (
               <ItemDropdown placeholder={t('mint_items_modal.add_item')} onChange={this.handleAddItems} filter={this.filterAddableItems} />
             )}
@@ -119,13 +122,13 @@ export default class MintItemsModal extends React.PureComponent<Props, State> {
                   {t('global.cancel')}
                 </Button>
               ) : (
-                <Button primary onClick={this.handleMintItems} loading={isLoading} disabled={isDisabled || !!error}>
-                  {t('global.mint')}
-                </Button>
-              )}
+                  <ChainButton primary onClick={this.handleMintItems} loading={isLoading} disabled={isDisabled || !!error} chainId={getChainIdByNetwork(Network.MATIC)}>
+                    {t('global.mint')}
+                  </ChainButton>
+                )}
             </ModalActions>
             {error ? <Row className="error" align="right">
-                <p className="danger-text">{error}</p>
+              <p className="danger-text">{error}</p>
             </Row> : null}
           </Form>
         </Modal.Content>

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -74,7 +74,7 @@ class Preview extends React.Component<Props & CollectedProps, State> {
     }
     try {
       isDCLInitialized = true
-      ;(window as any).devicePixelRatio = 1 // without this unity blows up majestically 💥🌈🦄🔥🤷🏼‍♂️
+        ; (window as any).devicePixelRatio = 1 // without this unity blows up majestically 💥🌈🦄🔥🤷🏼‍♂️
       await editorWindow.editor.initEngine(this.canvasContainer.current, '/unity/Build/unity.json')
       if (!unityDebugParams) {
         canvas = await editorWindow.editor.getDCLCanvas()

--- a/src/modules/collection/sagas.ts
+++ b/src/modules/collection/sagas.ts
@@ -1,5 +1,4 @@
-import { Address } from 'web3x-es/address'
-import { Contract, constants, providers } from 'ethers'
+import { Contract, providers } from 'ethers'
 import { replace } from 'connected-react-router'
 import { select, take, takeEvery, call, put, takeLatest, race, retry } from 'redux-saga/effects'
 import { ContractName, getContract } from 'decentraland-transactions'
@@ -239,13 +238,13 @@ function* handleSetCollectionMintersRequest(action: SetCollectionMintersRequestA
   try {
     const maticChainId = getChainIdByNetwork(Network.MATIC)
 
-    const addresses: Address[] = []
+    const addresses: string[] = []
     const values: boolean[] = []
 
     const newMinters = new Set(collection.minters)
 
     for (const { address, hasAccess } of accessList) {
-      addresses.push(Address.fromString(address))
+      addresses.push(address)
       values.push(hasAccess)
 
       if (hasAccess) {
@@ -270,13 +269,13 @@ function* handleSetCollectionManagersRequest(action: SetCollectionManagersReques
   try {
     const maticChainId = getChainIdByNetwork(Network.MATIC)
 
-    const addresses: Address[] = []
+    const addresses: string[] = []
     const values: boolean[] = []
 
     const newManagers = new Set(collection.managers)
 
     for (const { address, hasAccess } of accessList) {
-      addresses.push(Address.fromString(address))
+      addresses.push(address)
       values.push(hasAccess)
 
       if (hasAccess) {
@@ -301,11 +300,11 @@ function* handleMintCollectionItemsRequest(action: MintCollectionItemsRequestAct
   try {
     const maticChainId = getChainIdByNetwork(Network.MATIC)
 
-    const beneficiaries: Address[] = []
+    const beneficiaries: string[] = []
     const tokenIds: string[] = []
 
     for (const mint of mints) {
-      const beneficiary = Address.fromString(mint.address)
+      const beneficiary = mint.address
       for (let i = 0; i < mint.amount; i++) {
         beneficiaries.push(beneficiary)
         tokenIds.push(mint.item.tokenId!)
@@ -460,12 +459,7 @@ function* changeCollectionStatus(collection: Collection, isApproved: boolean) {
   const data: string = yield getMethodData(implementation.populateTransaction.setApproved(isApproved))
 
   const txHash: string = yield call(sendTransaction, contract, committee =>
-    committee.manageCollection(
-      Address.fromString(manager.address),
-      Address.fromString(forwarder.address),
-      Address.fromString(collection.contractAddress!),
-      data
-    )
+    committee.manageCollection(manager.address, forwarder.address, collection.contractAddress!, data)
   )
   return txHash
 }

--- a/src/modules/collection/types.ts
+++ b/src/modules/collection/types.ts
@@ -1,9 +1,7 @@
-import BN from 'bn.js'
-import { Address } from 'web3x-es/address'
 import { Item } from 'modules/item/types'
 
 export type Collection = {
-  id: string // uuid
+  id: string
   name: string
   owner: string
   contractAddress?: string
@@ -23,12 +21,7 @@ export enum RoleType {
   MINTER = 'minter'
 }
 
-export type InitializeItem = {
-  rarity: string
-  price: BN
-  beneficiary: Address
-  metadata: string
-}
+export type InitializeItem = [string, string, string, string]
 
 export type Mint = {
   address: string

--- a/src/modules/collection/utils.ts
+++ b/src/modules/collection/utils.ts
@@ -1,5 +1,4 @@
-import { Address } from 'web3x-es/address'
-import { toBN } from 'web3x-es/utils'
+import { constants } from 'ethers'
 import { env, utils } from 'decentraland-commons'
 import { ChainId, getURNProtocol } from '@dcl/schemas'
 import { ContractName, getContract } from 'decentraland-transactions'
@@ -58,12 +57,7 @@ export function toInitializeItems(items: Item[]): InitializeItem[] {
 }
 
 export function toInitializeItem(item: Item): InitializeItem {
-  return {
-    metadata: getMetadata(item),
-    rarity: item.rarity!.toLowerCase(),
-    price: toBN(item.price || 0),
-    beneficiary: item.beneficiary ? Address.fromString(item.beneficiary) : Address.ZERO
-  }
+  return [item.rarity!.toLowerCase(), item.price || '0', item.beneficiary ? item.beneficiary : constants.AddressZero, getMetadata(item)]
 }
 
 export function toCollectionObject(collections: Collection[]) {

--- a/src/modules/common/sagas.ts
+++ b/src/modules/common/sagas.ts
@@ -1,9 +1,9 @@
 import { all } from 'redux-saga/effects'
 
-import { createAuthorizationSaga } from 'decentraland-dapps/dist/modules/authorization/sagas'
 import { createProfileSaga } from 'decentraland-dapps/dist/modules/profile/sagas'
 import { transactionSaga } from 'decentraland-dapps/dist/modules/transaction/sagas'
 
+import { authorizationSaga } from 'decentraland-dapps/dist/modules/authorization/sagas'
 import { analyticsSaga } from 'modules/analytics/sagas'
 import { assetPackSaga } from 'modules/assetPack/sagas'
 import { assetSaga } from 'modules/asset/sagas'
@@ -33,10 +33,8 @@ import { uiSaga } from 'modules/ui/sagas'
 import { walletSaga } from 'modules/wallet/sagas'
 
 import { PEER_URL } from 'lib/api/peer'
-import { TRANSACTIONS_API_URL } from 'modules/wallet/utils'
 
 const profileSaga = createProfileSaga({ peerUrl: PEER_URL })
-const authorizationSaga = createAuthorizationSaga({ metaTransactionServerUrl: TRANSACTIONS_API_URL })
 
 export function* rootSaga() {
   yield all([

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -1,15 +1,14 @@
-import { Eth } from 'web3x-es/eth'
 import { Address } from 'web3x-es/address'
 import { replace } from 'connected-react-router'
 import { takeEvery, call, put, takeLatest, select, take, delay } from 'redux-saga/effects'
-import { ChainId } from '@dcl/schemas'
+import { ChainId, Network } from '@dcl/schemas'
 import { AuthIdentity } from 'dcl-crypto'
 import { ContractName, getContract } from 'decentraland-transactions'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { FetchTransactionSuccessAction, FETCH_TRANSACTION_SUCCESS } from 'decentraland-dapps/dist/modules/transaction/actions'
 import { closeModal } from 'decentraland-dapps/dist/modules/modal/actions'
 import { getChainId } from 'decentraland-dapps/dist/modules/wallet/selectors'
-import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
+import { sendTransaction } from 'decentraland-dapps/dist/modules/wallet/utils'
 import {
   FetchItemsRequestAction,
   fetchItemsRequest,
@@ -58,9 +57,7 @@ import {
   DeployItemContentsFailureAction
 } from './actions'
 import { FetchCollectionRequestAction, FETCH_COLLECTION_REQUEST } from 'modules/collection/actions'
-import { getWallet, sendWalletMetaTransaction } from 'modules/wallet/utils'
 import { getIdentity } from 'modules/identity/utils'
-import { ERC721CollectionV2 } from 'contracts/ERC721CollectionV2'
 import { locations } from 'routing/locations'
 import { builder } from 'lib/api/builder'
 import { getCollection, getCollectionItems } from 'modules/collection/selectors'
@@ -72,6 +69,7 @@ import { Item } from './types'
 import { getItem } from './selectors'
 import { ItemTooBigError } from './errors'
 import { hasOnChainDataChanged, getMetadata, isValidText, isItemSizeError, MAX_FILE_SIZE } from './utils'
+import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
 
 export function* itemSaga() {
   yield takeEvery(FETCH_ITEMS_REQUEST, handleFetchItemsRequest)
@@ -169,21 +167,17 @@ function* handleSavePublishedItemRequest(action: SavePublishedItemRequestAction)
       throw new ItemTooBigError()
     }
 
-    const [wallet, eth]: [Wallet, Eth] = yield getWallet()
-    const maticChainId = wallet.networks.MATIC.chainId
     let txHash: string | undefined
+    const maticChainId = getChainIdByNetwork(Network.MATIC)
 
     // Items should be uploaded to the builder server in order to be available to be added to the catalysts
     yield call(() => builder.saveItemContents(item, contents))
 
     if (hasOnChainDataChanged(originalItem, item)) {
       const metadata = getMetadata(item)
-      const implementation = new ERC721CollectionV2(eth, Address.fromString(collection.contractAddress!))
-
       const contract = { ...getContract(ContractName.ERC721CollectionV2, maticChainId), address: collection.contractAddress! }
-      txHash = yield sendWalletMetaTransaction(
-        contract,
-        implementation.methods.editItemsData([item.tokenId!], [item.price!], [Address.fromString(item.beneficiary!)], [metadata])
+      txHash = yield call(sendTransaction, contract, collection =>
+        collection.editItemsData([item.tokenId!], [item.price!], [Address.fromString(item.beneficiary!)], [metadata])
       )
     } else {
       yield put(deployItemContentsRequest(collection, item))

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -1,4 +1,3 @@
-import { Address } from 'web3x-es/address'
 import { replace } from 'connected-react-router'
 import { takeEvery, call, put, takeLatest, select, take, delay } from 'redux-saga/effects'
 import { ChainId, Network } from '@dcl/schemas'
@@ -177,7 +176,7 @@ function* handleSavePublishedItemRequest(action: SavePublishedItemRequestAction)
       const metadata = getMetadata(item)
       const contract = { ...getContract(ContractName.ERC721CollectionV2, maticChainId), address: collection.contractAddress! }
       txHash = yield call(sendTransaction, contract, collection =>
-        collection.editItemsData([item.tokenId!], [item.price!], [Address.fromString(item.beneficiary!)], [metadata])
+        collection.editItemsData([item.tokenId!], [item.price!], [item.beneficiary!], [metadata])
       )
     } else {
       yield put(deployItemContentsRequest(collection, item))

--- a/src/modules/toast/sagas.ts
+++ b/src/modules/toast/sagas.ts
@@ -45,5 +45,5 @@ function* handleDeployItemFailure(action: DeployItemContentsFailureAction) {
 }
 
 function isUserDeniedSignature(message: string = '') {
-  return message.indexOf('User denied message signature') !== -1
+  return message.indexOf('User denied') !== -1
 }

--- a/src/modules/wallet/sagas.ts
+++ b/src/modules/wallet/sagas.ts
@@ -13,10 +13,12 @@ import {
 } from 'decentraland-dapps/dist/modules/wallet/actions'
 import { fetchAuthorizationsRequest } from 'decentraland-dapps/dist/modules/authorization/actions'
 import { Authorization, AuthorizationType } from 'decentraland-dapps/dist/modules/authorization/types'
+import { TRANSACTIONS_API_URL } from './utils'
 
 const baseWalletSaga = createWalletSaga({
   CHAIN_ID: env.get('REACT_APP_CHAIN_ID') || ChainId.ETHEREUM_MAINNET,
-  POLL_INTERVAL: 0
+  POLL_INTERVAL: 0,
+  TRANSACTIONS_API_URL
 })
 
 export function* walletSaga() {

--- a/src/modules/wallet/utils.ts
+++ b/src/modules/wallet/utils.ts
@@ -1,11 +1,9 @@
 import { call, select } from 'redux-saga/effects'
-import { Address } from 'web3x-es/address'
+import { PopulatedTransaction } from 'ethers'
 import { Eth } from 'web3x-es/eth'
-import { TxSend } from 'web3x-es/contract'
 import { LegacyProviderAdapter } from 'web3x-es/providers'
 import { env } from 'decentraland-commons'
-import { ContractData, sendMetaTransaction } from 'decentraland-transactions'
-import { getNetworkProvider, getConnectedProvider } from 'decentraland-dapps/dist/lib/eth'
+import { getConnectedProvider } from 'decentraland-dapps/dist/lib/eth'
 import { Wallet, Provider } from 'decentraland-dapps/dist/modules/wallet/types'
 import { getData as getBaseWallet } from 'decentraland-dapps/dist/modules/wallet/selectors'
 
@@ -31,21 +29,10 @@ export function* getWallet() {
   return [wallet, eth]
 }
 
-export function* sendWalletMetaTransaction(contract: ContractData, method: TxSend<any>) {
-  const [wallet, eth]: [Wallet, Eth] = yield call(getWallet)
-  const from = Address.fromString(wallet.address)
-  const provider = eth.provider
-
-  const metaTxProvider: Provider = yield call(() => getNetworkProvider(contract.chainId))
-  const txData = getMethodData(method, from)
-
-  const txHash: string = yield call(() =>
-    sendMetaTransaction(provider, metaTxProvider, txData, contract, { serverURL: TRANSACTIONS_API_URL })
-  )
-  return txHash
-}
-
-export function getMethodData(method: TxSend<any>, from: Address): string {
-  const payload = method.getSendRequestPayload({ from })
-  return payload.params[0].data
+export function* getMethodData(populatedTransactionPromise: Promise<PopulatedTransaction>) {
+  const data: string = yield call(async () => {
+    const populatedTransaction = await populatedTransactionPromise
+    return populatedTransaction.data!
+  })
+  return data
 }


### PR DESCRIPTION
This PR adds native support for Polygon transactions, you can perform the following actions while connected to Polygon (you will need MATIC to pay for gas):

+ Approve MANA to publish a collection
+ Publish a collection
+ Edit price/beneficiary of a published item
+ Edit category of a published non-approved item
+ Toggle collection on sale
+ Accept or Reject a collection (only for committee members)
+ Add/Edit minters
+ Add/Edit collaborators
+ Mint items

It blocks the following actions while you are connected to Polygon:

+ Approve MANA to claim name
+ Claim name
+ Set ENS resolver
+ Set ENS content

<img width="1015" alt="Screen Shot 2021-09-10 at 4 10 40 PM" src="https://user-images.githubusercontent.com/2781777/132908761-942d34ec-a2a4-4426-82d4-b22d0dffe632.png">

<img width="1025" alt="Screen Shot 2021-09-10 at 4 09 40 PM" src="https://user-images.githubusercontent.com/2781777/132908776-f475fb0a-9f8e-4ea6-8d4b-05fdc279522c.png">

