### PR TITLE
feat: wait for indexer after rescue

### DIFF
--- a/src/components/Modals/ApprovalFlowModal/ApprovalFlowModal.container.ts
+++ b/src/components/Modals/ApprovalFlowModal/ApprovalFlowModal.container.ts
@@ -6,7 +6,7 @@ import { getLoading as getLoadingItemActions } from 'modules/item/selectors'
 import { getLoading as getLoadingCollectionActions } from 'modules/collection/selectors'
 import { getPendingTransactions } from 'modules/transaction/selectors'
 import { approveCollectionRequest, APPROVE_COLLECTION_REQUEST, APPROVE_COLLECTION_SUCCESS } from 'modules/collection/actions'
-import { rescueItemsRequest, RESCUE_ITEMS_REQUEST, RESCUE_ITEMS_SUCCESS } from 'modules/item/actions'
+import { rescueItemsRequest, RESCUE_ITEMS_REQUEST } from 'modules/item/actions'
 import ApprovalFlowModal from './ApprovalFlowModal'
 import { deployEntitiesRequest, DEPLOY_ENTITIES_REQUEST } from 'modules/entity/actions'
 
@@ -17,7 +17,6 @@ const mapState = (state: RootState): MapStateProps => {
   const pendingTransactions = getPendingTransactions(state)
   return {
     isConfirmingRescueTx: loadingItemActions.some(action => action.type === RESCUE_ITEMS_REQUEST),
-    isAwaitingRescueTx: pendingTransactions.some(tx => tx.actionType === RESCUE_ITEMS_SUCCESS),
     isDeployingItems: loadingEntityActions.some(action => action.type === DEPLOY_ENTITIES_REQUEST),
     isConfirmingApproveTx: loadingCollectionActions.some(action => action.type === APPROVE_COLLECTION_REQUEST),
     isAwaitingApproveTx: pendingTransactions.some(tx => tx.actionType === APPROVE_COLLECTION_SUCCESS)

--- a/src/components/Modals/ApprovalFlowModal/ApprovalFlowModal.tsx
+++ b/src/components/Modals/ApprovalFlowModal/ApprovalFlowModal.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 
-import { sleep } from 'decentraland-commons/dist/utils'
 import { Modal } from 'decentraland-dapps/dist/containers'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Button, Center, Loader, ModalActions, ModalContent, ModalNavigation } from 'decentraland-ui'
@@ -13,17 +12,6 @@ export default class ApprovalFlowModal extends React.PureComponent<Props> {
 
   state: State = {
     didRescue: false,
-    isWaitingForSubgraph: false
-  }
-
-  mounted = false
-
-  componentDidMount() {
-    this.mounted = true
-  }
-
-  componentWillUnmount() {
-    this.mounted = false
   }
 
   renderHash(hash: string) {
@@ -42,12 +30,12 @@ export default class ApprovalFlowModal extends React.PureComponent<Props> {
   }
 
   renderRescueView() {
-    const { onClose, metadata, onRescueItems, isConfirmingRescueTx, isAwaitingRescueTx } = this.props
+    const { onClose, metadata, onRescueItems, isConfirmingRescueTx } = this.props
     const { collection, items, contentHashes } = metadata as ApprovalFlowModalMetadata<ApprovalFlowModalView.RESCUE>
     const { didRescue } = this.state
     const onConfirm = () => {
+      this.setState({ didRescue: true })
       onRescueItems(collection, items, contentHashes)
-      this.setState({ didResuce: true })
     }
     return <>
       <ModalNavigation title={t('approval_flow.rescue.title')} subtitle={t('approval_flow.rescue.subtitle')} onClose={onClose} />
@@ -60,7 +48,7 @@ export default class ApprovalFlowModal extends React.PureComponent<Props> {
         ))}
       </ModalContent>
       <ModalActions>
-        <Button primary disabled={didRescue || isConfirmingRescueTx || isAwaitingRescueTx} loading={didRescue || isAwaitingRescueTx} onClick={onConfirm}>{t('approval_flow.rescue.confirm')}</Button>
+        <Button primary disabled={didRescue || isConfirmingRescueTx} loading={didRescue} onClick={onConfirm}>{t('approval_flow.rescue.confirm')}</Button>
         <Button secondary onClick={onClose}>{t('global.cancel')}</Button>
       </ModalActions>
     </>
@@ -68,18 +56,7 @@ export default class ApprovalFlowModal extends React.PureComponent<Props> {
 
   renderDeployView() {
     const { onClose, metadata, onDeployItems, isDeployingItems } = this.props
-    const { items, entities, didRescue } = metadata as ApprovalFlowModalMetadata<ApprovalFlowModalView.DEPLOY>
-    const { isWaitingForSubgraph } = this.state
-    const onConfirm = async () => {
-      if (didRescue) {
-        this.setState({ isWaitingForSubgraph: true })
-        await sleep(5000) // give some leeway to the subgraph to index after a rescue
-        if (!this.mounted) return
-      }
-      onDeployItems(entities)
-      this.setState({ isWaitingForSubgraph: false })
-    }
-    const isLoading = isDeployingItems || isWaitingForSubgraph
+    const { items, entities } = metadata as ApprovalFlowModalMetadata<ApprovalFlowModalView.DEPLOY>
     return <>
       <ModalNavigation title={t('approval_flow.upload.title')} subtitle={t('approval_flow.upload.subtitle')} onClose={onClose} />
       <ModalContent className="deploy">
@@ -95,7 +72,7 @@ export default class ApprovalFlowModal extends React.PureComponent<Props> {
         )}
       </ModalContent>
       <ModalActions>
-        <Button primary disabled={isLoading} loading={isLoading} onClick={onConfirm}>{t('approval_flow.upload.confirm')}</Button>
+        <Button primary disabled={isDeployingItems} loading={isDeployingItems} onClick={() => onDeployItems(entities)}>{t('approval_flow.upload.confirm')}</Button>
         <Button secondary onClick={onClose}>{t('global.cancel')}</Button>
       </ModalActions>
     </>

--- a/src/components/Modals/ApprovalFlowModal/ApprovalFlowModal.types.ts
+++ b/src/components/Modals/ApprovalFlowModal/ApprovalFlowModal.types.ts
@@ -22,7 +22,7 @@ export type ApprovalFlowModalMetadata<V extends ApprovalFlowModalView = Approval
 } & (V extends ApprovalFlowModalView.RESCUE
   ? { items: Item[]; contentHashes: string[] }
   : V extends ApprovalFlowModalView.DEPLOY
-  ? { items: Item[]; entities: DeploymentPreparationData[], didRescue: boolean }
+  ? { items: Item[]; entities: DeploymentPreparationData[] }
   : V extends ApprovalFlowModalView.ERROR
   ? { error: string }
   : {})
@@ -32,20 +32,15 @@ export type Props = ModalProps & {
   onDeployItems: typeof deployEntitiesRequest
   onApproveCollection: typeof approveCollectionRequest
   isConfirmingRescueTx: boolean
-  isAwaitingRescueTx: boolean
   isDeployingItems: boolean
   isConfirmingApproveTx: boolean
   isAwaitingApproveTx: boolean
 }
 
 export type State = {
-  didRescue: boolean,
-  isWaitingForSubgraph: boolean
+  didRescue: boolean
 }
 
-export type MapStateProps = Pick<
-  Props,
-  'isAwaitingRescueTx' | 'isConfirmingRescueTx' | 'isDeployingItems' | 'isAwaitingApproveTx' | 'isConfirmingApproveTx'
->
+export type MapStateProps = Pick<Props, 'isConfirmingRescueTx' | 'isDeployingItems' | 'isAwaitingApproveTx' | 'isConfirmingApproveTx'>
 export type MapDispatchProps = Pick<Props, 'onRescueItems' | 'onDeployItems' | 'onApproveCollection'>
 export type MapDispatch = Dispatch<RescueItemsRequestAction | DeployEntitiesRequestAction | ApproveCollectionRequestAction>


### PR DESCRIPTION
The current approval flow saga waits for the rescue transaction to be mined before going to the next step (upload the files). If the user clicked the upload button too quickly, the upload could fail due to the subgraph not having indexed the new content hashes yet. To prevent this from happening there was a 5 seconds sleep before the upload to give the indexer some leeway, but that solution was very flaky and not always worked, ending up in an error screen and having to resume the approval flow again. 

This PR changes the saga to wait for the new content hashes to be indexed before continuing to the upload step, and removes the sleep logic from the modal component and the await of the rescue tx logic.