### PR TITLE
fix: stats

### DIFF
--- a/src/lib/api/analytics.ts
+++ b/src/lib/api/analytics.ts
@@ -1,0 +1,30 @@
+import { WeeklyStats } from 'modules/stats/types'
+
+// caching the stats promise since it should not change for 24hs. Caching the promise instead of using await so simultaneous calls to the function would result in a single request.
+let statsPromise:
+  | Promise<
+      Record<string, { last_7d: { users: number; sessions: number; median_session_time: number; max_concurrent_users: number | null } }>
+    >
+  | undefined = undefined
+
+class AnalyticsAPI {
+  async fetchWeeklyStats(base: string) {
+    if (!statsPromise) {
+      statsPromise = fetch('https://cdn-data.decentraland.org/scenes/scene-stats.json').then(resp => resp.json())
+    }
+    const json = await statsPromise
+    const stats = base in json ? json[base]['last_7d'] : null
+
+    const weeklyStats: WeeklyStats = {
+      base,
+      users: stats ? stats.users : 0,
+      sessions: stats ? stats.sessions : 0,
+      medianSessionTime: stats ? stats.median_session_time : 0,
+      maxConcurrentUsers: stats ? stats.max_concurrent_users || 0 : 0
+    }
+
+    return weeklyStats
+  }
+}
+
+export const analytics = new AnalyticsAPI()

--- a/src/lib/api/builder.ts
+++ b/src/lib/api/builder.ts
@@ -648,10 +648,10 @@ export class BuilderAPI extends BaseAPI {
 
     const weeklyStats: WeeklyStats = {
       base,
-      users: stats ? stats.users : 0,
-      sessions: stats ? stats.sessions : 0,
-      medianSessionTime: stats ? stats.median_session_time : 0,
-      maxConcurrentUsers: stats ? stats.max_concurrent_users || 0 : 0
+      users: stats?.users ?? 0,
+      sessions: stats?.sessions ?? 0,
+      medianSessionTime: stats?.median_session_time ?? 0,
+      maxConcurrentUsers: stats?.max_concurrent_users ?? 0
     }
 
     return weeklyStats

--- a/src/lib/api/builder.ts
+++ b/src/lib/api/builder.ts
@@ -666,7 +666,28 @@ export class BuilderAPI extends BaseAPI {
   }
 
   async fetchWeeklyStats(base: string) {
-    const remoteStats: RemoteWeeklyStats = await this.request('get', `/analytics/weekly?base=${base}`)
+    const resp = await fetch('https://cdn-data.decentraland.org/scenes/scene-stats.json')
+    const json: Record<
+      string,
+      { last_7d: { users: number; sessions: number; median_session_time: number; max_concurrent_users: number | null } }
+    > = await resp.json()
+    const stats = base in json ? json[base]['last_7d'] : null
+    const remoteStats: RemoteWeeklyStats = {
+      week: '',
+      title: '',
+      base,
+      users: stats ? stats.users : 0,
+      sessions: stats ? stats.sessions : 0,
+      median_session_time: stats ? stats.median_session_time : 0,
+      min_session_time: stats ? stats.median_session_time : 0,
+      average_session_time: stats ? stats.median_session_time : 0,
+      max_session_time: stats ? stats.median_session_time : 0,
+      direct_users: stats ? stats.users : 0,
+      direct_sessions: stats ? stats.sessions : 0,
+      max_concurrent_users: stats ? stats.max_concurrent_users || 0 : 0,
+      max_concurrent_users_time: ''
+    }
+
     return fromRemoteWeeklyStats(remoteStats)
   }
 

--- a/src/lib/api/builder.ts
+++ b/src/lib/api/builder.ts
@@ -26,7 +26,7 @@ export const getContentsStorageUrl = (hash: string = '') => `${BUILDER_SERVER_UR
 export const getAssetPackStorageUrl = (hash: string = '') => `${BUILDER_SERVER_URL}/storage/assetPacks/${hash}`
 export const getPreviewUrl = (projectId: string) => `${BUILDER_SERVER_URL}/projects/${projectId}/media/preview.png`
 
-// caching the stats promise since it should not change for 24hs. Caching the promise instead of the awaited so simultaneous calls to the function would result in a single request.
+// caching the stats promise since it should not change for 24hs. Caching the promise instead of using await so simultaneous calls to the function would result in a single request.
 let statsPromise:
   | Promise<
       Record<string, { last_7d: { users: number; sessions: number; median_session_time: number; max_concurrent_users: number | null } }>

--- a/src/modules/common/sagas.ts
+++ b/src/modules/common/sagas.ts
@@ -60,7 +60,7 @@ export function* rootSaga(builderAPI: BuilderAPI) {
     profileSaga(),
     projectSaga(builderAPI),
     sceneSaga(),
-    statsSaga(builderAPI),
+    statsSaga(),
     syncSaga(builderAPI),
     tileSaga(),
     toastSaga(),

--- a/src/modules/stats/sagas.ts
+++ b/src/modules/stats/sagas.ts
@@ -1,4 +1,3 @@
-import { BuilderAPI } from 'lib/api/builder'
 import { call, put, takeEvery } from 'redux-saga/effects'
 import { analytics } from 'lib/api/analytics'
 import {
@@ -9,7 +8,7 @@ import {
 } from './action'
 import { WeeklyStats } from './types'
 
-export function* statsSaga(_builder: BuilderAPI) {
+export function* statsSaga() {
   yield takeEvery(FETCH_WEEKLY_SCENE_STATS_REQUEST, handleFetchSceneStatsRequest)
 
   function* handleFetchSceneStatsRequest(action: FetchWeeklySceneStatsRequestAction) {

--- a/src/modules/stats/sagas.ts
+++ b/src/modules/stats/sagas.ts
@@ -1,5 +1,6 @@
 import { BuilderAPI } from 'lib/api/builder'
 import { call, put, takeEvery } from 'redux-saga/effects'
+import { analytics } from 'lib/api/analytics'
 import {
   fetchWeeklySceneStatsFailure,
   FetchWeeklySceneStatsRequestAction,
@@ -8,13 +9,13 @@ import {
 } from './action'
 import { WeeklyStats } from './types'
 
-export function* statsSaga(builder: BuilderAPI) {
+export function* statsSaga(_builder: BuilderAPI) {
   yield takeEvery(FETCH_WEEKLY_SCENE_STATS_REQUEST, handleFetchSceneStatsRequest)
 
   function* handleFetchSceneStatsRequest(action: FetchWeeklySceneStatsRequestAction) {
     const { base } = action.payload
     try {
-      const stats: WeeklyStats = yield call(() => builder.fetchWeeklyStats(base))
+      const stats: WeeklyStats = yield call(() => analytics.fetchWeeklyStats(base))
       yield put(fetchWeeklySceneStatsSuccess(base, stats))
     } catch (error) {
       yield put(fetchWeeklySceneStatsFailure(base, error.message))

--- a/src/modules/stats/types.ts
+++ b/src/modules/stats/types.ts
@@ -1,15 +1,7 @@
 export type WeeklyStats = {
-  week: string
-  title: string
   base: string
   users: number
   sessions: number
   medianSessionTime: number
-  minSessionTime: number
-  averageSessionTime: number
-  maxSessionTime: number
-  directUsers: number
-  directSessions: number
   maxConcurrentUsers: number
-  maxConcurrentUsersTime: string
 }


### PR DESCRIPTION
Use the data cdn to show stats. I'm perma caching in memory the promise since it only changes every 24hs. Also I'm caching the promise and not the result because in many cases there are several requests fired simultaneously and awaiting the result before caching would end up in many requests, this way there's only one.

This is a temporary solution until we have a server or something in place, but from my tests this is loading in a reasonable time (500ms, 400kb using brotli compression)