### PR TITLE
fix: Send the assetPacks query parameters as Axios parameters

### DIFF
--- a/src/lib/api/builder.ts
+++ b/src/lib/api/builder.ts
@@ -563,9 +563,9 @@ export class BuilderAPI extends BaseAPI {
   }
 
   async fetchAssetPacks(address?: string): Promise<FullAssetPack[]> {
-    const promisesOfRemoteAssetPacks: Array<Promise<RemoteAssetPack[]>> = [this.request('get', '/assetPacks?owner=default')]
+    const promisesOfRemoteAssetPacks: Array<Promise<RemoteAssetPack[]>> = [this.request('get', '/assetPacks', { owner: 'default' })]
     if (address) {
-      promisesOfRemoteAssetPacks.push(this.request('get', `/assetPacks?owner=${address}`))
+      promisesOfRemoteAssetPacks.push(this.request('get', '/assetPacks', { owner: address }))
     }
 
     const assetPacks: RemoteAssetPack[][] = await Promise.all(promisesOfRemoteAssetPacks)


### PR DESCRIPTION
This PR fixes the way we were sending the `/assetPacks` requests. The auth chain was incorrectly created using the query parameters because the `params` argument was not being used when doing the request to the backend service.