### PR TITLE
fix: Mint message showing an incorrect amount of minted items

### DIFF
--- a/src/components/ActivityPage/Transaction/Transaction.tsx
+++ b/src/components/ActivityPage/Transaction/Transaction.tsx
@@ -29,7 +29,7 @@ import {
   REJECT_COLLECTION_SUCCESS
 } from 'modules/collection/actions'
 import { SET_ENS_RESOLVER_SUCCESS, SET_ENS_CONTENT_SUCCESS, ALLOW_CLAIM_MANA_SUCCESS, CLAIM_NAME_SUCCESS } from 'modules/ens/actions'
-import { getSaleAddress } from 'modules/collection/utils'
+import { getSaleAddress, getTotalAmountOfMintedItems } from 'modules/collection/utils'
 import { isEnoughClaimMana } from 'modules/ens/utils'
 import { includes } from 'lib/address'
 import { difference } from 'lib/array'
@@ -245,8 +245,7 @@ const Transaction = (props: Props) => {
               values={{
                 collectionName: <Link to={locations.collectionDetail(collection.id)}>{collection.name}</Link>,
                 itemName: <Link to={locations.itemDetail(item.id)}>{item.name}</Link>,
-                amount: mints[0].amount,
-                count: mints.length
+                count: getTotalAmountOfMintedItems(mints)
               }}
             />
           }

--- a/src/components/Modals/MintItemsModal/MintItemsModal.tsx
+++ b/src/components/Modals/MintItemsModal/MintItemsModal.tsx
@@ -14,7 +14,6 @@ import { Props, State, ItemMints } from './MintItemsModal.types'
 import MintableItem from './MintableItem'
 import './MintItemsModal.css'
 
-
 export default class MintItemsModal extends React.PureComponent<Props, State> {
   state: State = this.getInitialState()
 
@@ -90,7 +89,16 @@ export default class MintItemsModal extends React.PureComponent<Props, State> {
 
   filterAddableItems = (item: Item) => {
     const { collection, items, ethAddress } = this.props
-    return item.collectionId === collection.id && !items.some(_item => _item.id === item.id && canMintItem(collection, item, ethAddress))
+    const { items: selectedItems } = this.state
+
+    const itemBelongsToCollection = item.collectionId === collection.id
+    const itemIsNotAlreadySelected = !selectedItems.some(_item => _item.id === item.id)
+
+    return (
+      itemBelongsToCollection &&
+      !items.some(_item => _item.id === item.id && canMintItem(collection, item, ethAddress)) &&
+      itemIsNotAlreadySelected
+    )
   }
 
   render() {
@@ -111,8 +119,8 @@ export default class MintItemsModal extends React.PureComponent<Props, State> {
             {isEmpty ? (
               <div className="empty">{t('mint_items_modal.no_items', { name: collection.name })}</div>
             ) : (
-                items.map(item => <MintableItem key={item.id} item={item} mints={itemMints[item.id]} onChange={this.handleMintsChange} />)
-              )}
+              items.map(item => <MintableItem key={item.id} item={item} mints={itemMints[item.id]} onChange={this.handleMintsChange} />)
+            )}
             {isFull ? null : (
               <ItemDropdown placeholder={t('mint_items_modal.add_item')} onChange={this.handleAddItems} filter={this.filterAddableItems} />
             )}
@@ -122,14 +130,22 @@ export default class MintItemsModal extends React.PureComponent<Props, State> {
                   {t('global.cancel')}
                 </Button>
               ) : (
-                  <ChainButton primary onClick={this.handleMintItems} loading={isLoading} disabled={isDisabled || !!error} chainId={getChainIdByNetwork(Network.MATIC)}>
-                    {t('global.mint')}
-                  </ChainButton>
-                )}
+                <ChainButton
+                  primary
+                  onClick={this.handleMintItems}
+                  loading={isLoading}
+                  disabled={isDisabled || !!error}
+                  chainId={getChainIdByNetwork(Network.MATIC)}
+                >
+                  {t('global.mint')}
+                </ChainButton>
+              )}
             </ModalActions>
-            {error ? <Row className="error" align="right">
-              <p className="danger-text">{error}</p>
-            </Row> : null}
+            {error ? (
+              <Row className="error" align="right">
+                <p className="danger-text">{error}</p>
+              </Row>
+            ) : null}
           </Form>
         </Modal.Content>
       </Modal>

--- a/src/modules/collection/utils.spec.ts
+++ b/src/modules/collection/utils.spec.ts
@@ -1,0 +1,44 @@
+import { Item } from 'modules/item/types'
+import { Mint } from './types'
+import { getTotalAmountOfMintedItems } from './utils'
+
+describe('when counting the amount of minted items', () => {
+  let mints: Mint[]
+  let item: Item
+
+  beforeEach(() => {
+    item = { id: 'anId' } as Item
+  })
+
+  describe('having no mints', () => {
+    beforeEach(() => {
+      mints = []
+    })
+
+    it('should return 0', () => {
+      expect(getTotalAmountOfMintedItems(mints)).toBe(0)
+    })
+  })
+
+  describe('having one mint of amount 3', () => {
+    beforeEach(() => {
+      mints = [{ address: 'anAddress', amount: 3, item }]
+    })
+
+    it('should return 3', () => {
+      expect(getTotalAmountOfMintedItems(mints)).toBe(3)
+    })
+  })
+
+  describe('having two mints of amount 2', () => {
+    beforeEach(() => {
+      mints = [
+        { address: 'anAddress', amount: 2, item },
+        { address: 'anotherAddress', amount: 2, item }
+      ]
+    })
+    it('should return 4', () => {
+      expect(getTotalAmountOfMintedItems(mints)).toBe(4)
+    })
+  })
+})

--- a/src/modules/collection/utils.ts
+++ b/src/modules/collection/utils.ts
@@ -5,7 +5,7 @@ import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
 import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 import { Item } from 'modules/item/types'
 import { isEqual, includes } from 'lib/address'
-import { Collection, Access } from './types'
+import { Collection, Access, Mint } from './types'
 import { locations } from 'routing/locations'
 
 export function setOnSale(collection: Collection, wallet: Wallet, isOnSale: boolean): Access[] {
@@ -87,4 +87,10 @@ export function canManageCollectionItems(collection: Collection, address?: strin
 
 export function hasReviews(collection: Collection) {
   return collection.reviewedAt !== collection.createdAt
+}
+
+export function getTotalAmountOfMintedItems(mints: Mint[]) {
+  return mints.reduce((total, mint) => {
+    return (total += mint.amount)
+  }, 0)
 }

--- a/src/modules/collection/utils.ts
+++ b/src/modules/collection/utils.ts
@@ -90,7 +90,5 @@ export function hasReviews(collection: Collection) {
 }
 
 export function getTotalAmountOfMintedItems(mints: Mint[]) {
-  return mints.reduce((total, mint) => {
-    return (total += mint.amount)
-  }, 0)
+  return mints.reduce((total, mint) => total + mint.amount, 0)
 }

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -807,7 +807,7 @@
     "collection_approved": "Approved the collection {name}",
     "collection_rejected": "Rejected the collection {name}",
     "saved_published_item": "You edited the item {name}",
-    "collection_item_minted": "Minted {itemName} for the collection {collectionName} {amount, plural, one {once} other {{amount} times}}",
+    "collection_item_minted": "Minted {itemName} for the collection {collectionName} {count, plural, one {once} other {{count} times}}",
     "collection_items_minted": "Minted {count} items for the collection {collectionName}",
     "updated_collection_managers": "Updated the collection's {name} managers",
     "updated_collection_minters": "Updated the collection's {name} minters",

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -816,7 +816,7 @@
     "collection_approved": "Collección {name} aprobada",
     "collection_rejected": "Collección {name} rechazada",
     "saved_published_item": "Has editado el item {name}",
-    "collection_item_minted": "Item {itemName} creado para la colección {collectionName} {amount, plural, one {una vez} other {{amount} veces}}",
+    "collection_item_minted": "Item {itemName} creado para la colección {collectionName} {count, plural, one {una vez} other {{count} veces}}",
     "collection_items_minted": "{count} items creados para la colleción {name}",
     "updated_collection_managers": "Actualizados los colaboradores de la colección {name}",
     "updated_collection_minters": "Actualizados los emisores de la colección {name}",

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -800,7 +800,7 @@
     "collection_approved": "批准了集合{name}",
     "collection_rejected": "拒绝收藏{name}",
     "saved_published_item": "您编辑了项目{name}",
-    "collection_item_minted": "为集合 {collectionName} 铸造了 {itemName} {amount, plural, one {一次} other {{amount} 次}}",
+    "collection_item_minted": "为集合 {collectionName} 铸造了 {itemName} {count, plural, one {一次} other {{count} 次}}",
     "collection_items_minted": "为{name}收集了{count}个项目",
     "updated_collection_managers": "更新了集合 {name} 管理器",
     "updated_collection_minters": "更新了集合 {name} 铸币厂",


### PR DESCRIPTION
This PR fixes the transaction message when the mint was/is minted. The amount was computed from the length of the mints, but each mint has an amount of times it should be minted.

This PR also fixes a small issue where the same item could be added twice to be minted.