### PR TITLE
fix: use fetchEntitiesByPointers instead of fetchAllDeployments

### DIFF
--- a/src/modules/collection/sagas.spec.ts
+++ b/src/modules/collection/sagas.spec.ts
@@ -3,8 +3,8 @@ import * as matchers from 'redux-saga-test-plan/matchers'
 import { expectSaga } from 'redux-saga-test-plan'
 import { replace } from 'connected-react-router'
 import { ChainId, Network, WearableRepresentation } from '@dcl/schemas'
-import { EntityType } from 'dcl-catalyst-commons'
-import { CatalystClient, DeploymentPreparationData, DeploymentWithMetadataContentAndPointers } from 'dcl-catalyst-client'
+import { Entity, EntityType, EntityVersion } from 'dcl-catalyst-commons'
+import { CatalystClient, DeploymentPreparationData } from 'dcl-catalyst-client'
 import { getAddress } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import { sendTransaction } from 'decentraland-dapps/dist/modules/wallet/utils'
 import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
@@ -61,22 +61,19 @@ const getItem = (collection: Collection, props: Partial<Item> = {}): Item =>
     ...props
   } as Item)
 
-const getEntity = (
-  item: Item,
-  props: Partial<DeploymentWithMetadataContentAndPointers> = {}
-): DeploymentWithMetadataContentAndPointers => ({
-  entityId: 'anEntity',
-  content: Object.keys(item.contents).map(key => ({ key, hash: item.contents[key] })),
+const getEntity = (item: Item, props: Partial<Entity> = {}): Entity => ({
+  id: 'anEntity',
+  content: Object.keys(item.contents).map(file => ({ file, hash: item.contents[file] })),
   metadata: {
     urn: 'urn:decentraland:collections-v2:aCollection:anItem',
     name: item.name,
     description: item.description,
     data: item.data
   },
-  deployedBy: '0xcafebabe',
-  entityTimestamp: 0,
-  entityType: EntityType.WEARABLE,
+  timestamp: 0,
+  type: EntityType.WEARABLE,
   pointers: ['urn:decentraland:collections-v2:aCollection:anItem'],
+  version: EntityVersion.V3,
   ...props
 })
 
@@ -120,7 +117,7 @@ describe('when executing the approval flow', () => {
       contentHash: 'QmNewContentHash'
     }
     const syncedEntity = getEntity(syncedItem)
-    const unsyncedEntity = getEntity(updatedItem, { content: [{ key: 'thumbnail.png', hash: 'QmOldThumbnailHash' }] })
+    const unsyncedEntity = getEntity(updatedItem, { content: [{ file: 'thumbnail.png', hash: 'QmOldThumbnailHash' }] })
     const deployData = getDeployData()
     it('should complete the flow doing the rescue, deploy and approve collection steps', () => {
       return expectSaga(collectionSaga, mockBuilder, mockCatalyst)
@@ -190,7 +187,7 @@ describe('when executing the approval flow', () => {
       contentHash: 'QmNewContentHash'
     }
     const syncedEntity = getEntity(syncedItem)
-    const unsyncedEntity = getEntity(updatedItem, { content: [{ key: 'thumbnail.png', hash: 'QmOldThumbnailHash' }] })
+    const unsyncedEntity = getEntity(updatedItem, { content: [{ file: 'thumbnail.png', hash: 'QmOldThumbnailHash' }] })
     const deployData = getDeployData()
     const curation = getCuration(collection)
     it('should complete the flow doing a rescue, deploy and approve curation steps', () => {
@@ -342,7 +339,7 @@ describe('when executing the approval flow', () => {
       contentHash: 'QmNewContentHash'
     }
     const syncedEntity = getEntity(syncedItem)
-    const unsyncedEntity = getEntity(updatedItem, { content: [{ key: 'thumbnail.png', hash: 'QmOldThumbnailHash' }] })
+    const unsyncedEntity = getEntity(updatedItem, { content: [{ file: 'thumbnail.png', hash: 'QmOldThumbnailHash' }] })
     const deployData = getDeployData()
     const deployError = 'Deployment Error'
     it('should open the modal in an error state', () => {
@@ -407,7 +404,7 @@ describe('when executing the approval flow', () => {
       contentHash: 'QmNewContentHash'
     }
     const syncedEntity = getEntity(syncedItem)
-    const unsyncedEntity = getEntity(updatedItem, { content: [{ key: 'thumbnail.png', hash: 'QmOldThumbnailHash' }] })
+    const unsyncedEntity = getEntity(updatedItem, { content: [{ file: 'thumbnail.png', hash: 'QmOldThumbnailHash' }] })
     const deployData = getDeployData()
     const approveError = 'Approve Collection Transaction Error'
     it('should open the modal in an error state', () => {
@@ -479,7 +476,7 @@ describe('when executing the approval flow', () => {
       contentHash: 'QmNewContentHash'
     }
     const syncedEntity = getEntity(syncedItem)
-    const unsyncedEntity = getEntity(updatedItem, { content: [{ key: 'thumbnail.png', hash: 'QmOldThumbnailHash' }] })
+    const unsyncedEntity = getEntity(updatedItem, { content: [{ file: 'thumbnail.png', hash: 'QmOldThumbnailHash' }] })
     const deployData = getDeployData()
     const curation = getCuration(collection)
     const curationError = 'Curation Error'

--- a/src/modules/deployment/utils.ts
+++ b/src/modules/deployment/utils.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import uuid from 'uuid'
-import { DeploymentContent } from 'dcl-catalyst-commons'
+import { EntityContentItemReference } from 'dcl-catalyst-commons'
 const CID = require('cids')
 const MemoryDatastore = require('interface-datastore').MemoryDatastore
 const pull = require('pull-stream')
@@ -214,13 +214,13 @@ function isUrl(maybeUrl: string) {
   return true
 }
 
-export function getThumbnail(definition?: SceneDefinition | null, content?: DeploymentContent[]): string | null {
+export function getThumbnail(definition?: SceneDefinition | null, content?: EntityContentItemReference[]): string | null {
   if (!definition || !definition.display || !definition.display.navmapThumbnail) {
     return null
   }
   let thumbnail = definition.display.navmapThumbnail
   if (!isUrl(thumbnail) && content) {
-    const file = content.find(file => file.key === thumbnail)
+    const file = content.find(reference => reference.file === thumbnail)
     if (file) {
       thumbnail = getCatalystContentUrl(file.hash)
     }

--- a/src/modules/entity/actions.ts
+++ b/src/modules/entity/actions.ts
@@ -1,23 +1,37 @@
-import { DeploymentOptions, DeploymentPreparationData, DeploymentWithMetadataContentAndPointers } from 'dcl-catalyst-client'
 import { action } from 'typesafe-actions'
+import { DeploymentPreparationData } from 'dcl-catalyst-client'
+import { Entity, EntityType } from 'dcl-catalyst-commons'
 
-// Fetch Item Entity
-export const FETCH_ENTITIES_REQUEST = '[Request] Fetch Entities'
-export const FETCH_ENTITIES_SUCCESS = '[Success] Fetch Entities'
-export const FETCH_ENTITIES_FAILURE = '[Failure] Fetch Entities'
+// Fetch Entities By Pointers
+export const FETCH_ENTITIES_BY_POINTERS_REQUEST = '[Request] Fetch Entities By Pointers'
+export const FETCH_ENTITIES_BY_POINTERS_SUCCESS = '[Success] Fetch Entities By Pointers'
+export const FETCH_ENTITIES_BY_POINTERS_FAILURE = '[Failure] Fetch Entities By Pointers'
 
-export const fetchEntitiesRequest = (options: DeploymentOptions<DeploymentWithMetadataContentAndPointers>) =>
-  action(FETCH_ENTITIES_REQUEST, { options })
-export const fetchEntitiesSuccess = (
-  entities: DeploymentWithMetadataContentAndPointers[],
-  options: DeploymentOptions<DeploymentWithMetadataContentAndPointers>
-) => action(FETCH_ENTITIES_SUCCESS, { entities, options })
-export const fetchEntitiesFailure = (error: string, options: DeploymentOptions<DeploymentWithMetadataContentAndPointers>) =>
-  action(FETCH_ENTITIES_FAILURE, { error, options })
+export const fetchEntitiesByPointersRequest = (type: EntityType, pointers: string[]) =>
+  action(FETCH_ENTITIES_BY_POINTERS_REQUEST, { type, pointers })
+export const fetchEntitiesByPointersSuccess = (type: EntityType, pointers: string[], entities: Entity[]) =>
+  action(FETCH_ENTITIES_BY_POINTERS_SUCCESS, { entities, type, pointers })
+export const fetchEntitiesByPointersFailure = (type: EntityType, pointers: string[], error: string) =>
+  action(FETCH_ENTITIES_BY_POINTERS_FAILURE, { error, type, pointers })
 
-export type FetchEntitiesRequestAction = ReturnType<typeof fetchEntitiesRequest>
-export type FetchEntitiesSuccessAction = ReturnType<typeof fetchEntitiesSuccess>
-export type FetchEntitiesFailureAction = ReturnType<typeof fetchEntitiesFailure>
+export type FetchEntitiesByPointersRequestAction = ReturnType<typeof fetchEntitiesByPointersRequest>
+export type FetchEntitiesByPointersSuccessAction = ReturnType<typeof fetchEntitiesByPointersSuccess>
+export type FetchEntitiesByPointersFailureAction = ReturnType<typeof fetchEntitiesByPointersFailure>
+
+// Fetch Entities By Hash
+export const FETCH_ENTITIES_BY_IDS_REQUEST = '[Request] Fetch Entities By Ids'
+export const FETCH_ENTITIES_BY_IDS_SUCCESS = '[Success] Fetch Entities By Ids'
+export const FETCH_ENTITIES_BY_IDS_FAILURE = '[Failure] Fetch Entities By Ids'
+
+export const fetchEntitiesByIdsRequest = (type: EntityType, ids: string[]) => action(FETCH_ENTITIES_BY_IDS_REQUEST, { type, ids })
+export const fetchEntitiesByIdsSuccess = (type: EntityType, ids: string[], entities: Entity[]) =>
+  action(FETCH_ENTITIES_BY_IDS_SUCCESS, { type, ids, entities })
+export const fetchEntitiesByIdsFailure = (type: EntityType, ids: string[], error: string) =>
+  action(FETCH_ENTITIES_BY_IDS_FAILURE, { type, ids, error })
+
+export type FetchEntitiesByIdsRequestAction = ReturnType<typeof fetchEntitiesByIdsRequest>
+export type FetchEntitiesByIdsSuccessAction = ReturnType<typeof fetchEntitiesByIdsSuccess>
+export type FetchEntitiesByIdsFailureAction = ReturnType<typeof fetchEntitiesByIdsFailure>
 
 // Deploy entities
 

--- a/src/modules/entity/reducer.spec.ts
+++ b/src/modules/entity/reducer.spec.ts
@@ -1,0 +1,114 @@
+import { EntityType, EntityVersion } from 'dcl-catalyst-commons'
+import {
+  fetchEntitiesByIdsFailure,
+  fetchEntitiesByIdsRequest,
+  fetchEntitiesByIdsSuccess,
+  fetchEntitiesByPointersFailure,
+  fetchEntitiesByPointersRequest,
+  fetchEntitiesByPointersSuccess
+} from './actions'
+import { EntityState, entityReducer } from './reducer'
+
+const entity = {
+  id: 'Qmhash',
+  timestamp: 1234,
+  type: EntityType.WEARABLE,
+  pointers: ['aPointer'],
+  content: [
+    {
+      hash: 'Qmhash',
+      file: 'pepito.jpg'
+    }
+  ],
+  metadata: {
+    owner: '0xpepito',
+    some: 'thing'
+  },
+  version: EntityVersion.V3
+}
+
+describe('when reducing the FETCH_ENTITIES_BY_POINTERS_REQUEST action', () => {
+  it('should add an action to the loading state', () => {
+    const state: EntityState = {
+      data: {},
+      loading: [],
+      error: null
+    }
+    const action = fetchEntitiesByPointersRequest(EntityType.WEARABLE, entity.pointers)
+    const newState = entityReducer(state, action)
+    expect(newState.loading).toHaveLength(1)
+  })
+})
+
+describe('when reducing the FETCH_ENTITIES_BY_POINTERS_SUCCESS action', () => {
+  it('should insert the entity into the state data and clear the loading state', () => {
+    const state: EntityState = {
+      data: {},
+      loading: [fetchEntitiesByPointersRequest(EntityType.WEARABLE, entity.pointers)],
+      error: null
+    }
+
+    const action = fetchEntitiesByPointersSuccess(EntityType.WEARABLE, entity.pointers, [entity])
+    const newState = entityReducer(state, action)
+    expect(newState.data[entity.id]).toEqual(entity)
+    expect(newState.loading).toHaveLength(0)
+  })
+})
+
+describe('when reducing the FETCH_ENTITIES_BY_POINTERS_FAILURE action', () => {
+  it('should store the error and clear the loading state', () => {
+    const state: EntityState = {
+      data: {},
+      loading: [fetchEntitiesByPointersRequest(EntityType.WEARABLE, entity.pointers)],
+      error: null
+    }
+    const error = 'Some Error'
+    const action = fetchEntitiesByPointersFailure(EntityType.WEARABLE, entity.pointers, error)
+    const newState = entityReducer(state, action)
+    expect(newState.error).toEqual(error)
+    expect(newState.loading).toHaveLength(0)
+  })
+})
+
+describe('when reducing the FETCH_ENTITIES_BY_IDS_REQUEST action', () => {
+  it('should add an action to the loading state', () => {
+    const state: EntityState = {
+      data: {},
+      loading: [],
+      error: null
+    }
+    const action = fetchEntitiesByIdsRequest(EntityType.WEARABLE, [entity.id])
+    const newState = entityReducer(state, action)
+    expect(newState.loading).toHaveLength(1)
+  })
+})
+
+describe('when reducing the FETCH_ENTITIES_BY_IDS_SUCCESS action', () => {
+  it('should insert the entity into the state data and clear the loading state', () => {
+    const state: EntityState = {
+      data: {},
+      loading: [fetchEntitiesByIdsRequest(EntityType.WEARABLE, [entity.id])],
+      error: null
+    }
+
+    const action = fetchEntitiesByIdsSuccess(EntityType.WEARABLE, [entity.id], [entity])
+    const newState = entityReducer(state, action)
+    expect(newState.data[entity.id]).toEqual(entity)
+    expect(newState.loading).toHaveLength(0)
+  })
+})
+
+describe('when reducing the FETCH_ENTITIES_BY_IDS_FAILURE action', () => {
+  it('should store the error and clear the loading state', () => {
+    const state: EntityState = {
+      data: {},
+      loading: [fetchEntitiesByIdsRequest(EntityType.WEARABLE, [entity.id])],
+      error: null
+    }
+    const error = 'Some Error'
+    const action = fetchEntitiesByIdsFailure(EntityType.WEARABLE, [entity.id], error)
+    const newState = entityReducer(state, action)
+    expect(newState.error).toEqual(error)
+    expect(newState.loading).toHaveLength(0)
+  })
+})

--- a/src/modules/entity/reducer.spec.ts
+++ b/src/modules/entity/reducer.spec.ts
@@ -50,7 +50,7 @@ describe('when reducing the FETCH_ENTITIES_BY_POINTERS_SUCCESS action', () => {
 
     const action = fetchEntitiesByPointersSuccess(EntityType.WEARABLE, entity.pointers, [entity])
     const newState = entityReducer(state, action)
-    expect(newState.data[entity.id]).toEqual(entity)
+    expect(newState.data).toEqual({ [entity.id]: entity })
     expect(newState.loading).toHaveLength(0)
   })
 })
@@ -93,7 +93,7 @@ describe('when reducing the FETCH_ENTITIES_BY_IDS_SUCCESS action', () => {
 
     const action = fetchEntitiesByIdsSuccess(EntityType.WEARABLE, [entity.id], [entity])
     const newState = entityReducer(state, action)
-    expect(newState.data[entity.id]).toEqual(entity)
+    expect(newState.data).toEqual({ [entity.id]: entity })
     expect(newState.loading).toHaveLength(0)
   })
 })

--- a/src/modules/entity/reducer.ts
+++ b/src/modules/entity/reducer.ts
@@ -1,4 +1,4 @@
-import { DeploymentWithMetadataContentAndPointers } from 'dcl-catalyst-client'
+import { Entity } from 'dcl-catalyst-commons'
 import { loadingReducer, LoadingState } from 'decentraland-dapps/dist/modules/loading/reducer'
 import {
   DeployEntitiesFailureAction,
@@ -7,16 +7,22 @@ import {
   DEPLOY_ENTITIES_FAILURE,
   DEPLOY_ENTITIES_REQUEST,
   DEPLOY_ENTITIES_SUCCESS,
-  FetchEntitiesFailureAction,
-  FetchEntitiesRequestAction,
-  FetchEntitiesSuccessAction,
-  FETCH_ENTITIES_FAILURE,
-  FETCH_ENTITIES_REQUEST,
-  FETCH_ENTITIES_SUCCESS
+  FetchEntitiesByIdsFailureAction,
+  FetchEntitiesByIdsRequestAction,
+  FetchEntitiesByIdsSuccessAction,
+  FetchEntitiesByPointersFailureAction,
+  FetchEntitiesByPointersRequestAction,
+  FetchEntitiesByPointersSuccessAction,
+  FETCH_ENTITIES_BY_IDS_FAILURE,
+  FETCH_ENTITIES_BY_IDS_REQUEST,
+  FETCH_ENTITIES_BY_IDS_SUCCESS,
+  FETCH_ENTITIES_BY_POINTERS_FAILURE,
+  FETCH_ENTITIES_BY_POINTERS_REQUEST,
+  FETCH_ENTITIES_BY_POINTERS_SUCCESS
 } from './actions'
 
 export type EntityState = {
-  data: Record<string, DeploymentWithMetadataContentAndPointers>
+  data: Record<string, Entity>
   loading: LoadingState
   error: string | null
 }
@@ -28,16 +34,20 @@ const INITIAL_STATE: EntityState = {
 }
 
 type EntityReducerAction =
-  | FetchEntitiesRequestAction
-  | FetchEntitiesSuccessAction
-  | FetchEntitiesFailureAction
+  | FetchEntitiesByPointersRequestAction
+  | FetchEntitiesByPointersSuccessAction
+  | FetchEntitiesByPointersFailureAction
+  | FetchEntitiesByIdsRequestAction
+  | FetchEntitiesByIdsSuccessAction
+  | FetchEntitiesByIdsFailureAction
   | DeployEntitiesRequestAction
   | DeployEntitiesSuccessAction
   | DeployEntitiesFailureAction
 
 export function entityReducer(state: EntityState = INITIAL_STATE, action: EntityReducerAction): EntityState {
   switch (action.type) {
-    case FETCH_ENTITIES_REQUEST:
+    case FETCH_ENTITIES_BY_POINTERS_REQUEST:
+    case FETCH_ENTITIES_BY_IDS_REQUEST:
     case DEPLOY_ENTITIES_REQUEST:
     case DEPLOY_ENTITIES_SUCCESS: {
       return {
@@ -46,7 +56,8 @@ export function entityReducer(state: EntityState = INITIAL_STATE, action: Entity
         error: null
       }
     }
-    case FETCH_ENTITIES_SUCCESS: {
+    case FETCH_ENTITIES_BY_POINTERS_SUCCESS:
+    case FETCH_ENTITIES_BY_IDS_SUCCESS: {
       return {
         ...state,
         loading: loadingReducer(state.loading, action),
@@ -54,13 +65,14 @@ export function entityReducer(state: EntityState = INITIAL_STATE, action: Entity
         data: {
           ...state.data,
           ...action.payload.entities.reduce((obj, entity) => {
-            obj[entity.entityId] = entity
+            obj[entity.id] = entity
             return obj
           }, {} as EntityState['data'])
         }
       }
     }
-    case FETCH_ENTITIES_FAILURE:
+    case FETCH_ENTITIES_BY_POINTERS_FAILURE:
+    case FETCH_ENTITIES_BY_IDS_FAILURE:
     case DEPLOY_ENTITIES_FAILURE: {
       return {
         ...state,

--- a/src/modules/entity/sagas.spec.ts
+++ b/src/modules/entity/sagas.spec.ts
@@ -1,50 +1,51 @@
-import { CatalystClient, DeploymentOptions, DeploymentWithMetadataContentAndPointers } from 'dcl-catalyst-client'
-import { EntityType } from 'dcl-catalyst-commons'
+import { CatalystClient } from 'dcl-catalyst-client'
+import { Entity, EntityType, EntityVersion } from 'dcl-catalyst-commons'
 import { expectSaga } from 'redux-saga-test-plan'
 import { call } from 'redux-saga/effects'
-import { fetchEntitiesFailure, fetchEntitiesRequest, fetchEntitiesSuccess } from './actions'
+import { fetchEntitiesByPointersFailure, fetchEntitiesByPointersRequest, fetchEntitiesByPointersSuccess } from './actions'
 import { entitySaga } from './sagas'
 
 describe('Entity sagas', () => {
   describe('when handling the fetch entities action', () => {
     const client = ({
-      fetchAllDeployments: jest.fn()
+      fetchEntitiesByPointers: jest.fn()
     } as unknown) as CatalystClient
 
     it('should dispatch a failue action if the client throws', () => {
-      const options: DeploymentOptions<DeploymentWithMetadataContentAndPointers> = { filters: { pointers: ['aPointer', 'anotherPointer'] } }
+      const pointers = ['aPointer', 'anotherPointer']
       const anErrorMessage = 'Something happened'
       return expectSaga(entitySaga, client)
-        .provide([[call([client, 'fetchAllDeployments'], options), Promise.reject(new Error(anErrorMessage))]])
-        .put(fetchEntitiesFailure(anErrorMessage, options))
-        .dispatch(fetchEntitiesRequest(options))
+        .provide([[call([client, 'fetchEntitiesByPointers'], EntityType.WEARABLE, pointers), Promise.reject(new Error(anErrorMessage))]])
+        .put(fetchEntitiesByPointersFailure(EntityType.WEARABLE, pointers, anErrorMessage))
+        .dispatch(fetchEntitiesByPointersRequest(EntityType.WEARABLE, pointers))
         .run({ silenceTimeout: true })
     })
 
     it('should dispatch a success action if the response returns successfully', () => {
-      const options: DeploymentOptions<DeploymentWithMetadataContentAndPointers> = { filters: { pointers: ['aPointer', 'anotherPointer'] } }
-      const entities: DeploymentWithMetadataContentAndPointers[] = [
+      const pointers = ['aPointer', 'anotherPointer']
+      const entities: Entity[] = [
         {
-          entityId: 'Qmhash',
-          deployedBy: '0xhash',
-          entityTimestamp: 1234,
-          entityType: EntityType.WEARABLE,
+          id: 'Qmhash',
+          timestamp: 1234,
+          type: EntityType.WEARABLE,
           pointers: ['aPointer'],
           content: [
             {
               hash: 'Qmhash',
-              key: 'pepito.jpg'
+              file: 'pepito.jpg'
             }
           ],
           metadata: {
+            owner: '0xpepito',
             some: 'thing'
-          }
+          },
+          version: EntityVersion.V3
         }
       ]
       return expectSaga(entitySaga, client)
-        .provide([[call([client, 'fetchAllDeployments'], options), Promise.resolve(entities)]])
-        .put(fetchEntitiesSuccess(entities, options))
-        .dispatch(fetchEntitiesRequest(options))
+        .provide([[call([client, 'fetchEntitiesByPointers'], EntityType.WEARABLE, pointers), Promise.resolve(entities)]])
+        .put(fetchEntitiesByPointersSuccess(EntityType.WEARABLE, pointers, entities))
+        .dispatch(fetchEntitiesByPointersRequest(EntityType.WEARABLE, pointers))
         .run({ silenceTimeout: true })
     })
   })

--- a/src/modules/entity/sagas.spec.ts
+++ b/src/modules/entity/sagas.spec.ts
@@ -2,11 +2,18 @@ import { CatalystClient } from 'dcl-catalyst-client'
 import { Entity, EntityType, EntityVersion } from 'dcl-catalyst-commons'
 import { expectSaga } from 'redux-saga-test-plan'
 import { call } from 'redux-saga/effects'
-import { fetchEntitiesByPointersFailure, fetchEntitiesByPointersRequest, fetchEntitiesByPointersSuccess } from './actions'
+import {
+  fetchEntitiesByIdsFailure,
+  fetchEntitiesByIdsRequest,
+  fetchEntitiesByIdsSuccess,
+  fetchEntitiesByPointersFailure,
+  fetchEntitiesByPointersRequest,
+  fetchEntitiesByPointersSuccess
+} from './actions'
 import { entitySaga } from './sagas'
 
 describe('Entity sagas', () => {
-  describe('when handling the fetch entities action', () => {
+  describe('when handling the FETCH_ENTITIES_BY_POINTERS_REQUEST action', () => {
     const client = ({
       fetchEntitiesByPointers: jest.fn()
     } as unknown) as CatalystClient
@@ -46,6 +53,50 @@ describe('Entity sagas', () => {
         .provide([[call([client, 'fetchEntitiesByPointers'], EntityType.WEARABLE, pointers), Promise.resolve(entities)]])
         .put(fetchEntitiesByPointersSuccess(EntityType.WEARABLE, pointers, entities))
         .dispatch(fetchEntitiesByPointersRequest(EntityType.WEARABLE, pointers))
+        .run({ silenceTimeout: true })
+    })
+  })
+
+  describe('when handling the FETCH_ENTITIES_BY_IDS_REQUEST action', () => {
+    const client = ({
+      fetchEntitiesByIds: jest.fn()
+    } as unknown) as CatalystClient
+
+    it('should dispatch a failue action if the client throws', () => {
+      const ids = ['QmHash']
+      const anErrorMessage = 'Something happened'
+      return expectSaga(entitySaga, client)
+        .provide([[call([client, 'fetchEntitiesByIds'], EntityType.WEARABLE, ids), Promise.reject(new Error(anErrorMessage))]])
+        .put(fetchEntitiesByIdsFailure(EntityType.WEARABLE, ids, anErrorMessage))
+        .dispatch(fetchEntitiesByIdsRequest(EntityType.WEARABLE, ids))
+        .run({ silenceTimeout: true })
+    })
+
+    it('should dispatch a success action if the response returns successfully', () => {
+      const ids = ['QmHash']
+      const entities: Entity[] = [
+        {
+          id: 'Qmhash',
+          timestamp: 1234,
+          type: EntityType.WEARABLE,
+          pointers: ['aPointer'],
+          content: [
+            {
+              hash: 'Qmhash',
+              file: 'pepito.jpg'
+            }
+          ],
+          metadata: {
+            owner: '0xpepito',
+            some: 'thing'
+          },
+          version: EntityVersion.V3
+        }
+      ]
+      return expectSaga(entitySaga, client)
+        .provide([[call([client, 'fetchEntitiesByIds'], EntityType.WEARABLE, ids), Promise.resolve(entities)]])
+        .put(fetchEntitiesByIdsSuccess(EntityType.WEARABLE, ids, entities))
+        .dispatch(fetchEntitiesByIdsRequest(EntityType.WEARABLE, ids))
         .run({ silenceTimeout: true })
     })
   })

--- a/src/modules/entity/selectors.ts
+++ b/src/modules/entity/selectors.ts
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect'
-import { DeploymentWithMetadataContentAndPointers } from 'dcl-catalyst-client'
+import { Entity } from 'dcl-catalyst-commons'
 import { RootState } from 'modules/common/types'
 import { EntityState } from './reducer'
 
@@ -7,6 +7,4 @@ export const getState = (state: RootState) => state.entity
 export const getData = (state: RootState) => getState(state).data
 export const getError = (state: RootState) => getState(state).error
 export const getLoading = (state: RootState) => getState(state).loading
-export const getEntities = createSelector<RootState, EntityState['data'], DeploymentWithMetadataContentAndPointers[]>(getData, entityData =>
-  Object.values(entityData)
-)
+export const getEntities = createSelector<RootState, EntityState['data'], Entity[]>(getData, entityData => Object.values(entityData))

--- a/src/modules/item/sagas.spec.ts
+++ b/src/modules/item/sagas.spec.ts
@@ -37,6 +37,7 @@ import { buildZipContents, MAX_FILE_SIZE } from './utils'
 import { getData as getItemsById, getEntityByItemId, getItems } from './selectors'
 import { ThirdParty } from 'modules/thirdParty/types'
 import { downloadZip } from 'lib/zip'
+import { Entity, EntityType, EntityVersion } from 'dcl-catalyst-commons'
 
 let blob: Blob = new Blob()
 const contents: Record<string, Blob> = { path: blob }
@@ -313,7 +314,7 @@ describe('when reseting an item to the state found in the catalyst', () => {
   const itemId = 'itemId'
 
   let itemsById: any
-  let entitiesByItemId: any
+  let entitiesByItemId: Record<string, Entity>
   let replacedItem: any
   let replacedContents: any
 
@@ -343,7 +344,12 @@ describe('when reseting an item to the state found in the catalyst', () => {
 
     entitiesByItemId = {
       [itemId]: {
-        content: [{ key: 'key', hash: 'hash' }],
+        id: 'anEntity',
+        version: EntityVersion.V3,
+        type: EntityType.WEARABLE,
+        timestamp: Date.now(),
+        pointers: [],
+        content: [{ file: 'key', hash: 'hash' }],
         metadata: {
           name: 'name',
           description: 'description',

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -7,6 +7,7 @@ import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { closeModal } from 'decentraland-dapps/dist/modules/modal/actions'
 import { sendTransaction } from 'decentraland-dapps/dist/modules/wallet/utils'
 import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
+import { Entity, EntityType } from 'dcl-catalyst-commons'
 import {
   FetchItemsRequestAction,
   fetchItemsRequest,
@@ -88,7 +89,6 @@ import { Item, Rarity, CatalystItem, BodyShapeType } from './types'
 import { getData as getItemsById, getItems, getEntityByItemId, getCollectionItems } from './selectors'
 import { ItemTooBigError } from './errors'
 import { buildZipContents, getMetadata, isValidText, MAX_FILE_SIZE, toThirdPartyContractItems } from './utils'
-import { Entity, EntityType } from 'dcl-catalyst-commons'
 
 export function* itemSaga(builder: BuilderAPI) {
   yield takeEvery(FETCH_ITEMS_REQUEST, handleFetchItemsRequest)

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -7,7 +7,6 @@ import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { closeModal } from 'decentraland-dapps/dist/modules/modal/actions'
 import { sendTransaction } from 'decentraland-dapps/dist/modules/wallet/utils'
 import { getChainIdByNetwork } from 'decentraland-dapps/dist/lib/eth'
-import { DeploymentWithMetadataContentAndPointers } from 'dcl-catalyst-client'
 import {
   FetchItemsRequestAction,
   fetchItemsRequest,
@@ -79,7 +78,7 @@ import { getItemId } from 'modules/location/selectors'
 import { Collection } from 'modules/collection/types'
 import { getLoading as getLoadingItemAction } from 'modules/item/selectors'
 import { LoginSuccessAction, LOGIN_SUCCESS } from 'modules/identity/actions'
-import { fetchEntitiesRequest } from 'modules/entity/actions'
+import { fetchEntitiesByPointersRequest } from 'modules/entity/actions'
 import { getMethodData } from 'modules/wallet/utils'
 import { getCatalystContentUrl } from 'lib/api/peer'
 import { downloadZip } from 'lib/zip'
@@ -89,6 +88,7 @@ import { Item, Rarity, CatalystItem, BodyShapeType } from './types'
 import { getData as getItemsById, getItems, getEntityByItemId, getCollectionItems } from './selectors'
 import { ItemTooBigError } from './errors'
 import { buildZipContents, getMetadata, isValidText, MAX_FILE_SIZE, toThirdPartyContractItems } from './utils'
+import { Entity, EntityType } from 'dcl-catalyst-commons'
 
 export function* itemSaga(builder: BuilderAPI) {
   yield takeEvery(FETCH_ITEMS_REQUEST, handleFetchItemsRequest)
@@ -114,7 +114,7 @@ export function* itemSaga(builder: BuilderAPI) {
     try {
       const rarities: Rarity[] = yield call([builder, 'fetchRarities'])
       yield put(fetchRaritiesSuccess(rarities))
-    } catch (error: any) {
+    } catch (error) {
       yield put(fetchRaritiesFailure(error.message))
     }
   }
@@ -124,7 +124,7 @@ export function* itemSaga(builder: BuilderAPI) {
     try {
       const items: Item[] = yield call(() => builder.fetchItems(address))
       yield put(fetchItemsSuccess(items))
-    } catch (error: any) {
+    } catch (error) {
       yield put(fetchItemsFailure(error.message))
     }
   }
@@ -134,7 +134,7 @@ export function* itemSaga(builder: BuilderAPI) {
     try {
       const item: Item = yield call(() => builder.fetchItem(id))
       yield put(fetchItemSuccess(id, item))
-    } catch (error: any) {
+    } catch (error) {
       yield put(fetchItemFailure(id, error.message))
     }
   }
@@ -144,7 +144,7 @@ export function* itemSaga(builder: BuilderAPI) {
     try {
       const items: Item[] = yield call(() => builder.fetchCollectionItems(collectionId))
       yield put(fetchCollectionItemsSuccess(collectionId, items))
-    } catch (error: any) {
+    } catch (error) {
       yield put(fetchCollectionItemsFailure(collectionId, error.message))
     }
   }
@@ -174,7 +174,7 @@ export function* itemSaga(builder: BuilderAPI) {
       yield call([builder, 'saveItem'], item, contents)
 
       yield put(saveItemSuccess(item, contents))
-    } catch (error: any) {
+    } catch (error) {
       yield put(saveItemFailure(actionItem, contents, error.message))
     }
   }
@@ -209,7 +209,7 @@ export function* itemSaga(builder: BuilderAPI) {
       )
 
       yield put(setPriceAndBeneficiarySuccess(newItem, chainId, txHash))
-    } catch (error: any) {
+    } catch (error) {
       yield put(setPriceAndBeneficiaryFailure(itemId, price, beneficiary, error.message))
     }
   }
@@ -228,7 +228,7 @@ export function* itemSaga(builder: BuilderAPI) {
 
       yield put(publishThirdPartyItemsSuccess(txHash, maticChainId, thirdParty, collection, items))
       yield put(push(locations.activity()))
-    } catch (error: any) {
+    } catch (error) {
       yield put(publishThirdPartyItemsFailure(thirdParty, items, error.message))
     }
   }
@@ -242,7 +242,7 @@ export function* itemSaga(builder: BuilderAPI) {
       if (itemIdInUriParam === item.id) {
         yield put(replace(locations.collections()))
       }
-    } catch (error: any) {
+    } catch (error) {
       yield put(deleteItemFailure(item, error.message))
     }
   }
@@ -271,7 +271,7 @@ export function* itemSaga(builder: BuilderAPI) {
     try {
       const { items: newItems }: { items: Item[] } = yield call(() => builder.publishCollection(collection.id))
       yield put(setItemsTokenIdSuccess(newItems))
-    } catch (error: any) {
+    } catch (error) {
       yield put(setItemsTokenIdFailure(collection, items, error.message))
     }
   }
@@ -305,11 +305,11 @@ export function* itemSaga(builder: BuilderAPI) {
       }
       const items: Item[] = yield select(getItems)
       const collectionsById: Record<string, Collection> = yield select(getCollectionsById)
-      const urns = items
+      const pointers = items
         .filter(item => item.isPublished)
         .map(item => buildCatalystItemURN(collectionsById[item.collectionId!].contractAddress!, item.tokenId!))
-      if (urns.length > 0) {
-        yield put(fetchEntitiesRequest({ filters: { pointers: urns, onlyCurrentlyPointed: true } }))
+      if (pointers.length > 0) {
+        yield put(fetchEntitiesByPointersRequest(EntityType.WEARABLE, pointers))
       }
     }
   }
@@ -336,7 +336,7 @@ export function* itemSaga(builder: BuilderAPI) {
 
       const newItems = items.map<Item>((item, index) => ({ ...item, contentHash: contentHashes[index] }))
       yield put(rescueItemsSuccess(collection, newItems, contentHashes, chainId, txHash))
-    } catch (error: any) {
+    } catch (error) {
       yield put(rescueItemsFailure(collection, items, contentHashes, error.message))
     }
   }
@@ -377,7 +377,7 @@ export function* itemSaga(builder: BuilderAPI) {
 
       // success 🎉
       yield put(downloadItemSuccess(itemId))
-    } catch (error: any) {
+    } catch (error) {
       yield put(downloadItemFailure(itemId, error.message))
     }
   }
@@ -386,7 +386,7 @@ export function* itemSaga(builder: BuilderAPI) {
 export function* handleResetItemRequest(action: ResetItemRequestAction) {
   const { itemId } = action.payload
   const itemsById: Record<string, Item> = yield select(getItemsById)
-  const entitiesByItemId: Record<string, DeploymentWithMetadataContentAndPointers> = yield select(getEntityByItemId)
+  const entitiesByItemId: Record<string, Entity> = yield select(getEntityByItemId)
 
   const item = itemsById[itemId]
   const entity = entitiesByItemId[itemId]
@@ -398,8 +398,8 @@ export function* handleResetItemRequest(action: ResetItemRequestAction) {
       throw new Error('Entity does not have content')
     }
 
-    const entityContentsAsMap = entity.content.reduce<Record<string, string>>((contents, { key, hash }) => {
-      contents[key] = hash
+    const entityContentsAsMap = entity.content.reduce<Record<string, string>>((contents, { file, hash }) => {
+      contents[file] = hash
       return contents
     }, {})
 
@@ -440,7 +440,7 @@ export function* handleResetItemRequest(action: ResetItemRequestAction) {
     } else if (saveItemResult.failure) {
       yield put(resetItemFailure(itemId, saveItemResult.failure.payload.error))
     }
-  } catch (error: any) {
+  } catch (error) {
     yield put(resetItemFailure(itemId, error.message))
   }
 }

--- a/src/modules/item/selectors.spec.ts
+++ b/src/modules/item/selectors.spec.ts
@@ -244,7 +244,7 @@ describe('Item selectors', () => {
               content: [
                 {
                   hash: 'QmA',
-                  key: 'file.ext'
+                  file: 'file.ext'
                 }
               ],
               metadata: {
@@ -264,7 +264,7 @@ describe('Item selectors', () => {
               content: [
                 {
                   hash: 'QmB',
-                  key: 'file.ext'
+                  file: 'file.ext'
                 }
               ],
               metadata: {
@@ -284,7 +284,7 @@ describe('Item selectors', () => {
               content: [
                 {
                   hash: 'QmC',
-                  key: 'file.ext'
+                  file: 'file.ext'
                 }
               ],
               metadata: {

--- a/src/modules/item/selectors.ts
+++ b/src/modules/item/selectors.ts
@@ -1,5 +1,5 @@
+import { Entity } from 'dcl-catalyst-commons'
 import { createSelector } from 'reselect'
-import { DeploymentWithMetadataContentAndPointers } from 'dcl-catalyst-client'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 import { getAddress } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import { RootState } from 'modules/common/types'
@@ -79,12 +79,7 @@ export const getItemsByURN = createSelector<RootState, Item[], Record<string, Co
   }
 )
 
-export const getEntityByItemId = createSelector<
-  RootState,
-  DeploymentWithMetadataContentAndPointers[],
-  Record<string, Item>,
-  Record<string, DeploymentWithMetadataContentAndPointers>
->(
+export const getEntityByItemId = createSelector<RootState, Entity[], Record<string, Item>, Record<string, Entity>>(
   state => getEntities(state),
   state => getItemsByURN(state),
   (entities, itemsByURN) =>
@@ -95,7 +90,7 @@ export const getEntityByItemId = createSelector<
         obj[item.id] = entity
       }
       return obj
-    }, {} as Record<string, DeploymentWithMetadataContentAndPointers>)
+    }, {} as Record<string, Entity>)
 )
 
 export const getStatusByItemId = createSelector<

--- a/src/modules/item/utils.ts
+++ b/src/modules/item/utils.ts
@@ -1,7 +1,7 @@
 import { Address } from 'web3x/address'
 import { constants } from 'ethers'
-import { DeploymentWithMetadataContentAndPointers } from 'dcl-catalyst-client'
 import { utils } from 'decentraland-commons'
+import { Entity } from 'dcl-catalyst-commons'
 import future from 'fp-future'
 import { getContentsStorageUrl } from 'lib/api/builder'
 import { Collection } from 'modules/collection/types'
@@ -350,7 +350,7 @@ export function areEqualRepresentations(a: WearableRepresentation[], b: Wearable
   return true
 }
 
-export function areSynced(item: Item, entity: DeploymentWithMetadataContentAndPointers) {
+export function areSynced(item: Item, entity: Entity) {
   // check if metadata is synced
   const catalystItem = entity.metadata! as CatalystItem
   const hasMetadataChanged =
@@ -370,7 +370,7 @@ export function areSynced(item: Item, entity: DeploymentWithMetadataContentAndPo
   }
 
   // check if contents are synced
-  const contents = entity.content!.reduce((map, entry) => map.set(entry.key, entry.hash), new Map<string, string>())
+  const contents = entity.content!.reduce((map, entry) => map.set(entry.file, entry.hash), new Map<string, string>())
   for (const path in item.contents) {
     const hash = item.contents[path]
     if (contents.get(path) !== hash) {


### PR DESCRIPTION
Replaces the use of the deprecated and throttled `fetchAllDeployments` for `fetchEntitiesByPointers` and `fetchEntitiesByIds`. The first method returns a `DeploymentWithContentAndMetadata` and the latter ones an `Entity`, so I had to make some refactors but all the important data was available.