### PR TITLE
fix: Info popups

### DIFF
--- a/src/components/InfoIcon/InfoIcon.tsx
+++ b/src/components/InfoIcon/InfoIcon.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react'
 import classnames from 'classnames'
+import { omit } from 'decentraland-commons/dist/utils'
 import styles from './InfoIcon.module.css'
 import { Props } from './InfoIcon.types'
 
 export default class InfoIcon extends React.PureComponent<Props> {
   render() {
     const { className } = this.props
-    return <i className={classnames(styles.info, className)} />
+    return <i {...omit(this.props, ['className'])} className={classnames(styles.info, className)} />
   }
 }

--- a/src/components/InfoIcon/InfoIcon.tsx
+++ b/src/components/InfoIcon/InfoIcon.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react'
 import classnames from 'classnames'
-import { omit } from 'decentraland-commons/dist/utils'
 import styles from './InfoIcon.module.css'
 import { Props } from './InfoIcon.types'
 
 export default class InfoIcon extends React.PureComponent<Props> {
   render() {
     const { className } = this.props
-    return <i {...omit(this.props, ['className'])} className={classnames(styles.info, className)} />
+    return <i {...this.props} className={classnames(styles.info, className)} />
   }
 }

--- a/src/components/ItemEditorPage/RightPanel/MultiSelect/MultiSelect.css
+++ b/src/components/ItemEditorPage/RightPanel/MultiSelect/MultiSelect.css
@@ -24,7 +24,7 @@
   align-items: center;
 }
 
-.MultiSelect.ui.dropdown.inline .label .Info {
+.MultiSelect.ui.dropdown.inline .info {
   margin-left: 5px;
 }
 

--- a/src/components/ItemEditorPage/RightPanel/MultiSelect/MultiSelect.tsx
+++ b/src/components/ItemEditorPage/RightPanel/MultiSelect/MultiSelect.tsx
@@ -58,7 +58,7 @@ export default class MultiSelect<T extends string> extends React.PureComponent<P
       <>
         <div className="label">
           {label}
-          {info ? <Info content={info} /> : null}
+          {info ? <Info content={info} className="info" /> : null}
         </div>
         <div className="values">
           {value.length > 0 ? (

--- a/src/components/Modals/EditPriceAndBeneficiaryModal/EditPriceAndBeneficiaryModal.css
+++ b/src/components/Modals/EditPriceAndBeneficiaryModal/EditPriceAndBeneficiaryModal.css
@@ -25,7 +25,7 @@
   padding-left: 18px;
 }
 
-.EditPriceAndBeneficiaryModal .Info {
+.EditPriceAndBeneficiaryModal .info {
   width: 11px;
   height: 11px;
   margin-left: 8px;

--- a/src/components/Modals/EditPriceAndBeneficiaryModal/EditPriceAndBeneficiaryModal.tsx
+++ b/src/components/Modals/EditPriceAndBeneficiaryModal/EditPriceAndBeneficiaryModal.tsx
@@ -138,7 +138,7 @@ export default class EditPriceAndBeneficiaryModal extends React.PureComponent<Pr
                 (
                   <>
                     {t('edit_price_and_beneficiary_modal.beneficiary_label')}
-                    <Info content={t('edit_price_and_beneficiary_modal.beneficiary_popup')} />
+                    <Info content={t('edit_price_and_beneficiary_modal.beneficiary_popup')} className="info" />
                   </>
                 ) as FieldProps['label']
               }

--- a/src/components/Modals/EstateEditorModal/EstateEditorModal.css
+++ b/src/components/Modals/EstateEditorModal/EstateEditorModal.css
@@ -34,7 +34,7 @@
   margin-right: 8px;
 }
 
-.EstateEditorModal .Info {
+.EstateEditorModal .info {
   margin-top: 1px;
   margin-right: 8px;
 }

--- a/src/components/Modals/EstateEditorModal/EstateEditorModal.tsx
+++ b/src/components/Modals/EstateEditorModal/EstateEditorModal.tsx
@@ -226,7 +226,7 @@ export default class EstateEditorModal extends React.PureComponent<Props, State>
             ) : null}
             {needsTwoTxs ? (
               <div className="message info">
-                <Info />
+                <Info className="info" />
                 {t('estate_editor.needs_two_txs', { toAdd: coordsToAdd.length, toRemove: coordsToRemove.length })}
               </div>
             ) : null}


### PR DESCRIPTION
This PR fixes the Info popups that:
- Were not opening due to `react-semantic-ui` expecting a semantic component instead of a custom component for the popup trigger.
- Had issues with the styles due to being styled from other components.