### PR TITLE
fix: lock the collection after the tx

### DIFF
--- a/src/modules/collection/sagas.ts
+++ b/src/modules/collection/sagas.ts
@@ -255,10 +255,6 @@ export function* collectionSaga(builder: BuilderAPI, catalyst: CatalystClient) {
       // We wait for TOS to end first to avoid locking the collection preemptively if this endpoint fails
       yield retry(10, 500, builder.saveTOS, collection, email)
 
-      // TODO: uncomment this and add feature flag once we have support for them
-      // const lock: string = yield retry(10, 500, builder.lockCollection, collection)
-      // collection = { ...collection, lock: +new Date(lock) }
-
       const txHash: string = yield call(sendTransaction, manager, collectionManager =>
         collectionManager.createCollection(
           forwarder.address,
@@ -271,6 +267,10 @@ export function* collectionSaga(builder: BuilderAPI, catalyst: CatalystClient) {
           toInitializeItems(items)
         )
       )
+
+      // TODO: uncomment this and add feature flag once we have support for them
+      // const lock: string = yield retry(10, 500, builder.lockCollection, collection)
+      // collection = { ...collection, lock: +new Date(lock) }
 
       yield put(publishCollectionSuccess(collection, items, maticChainId, txHash))
       yield put(replace(locations.activity()))


### PR DESCRIPTION
You might be asking yourself, why is this lone developer moving commented code around. How observant of you. The reason is that it's easier to do now that to remember to do it in the future.

The fix is for the lock to occur after the user confirms the TX popup (whatever wallet might be), so the collection is not locked with a TX rejection.