### PR TITLE
feat: throw on unknown item type

### DIFF
--- a/src/modules/item/utils.ts
+++ b/src/modules/item/utils.ts
@@ -125,10 +125,6 @@ export function getBackgroundStyle(rarity?: ItemRarity) {
 export function getMetadata(item: Item) {
   const version = 1
   const type = item.type[0]
-  const slug = item.name
-    .trim()
-    .replace(/\s/, '-')
-    .toLowerCase()
 
   switch (item.type) {
     case ItemType.WEARABLE: {
@@ -139,7 +135,7 @@ export function getMetadata(item: Item) {
       return `${version}:${type}:${item.name}:${item.description}:${data.category}:${bodyShapeTypes}`
     }
     default:
-      return `${version}:${type}:${slug}`
+      throw new Error(`Unknown item.type "${item.type}"`)
   }
 }
 


### PR DESCRIPTION
The slug implementation was wrong (it was only replacing the first whitespace instead of all of them) and also I don't think we should have a default handler for this, and throw instead of unknown item types