### PR TITLE
Moves status icon to the beginning of the collection name

### DIFF
--- a/src/components/CollectionsPage/CollectionCard/CollectionCard.tsx
+++ b/src/components/CollectionsPage/CollectionCard/CollectionCard.tsx
@@ -43,7 +43,7 @@ const CollectionCard = (props: Props & CollectedProps) => {
             <CollectionImage collectionId={collection.id} />
             <Card.Content>
               <div className="text" title={collection.name}>
-                {collection.name} <CollectionStatus collection={collection} />
+                <CollectionStatus collection={collection} /> {collection.name}
               </div>
               <div className="subtitle">
                 {t(`collection.type.${type}`)}&nbsp;·&nbsp;


### PR DESCRIPTION
Fixes https://github.com/decentraland/builder/issues/1709

![left-status](https://user-images.githubusercontent.com/4969737/149211311-28b27b79-795c-44e5-b6d1-4bf002af04ff.PNG)

