### PR TITLE
refactor: Correct casing for Curation timestamps

### DIFF
--- a/src/components/CurationPage/CollectionRow/CollectionRow.tsx
+++ b/src/components/CurationPage/CollectionRow/CollectionRow.tsx
@@ -59,7 +59,7 @@ export default class CollectionRow extends React.PureComponent<Props> {
 
   render() {
     const { collection, items, curation } = this.props
-    const createdAtDate = new Date(curation?.created_at || collection.createdAt)
+    const createdAtDate = new Date(curation?.createdAt || collection.createdAt)
 
     return (
       <Link className="CollectionRow" to={locations.itemEditor({ collectionId: collection.id, isReviewing: 'true' })}>

--- a/src/components/CurationPage/CurationPage.tsx
+++ b/src/components/CurationPage/CurationPage.tsx
@@ -85,8 +85,8 @@ export default class CurationPage extends React.PureComponent<Props, State> {
 
         switch (sortBy) {
           case SortBy.NEWEST: {
-            const dateA = curationA ? curationA.created_at : collectionA.createdAt
-            const dateB = curationB ? curationB.created_at : collectionB.createdAt
+            const dateA = curationA ? curationA.createdAt : collectionA.createdAt
+            const dateB = curationB ? curationB.createdAt : collectionB.createdAt
 
             return dateA < dateB ? 1 : -1
           }

--- a/src/lib/api/builder.ts
+++ b/src/lib/api/builder.ts
@@ -384,8 +384,8 @@ function fromRemoteCuration(remoteCuration: RemoteCuration): Curation {
     id: remoteCuration.id,
     collectionId: remoteCuration.collection_id,
     status: remoteCuration.status,
-    created_at: +new Date(remoteCuration.created_at),
-    updated_at: +new Date(remoteCuration.updated_at)
+    createdAt: +new Date(remoteCuration.created_at),
+    updatedAt: +new Date(remoteCuration.updated_at)
   }
 }
 

--- a/src/modules/curation/reducer.spec.ts
+++ b/src/modules/curation/reducer.spec.ts
@@ -19,8 +19,8 @@ const getMockCuration = (props: Partial<Curation> = {}): Curation => ({
   id: 'id',
   collectionId: 'collectionId',
   status: CurationStatus.PENDING,
-  created_at: 0,
-  updated_at: 0,
+  createdAt: 0,
+  updatedAt: 0,
   ...props
 })
 
@@ -96,7 +96,7 @@ describe('when an action of type FETCH_CURATION_SUCCESS is called', () => {
         error: 'Some Error'
       }
 
-      const newCuration = getMockCuration({ updated_at: 100, created_at: 100, status: CurationStatus.APPROVED })
+      const newCuration = getMockCuration({ updatedAt: 100, createdAt: 100, status: CurationStatus.APPROVED })
 
       expect(curationReducer(state, fetchCurationSuccess('collectionId', newCuration))).toStrictEqual({
         data: { collectionId: newCuration },

--- a/src/modules/curation/selectors.spec.ts
+++ b/src/modules/curation/selectors.spec.ts
@@ -3,12 +3,12 @@ import { INITIAL_STATE } from './reducer'
 import { FETCH_CURATION_REQUEST } from './actions'
 import { Curation, CurationStatus } from './types'
 
-const getMockCuration = (props: Partial<Curation> = {}) => ({
+const getMockCuration = (props: Partial<Curation> = {}): Curation => ({
   id: 'id',
   collectionId: 'collectionId',
-  created_at: 0,
-  status: 'pending',
-  updated_at: 0,
+  createdAt: 0,
+  status: CurationStatus.PENDING,
+  updatedAt: 0,
   ...props
 })
 

--- a/src/modules/curation/types.ts
+++ b/src/modules/curation/types.ts
@@ -8,6 +8,6 @@ export type Curation = {
   id: string
   collectionId: string
   status: CurationStatus
-  created_at: number
-  updated_at: number
+  createdAt: number
+  updatedAt: number
 }


### PR DESCRIPTION
Curation type had created_at and updated_at which was not the correct casing.

Updated them to createdAt and updatedAt respectively.
