### PR TITLE
feat: Make the TP items updatable after being published (#1797)

### DIFF
--- a/src/components/Modals/PublishThirdPartyCollectionModal/PublishThirdPartyCollectionModal.container.ts
+++ b/src/components/Modals/PublishThirdPartyCollectionModal/PublishThirdPartyCollectionModal.container.ts
@@ -4,7 +4,7 @@ import { RootState } from 'modules/common/types'
 import { getCollectionThirdParty } from 'modules/thirdParty/selectors'
 import { publishThirdPartyItemsRequest, PUBLISH_THIRD_PARTY_ITEMS_REQUEST } from 'modules/item/actions'
 import { getCollection } from 'modules/collection/selectors'
-import { getLoading, getCollectionItems } from 'modules/item/selectors'
+import { getLoading, getCollectionItems, getStatusForItemIds } from 'modules/item/selectors'
 import { OwnProps, MapStateProps, MapDispatchProps, MapDispatch } from './PublishThirdPartyCollectionModal.types'
 import PublishCollectionModal from './PublishThirdPartyCollectionModal'
 
@@ -18,12 +18,18 @@ const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
     collection,
     items,
     thirdParty: collection ? getCollectionThirdParty(state, collection) : null,
-    isPublishLoading: isLoadingType(getLoading(state), PUBLISH_THIRD_PARTY_ITEMS_REQUEST)
+    isPublishLoading: isLoadingType(getLoading(state), PUBLISH_THIRD_PARTY_ITEMS_REQUEST),
+    itemsStatus: getStatusForItemIds(
+      state,
+      items.map(i => i.id)
+    )
   }
 }
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
-  onPublish: (thirdParty, items) => dispatch(publishThirdPartyItemsRequest(thirdParty, items))
+  onPublish: (thirdParty, items) => dispatch(publishThirdPartyItemsRequest(thirdParty, items)), // TODO: @TP Should call the pushChanges action
+  onPushChanges: (thirdParty, items) => dispatch(publishThirdPartyItemsRequest(thirdParty, items)), // TODO: @TP Should call the onPushChanges action that will be introduced in #1752
+  onPublishAndPushChanges: (thirdParty, items) => dispatch(publishThirdPartyItemsRequest(thirdParty, items)) // TODO: @TP Should call the publishAndPushChanges action that will be introduced in #1752
 })
 
 export default connect(mapState, mapDispatch)(PublishCollectionModal)

--- a/src/components/Modals/PublishThirdPartyCollectionModal/PublishThirdPartyCollectionModal.tsx
+++ b/src/components/Modals/PublishThirdPartyCollectionModal/PublishThirdPartyCollectionModal.tsx
@@ -2,31 +2,81 @@ import * as React from 'react'
 import { ModalNavigation, Button } from 'decentraland-ui'
 import Modal from 'decentraland-dapps/dist/containers/Modal'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
+import { SyncStatus } from 'modules/item/types'
+import { isStatusAllowedToPushChanges } from 'modules/item/utils'
+import { PublishButtonAction } from 'components/ThirdPartyCollectionDetailPage/CollectionPublishButton/CollectionPublishButton.types'
+import { getTPButtonActionLabel } from 'components/ThirdPartyCollectionDetailPage/CollectionPublishButton/CollectionPublishButton'
 import { Props } from './PublishThirdPartyCollectionModal.types'
 
 export default class PublishThirdPartyCollectionModal extends React.PureComponent<Props> {
-  handlePublish = () => {
-    const { thirdParty, items, onPublish } = this.props
-    onPublish(thirdParty!, items!)
+  handleSubmit = () => {
+    const {
+      items,
+      thirdParty,
+      onPublish,
+      onPushChanges,
+      onPublishAndPushChanges,
+      metadata: { action }
+    } = this.props
+
+    let fn
+    switch (action) {
+      case PublishButtonAction.PUSH_CHANGES:
+        fn = onPushChanges
+      case PublishButtonAction.PUBLISH_AND_PUSH_CHANGES:
+        fn = onPublishAndPushChanges
+      default:
+        fn = onPublish
+    }
+
+    fn(thirdParty!, items!)
+  }
+
+  getModalDescriptionText = () => {
+    const { items, thirdParty, collection, itemsStatus } = this.props
+
+    const itemsToPublish = Object.values(itemsStatus).filter(status => status === SyncStatus.UNPUBLISHED).length
+    const itemsToPushChanges = Object.values(itemsStatus).filter(isStatusAllowedToPushChanges).length
+
+    const isPublishingAndPushingChanges = itemsToPushChanges > 0 && itemsToPublish > 0
+    const isJustPushingChanges = itemsToPushChanges > 0 && !itemsToPublish
+
+    if (isPublishingAndPushingChanges) {
+      return t('publish_third_party_collection_modal.publish_and_push_changes_description', {
+        slotsToUse: itemsToPublish,
+        itemsWithChanges: itemsToPushChanges,
+        availableSlots: thirdParty?.availableSlots,
+        collectionName: collection!.name
+      })
+    } else if (isJustPushingChanges) {
+      return t('publish_third_party_collection_modal.push_changes_description', {
+        itemsWithChanges: itemsToPushChanges,
+        collectionName: collection!.name
+      })
+    }
+
+    return t('publish_third_party_collection_modal.publish_description', {
+      slotsToUse: items.length,
+      availableSlots: thirdParty?.availableSlots,
+      collectionName: collection!.name
+    })
   }
 
   render() {
-    const { collection, items, thirdParty, isPublishLoading, onClose } = this.props
+    const {
+      isPublishLoading,
+      onClose,
+      metadata: { action }
+    } = this.props
 
     return (
       <Modal className="PublishThirdPartyCollectionModal" size="tiny" onClose={onClose}>
         <ModalNavigation title={t('publish_third_party_collection_modal.title')} onClose={onClose} />
         <Modal.Content>
-          <div>
-            {t('publish_third_party_collection_modal.description', {
-              slotsToUse: items.length,
-              availableSlots: thirdParty?.availableSlots,
-              collectionName: collection!.name
-            })}
-          </div>
+          <div>{this.getModalDescriptionText()}</div>
           <br />
-          <Button primary fluid loading={isPublishLoading} onClick={this.handlePublish}>
-            {t('global.publish')}
+          <Button primary fluid loading={isPublishLoading} onClick={this.handleSubmit}>
+            {getTPButtonActionLabel(action)}
           </Button>
           <br />
           <Button secondary fluid onClick={onClose}>

--- a/src/components/Modals/PublishThirdPartyCollectionModal/PublishThirdPartyCollectionModal.types.ts
+++ b/src/components/Modals/PublishThirdPartyCollectionModal/PublishThirdPartyCollectionModal.types.ts
@@ -2,24 +2,29 @@ import { Dispatch } from 'redux'
 import { ModalProps } from 'decentraland-dapps/dist/providers/ModalProvider/ModalProvider.types'
 import { Collection } from 'modules/collection/types'
 import { ThirdParty } from 'modules/thirdParty/types'
-import { Item } from 'modules/item/types'
+import { Item, SyncStatus } from 'modules/item/types'
+import { PublishButtonAction } from 'components/ThirdPartyCollectionDetailPage/CollectionPublishButton/CollectionPublishButton.types'
 import { publishThirdPartyItemsRequest, PublishThirdPartyItemsRequestAction } from 'modules/item/actions'
+
+export type PublishThirdPartyCollectionModalMetadata = {
+  collectionId: string
+  itemIds: string[]
+  action: PublishButtonAction
+}
 
 export type Props = ModalProps & {
   metadata: PublishThirdPartyCollectionModalMetadata
   collection: Collection | null
   thirdParty: ThirdParty | null
   items: Item[]
+  itemsStatus: Record<string, SyncStatus>
   isPublishLoading: boolean
   onPublish: typeof publishThirdPartyItemsRequest
-}
-
-export type PublishThirdPartyCollectionModalMetadata = {
-  collectionId: string
-  itemIds: string[]
+  onPushChanges: typeof publishThirdPartyItemsRequest // TODO: @TP pushChangesType of action
+  onPublishAndPushChanges: typeof publishThirdPartyItemsRequest // TODO: @TP publishAndPushChanges of action
 }
 
 export type OwnProps = Pick<Props, 'metadata'>
-export type MapStateProps = Pick<Props, 'collection' | 'items' | 'thirdParty' | 'isPublishLoading'>
-export type MapDispatchProps = Pick<Props, 'onPublish'>
+export type MapStateProps = Pick<Props, 'collection' | 'items' | 'thirdParty' | 'isPublishLoading' | 'itemsStatus'>
+export type MapDispatchProps = Pick<Props, 'onPublish' | 'onPushChanges' | 'onPublishAndPushChanges'>
 export type MapDispatch = Dispatch<PublishThirdPartyItemsRequestAction>

--- a/src/components/ThirdPartyCollectionDetailPage/CollectionPublishButton/CollectionPublishButton.container.ts
+++ b/src/components/ThirdPartyCollectionDetailPage/CollectionPublishButton/CollectionPublishButton.container.ts
@@ -1,13 +1,22 @@
 import { connect } from 'react-redux'
 import { RootState } from 'modules/common/types'
 import { openModal } from 'modules/modal/actions'
-import { MapStateProps, MapDispatchProps, MapDispatch } from './CollectionPublishButton.types'
+import { getStatusForItemIds } from 'modules/item/selectors'
+import { MapStateProps, MapDispatchProps, MapDispatch, OwnProps, PublishButtonAction } from './CollectionPublishButton.types'
 import CollectionPublishButton from './CollectionPublishButton'
 
-const mapState = (_state: RootState): MapStateProps => ({})
+const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
+  return {
+    itemsStatus: getStatusForItemIds(
+      state,
+      ownProps.items.map(i => i.id)
+    )
+  }
+}
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
-  onPublish: (collectionId: string, itemIds: string[]) => dispatch(openModal('PublishThirdPartyCollectionModal', { collectionId, itemIds }))
+  onClick: (collectionId: string, itemIds: string[], action: PublishButtonAction) =>
+    dispatch(openModal('PublishThirdPartyCollectionModal', { collectionId, itemIds, action }))
 })
 
 export default connect(mapState, mapDispatch)(CollectionPublishButton)

--- a/src/components/ThirdPartyCollectionDetailPage/CollectionPublishButton/CollectionPublishButton.types.ts
+++ b/src/components/ThirdPartyCollectionDetailPage/CollectionPublishButton/CollectionPublishButton.types.ts
@@ -1,15 +1,23 @@
 import { Dispatch } from 'redux'
 import { OpenModalAction } from 'modules/modal/actions'
 import { Collection } from 'modules/collection/types'
-import { Item } from 'modules/item/types'
+import { Item, SyncStatus } from 'modules/item/types'
+
+export enum PublishButtonAction {
+  PUBLISH,
+  PUSH_CHANGES,
+  PUBLISH_AND_PUSH_CHANGES
+}
 
 export type Props = {
   collection: Collection
   items: Item[]
+  itemsStatus: Record<string, SyncStatus>
   slots: number
-  onPublish: (collectionId: string, itemIds: string[]) => void
+  onClick: (collectionId: string, itemIds: string[], action: PublishButtonAction) => void
 }
 
-export type MapStateProps = {}
-export type MapDispatchProps = Pick<Props, 'onPublish'>
+export type OwnProps = Pick<Props, 'items'>
+export type MapStateProps = Pick<Props, 'itemsStatus'>
+export type MapDispatchProps = Pick<Props, 'onClick'>
 export type MapDispatch = Dispatch<OpenModalAction>

--- a/src/modules/item/selectors.spec.ts
+++ b/src/modules/item/selectors.spec.ts
@@ -9,6 +9,7 @@ import {
   getItems,
   getRarities,
   getStatusByItemId,
+  getStatusForItemIds,
   getWalletItems,
   getWalletOrphanItems,
   hasViewAndEditRights
@@ -127,90 +128,274 @@ describe('Item selectors', () => {
     })
   })
 
-  describe('when getting status by item id', () => {
-    it('should return the status for each published item', () => {
-      mockGetChainIdByNetwork.mockReturnValue(ChainId.MATIC_MAINNET)
-      const mockState = {
-        collectionCuration: {
-          data: {
-            '0': {
+  describe('when getting status', () => {
+    mockGetChainIdByNetwork.mockReturnValue(ChainId.MATIC_MAINNET)
+    const mockState = {
+      collectionCuration: {
+        data: {
+          '0': {
+            id: '0',
+            collectionId: '0',
+            status: 'approved'
+          },
+          '1': {
+            id: '1',
+            collectionId: '1',
+            status: 'rejected'
+          },
+          '3': {
+            id: '3',
+            collectionId: '3',
+            status: 'pending'
+          }
+        }
+      },
+      itemCuration: {
+        data: {
+          '0': [
+            {
               id: '0',
-              collectionId: '0',
+              itemId: '0',
               status: 'approved'
             },
-            '1': {
+            {
               id: '1',
-              collectionId: '1',
+              itemId: '1',
               status: 'rejected'
             },
-            '3': {
+            {
               id: '3',
-              collectionId: '3',
+              itemId: '3',
               status: 'pending'
             }
+          ],
+          '4': [
+            {
+              id: '4',
+              itemId: '5',
+              status: 'pending'
+            },
+            {
+              id: '5',
+              itemId: '6',
+              status: 'approved'
+            },
+            {
+              id: '6',
+              itemId: '7',
+              status: 'approved'
+            },
+            {
+              id: '7',
+              itemId: '8',
+              status: 'approved'
+            }
+          ]
+        }
+      },
+      item: {
+        data: {
+          '0': {
+            id: '0',
+            collectionId: '0',
+            tokenId: 'aTokenId',
+            isPublished: true,
+            isApproved: false
+          },
+          '1': {
+            id: '1',
+            collectionId: '1',
+            tokenId: 'anotherTokenId',
+            isPublished: true,
+            isApproved: true,
+            contents: {
+              'file.ext': 'QmA'
+            },
+            name: 'pepito',
+            description: 'yes it is a pepito',
+            data: {
+              category: WearableCategory.HAT,
+              replaces: [],
+              hides: [],
+              representations: [],
+              tags: []
+            }
+          },
+          '2': {
+            id: '2',
+            collectionId: '2',
+            tokenId: 'yetAnotherTokenId',
+            isPublished: true,
+            isApproved: true,
+            contents: {
+              'file.ext': 'QmB_new'
+            },
+            name: 'pepito',
+            description: 'pepito hat very nice',
+            data: {
+              category: WearableCategory.HAT,
+              replaces: [],
+              hides: [],
+              representations: [],
+              tags: []
+            }
+          },
+          '3': {
+            id: '3',
+            collectionId: '3',
+            tokenId: 'yetAnotherDifferentTokenId',
+            isPublished: true,
+            isApproved: true,
+            contents: {
+              'file.ext': 'QmC_new'
+            },
+            name: 'pepito',
+            description: 'pepito hat very nice',
+            data: {
+              category: WearableCategory.HAT,
+              replaces: [],
+              hides: [],
+              representations: [],
+              tags: []
+            }
+          },
+          '4': {
+            id: '4',
+            collectionId: '4',
+            tokenId: 'yetAnotherDifferentTokenId',
+            isPublished: false,
+            isApproved: false,
+            contents: {
+              'file.ext': 'QmC_new'
+            },
+            name: 'pepito',
+            description: 'pepito hat very nice',
+            urn: 'urn:decentraland:mumbai:collections-thirdparty:thirdparty2:the-real-deal', // TP
+            data: {
+              category: WearableCategory.HAT,
+              replaces: [],
+              hides: [],
+              representations: [],
+              tags: []
+            }
+          },
+          '5': {
+            id: '5',
+            collectionId: '4',
+            tokenId: 'yetAnotherDifferentTokenId',
+            isPublished: true,
+            isApproved: true,
+            contents: {
+              'file.ext': 'QmC_new'
+            },
+            name: 'pepito',
+            description: 'pepito hat very nice',
+            urn: 'urn:decentraland:mumbai:collections-thirdparty:thirdparty2:the-real-deal', // TP
+            data: {
+              category: WearableCategory.HAT,
+              replaces: [],
+              hides: [],
+              representations: [],
+              tags: []
+            }
+          },
+          '6': {
+            id: '6',
+            collectionId: '4',
+            tokenId: 'TPTokenId',
+            isPublished: true,
+            isApproved: true,
+            contents: {
+              'file.ext': 'QmC_new'
+            },
+            name: 'pepito',
+            description: 'pepito hat very nice',
+            urn: 'urn:decentraland:mumbai:collections-thirdparty:thirdparty2:the-real-deal', // TP
+            data: {
+              category: WearableCategory.HAT,
+              replaces: [],
+              hides: [],
+              representations: [],
+              tags: []
+            }
+          },
+          '7': {
+            id: '7',
+            collectionId: '4',
+            tokenId: 'anotherDifferentTPTokenId',
+            isPublished: true,
+            isApproved: true,
+            contents: {
+              'file.ext': 'QmC_new'
+            },
+            name: 'pepito',
+            description: 'pepito hat very nice',
+            urn: 'urn:decentraland:mumbai:collections-thirdparty:thirdparty2:the-real-deal', // TP
+            data: {
+              category: WearableCategory.HAT,
+              replaces: [],
+              hides: [],
+              representations: [],
+              tags: []
+            }
+          },
+          '8': {
+            id: '8',
+            collectionId: '4',
+            tokenId: 'yetAnotherDifferentTPTokenId',
+            isPublished: true,
+            isApproved: true,
+            contents: {
+              'file.ext': 'QmC_new'
+            },
+            name: 'pepito',
+            description: 'pepito hat very nice',
+            urn: 'urn:decentraland:mumbai:collections-thirdparty:thirdparty2:the-real-deal', // TP
+            data: {
+              category: WearableCategory.HAT,
+              replaces: [],
+              hides: [],
+              representations: [],
+              tags: []
+            }
           }
-        },
-        itemCuration: {
-          data: {
-            '0': [
+        }
+      },
+      collection: {
+        data: {
+          '0': {
+            id: '0',
+            contractAddress: 'anAddress'
+          },
+          '1': {
+            id: '1',
+            contractAddress: 'anotherAddress'
+          },
+          '2': {
+            id: '2',
+            contractAddress: 'yetAnotherAddress'
+          },
+          '3': {
+            id: '3',
+            contractAddress: 'yetAnotherDifferentAddress'
+          },
+          '4': {
+            id: '4',
+            contractAddress: 'TPAddress'
+          }
+        }
+      },
+      entity: {
+        data: {
+          Qm1: {
+            content: [
               {
-                id: '0',
-                itemId: '0',
-                status: 'approved'
-              },
-              {
-                id: '1',
-                itemId: '1',
-                status: 'rejected'
-              },
-              {
-                id: '3',
-                itemId: '3',
-                status: 'pending'
+                hash: 'QmA',
+                file: 'file.ext'
               }
             ],
-            '4': [
-              {
-                id: '4',
-                itemId: '5',
-                status: 'pending'
-              },
-              {
-                id: '5',
-                itemId: '6',
-                status: 'approved'
-              },
-              {
-                id: '6',
-                itemId: '7',
-                status: 'approved'
-              },
-              {
-                id: '7',
-                itemId: '8',
-                status: 'approved'
-              }
-            ]
-          }
-        },
-        item: {
-          data: {
-            '0': {
-              id: '0',
-              collectionId: '0',
-              tokenId: 'aTokenId',
-              isPublished: true,
-              isApproved: false
-            },
-            '1': {
-              id: '1',
-              collectionId: '1',
-              tokenId: 'anotherTokenId',
-              isPublished: true,
-              isApproved: true,
-              contents: {
-                'file.ext': 'QmA'
-              },
+            metadata: {
+              id: 'urn:decentraland:matic:collections-v2:anotherAddress:anotherTokenId',
               name: 'pepito',
               description: 'yes it is a pepito',
               data: {
@@ -220,137 +405,19 @@ describe('Item selectors', () => {
                 representations: [],
                 tags: []
               }
-            },
-            '2': {
-              id: '2',
-              collectionId: '2',
-              tokenId: 'yetAnotherTokenId',
-              isPublished: true,
-              isApproved: true,
-              contents: {
-                'file.ext': 'QmB_new'
-              },
-              name: 'pepito',
-              description: 'pepito hat very nice',
-              data: {
-                category: WearableCategory.HAT,
-                replaces: [],
-                hides: [],
-                representations: [],
-                tags: []
+            }
+          },
+          Qm2: {
+            content: [
+              {
+                hash: 'QmB',
+                file: 'file.ext'
               }
-            },
-            '3': {
-              id: '3',
-              collectionId: '3',
-              tokenId: 'yetAnotherDifferentTokenId',
-              isPublished: true,
-              isApproved: true,
-              contents: {
-                'file.ext': 'QmC_new'
-              },
+            ],
+            metadata: {
+              id: 'urn:decentraland:matic:collections-v2:yetAnotherAddress:yetAnotherTokenId',
               name: 'pepito',
               description: 'pepito hat very nice',
-              data: {
-                category: WearableCategory.HAT,
-                replaces: [],
-                hides: [],
-                representations: [],
-                tags: []
-              }
-            },
-            '4': {
-              id: '4',
-              collectionId: '4',
-              tokenId: 'yetAnotherDifferentTokenId',
-              isPublished: false,
-              isApproved: false,
-              contents: {
-                'file.ext': 'QmC_new'
-              },
-              name: 'pepito',
-              description: 'pepito hat very nice',
-              urn: 'urn:decentraland:mumbai:collections-thirdparty:thirdparty2:the-real-deal', // TP
-              data: {
-                category: WearableCategory.HAT,
-                replaces: [],
-                hides: [],
-                representations: [],
-                tags: []
-              }
-            },
-            '5': {
-              id: '5',
-              collectionId: '4',
-              tokenId: 'yetAnotherDifferentTokenId',
-              isPublished: true,
-              isApproved: true,
-              contents: {
-                'file.ext': 'QmC_new'
-              },
-              name: 'pepito',
-              description: 'pepito hat very nice',
-              urn: 'urn:decentraland:mumbai:collections-thirdparty:thirdparty2:the-real-deal', // TP
-              data: {
-                category: WearableCategory.HAT,
-                replaces: [],
-                hides: [],
-                representations: [],
-                tags: []
-              }
-            },
-            '6': {
-              id: '6',
-              collectionId: '4',
-              tokenId: 'TPTokenId',
-              isPublished: true,
-              isApproved: true,
-              contents: {
-                'file.ext': 'QmC_new'
-              },
-              name: 'pepito',
-              description: 'pepito hat very nice',
-              urn: 'urn:decentraland:mumbai:collections-thirdparty:thirdparty2:the-real-deal', // TP
-              data: {
-                category: WearableCategory.HAT,
-                replaces: [],
-                hides: [],
-                representations: [],
-                tags: []
-              }
-            },
-            '7': {
-              id: '7',
-              collectionId: '4',
-              tokenId: 'anotherDifferentTPTokenId',
-              isPublished: true,
-              isApproved: true,
-              contents: {
-                'file.ext': 'QmC_new'
-              },
-              name: 'pepito',
-              description: 'pepito hat very nice',
-              urn: 'urn:decentraland:mumbai:collections-thirdparty:thirdparty2:the-real-deal', // TP
-              data: {
-                category: WearableCategory.HAT,
-                replaces: [],
-                hides: [],
-                representations: [],
-                tags: []
-              }
-            },
-            '8': {
-              id: '8',
-              collectionId: '4',
-              tokenId: 'yetAnotherDifferentTPTokenId',
-              isPublished: true,
-              isApproved: true,
-              contents: {
-                'file.ext': 'QmC_new'
-              },
-              name: 'pepito',
-              description: 'pepito hat very nice',
-              urn: 'urn:decentraland:mumbai:collections-thirdparty:thirdparty2:the-real-deal', // TP
               data: {
                 category: WearableCategory.HAT,
                 replaces: [],
@@ -359,137 +426,71 @@ describe('Item selectors', () => {
                 tags: []
               }
             }
-          }
-        },
-        collection: {
-          data: {
-            '0': {
-              id: '0',
-              contractAddress: 'anAddress'
-            },
-            '1': {
-              id: '1',
-              contractAddress: 'anotherAddress'
-            },
-            '2': {
-              id: '2',
-              contractAddress: 'yetAnotherAddress'
-            },
-            '3': {
-              id: '3',
-              contractAddress: 'yetAnotherDifferentAddress'
-            },
-            '4': {
-              id: '4',
-              contractAddress: 'TPAddress'
+          },
+          Qm3: {
+            content: [
+              {
+                hash: 'QmC',
+                file: 'file.ext'
+              }
+            ],
+            metadata: {
+              id: 'urn:decentraland:matic:collections-v2:yetAnotherDifferentAddress:yetAnotherDifferentTokenId',
+              name: 'pepito',
+              description: 'pepito hat very nice',
+              data: {
+                category: WearableCategory.HAT,
+                replaces: [],
+                hides: [],
+                representations: [],
+                tags: []
+              }
             }
-          }
-        },
-        entity: {
-          data: {
-            Qm1: {
-              content: [
-                {
-                  hash: 'QmA',
-                  file: 'file.ext'
-                }
-              ],
-              metadata: {
-                id: 'urn:decentraland:matic:collections-v2:anotherAddress:anotherTokenId',
-                name: 'pepito',
-                description: 'yes it is a pepito',
-                data: {
-                  category: WearableCategory.HAT,
-                  replaces: [],
-                  hides: [],
-                  representations: [],
-                  tags: []
-                }
+          },
+          Qm4: {
+            content: [
+              {
+                hash: 'QmC',
+                file: 'file.ext'
               }
-            },
-            Qm2: {
-              content: [
-                {
-                  hash: 'QmB',
-                  file: 'file.ext'
-                }
-              ],
-              metadata: {
-                id: 'urn:decentraland:matic:collections-v2:yetAnotherAddress:yetAnotherTokenId',
-                name: 'pepito',
-                description: 'pepito hat very nice',
-                data: {
-                  category: WearableCategory.HAT,
-                  replaces: [],
-                  hides: [],
-                  representations: [],
-                  tags: []
-                }
+            ],
+            metadata: {
+              id: 'urn:decentraland:matic:collections-v2:TPAddress:anotherDifferentTPTokenId',
+              name: 'pepito',
+              description: 'pepito hat very nice',
+              data: {
+                category: WearableCategory.HAT,
+                replaces: [],
+                hides: [],
+                representations: [],
+                tags: []
               }
-            },
-            Qm3: {
-              content: [
-                {
-                  hash: 'QmC',
-                  file: 'file.ext'
-                }
-              ],
-              metadata: {
-                id: 'urn:decentraland:matic:collections-v2:yetAnotherDifferentAddress:yetAnotherDifferentTokenId',
-                name: 'pepito',
-                description: 'pepito hat very nice',
-                data: {
-                  category: WearableCategory.HAT,
-                  replaces: [],
-                  hides: [],
-                  representations: [],
-                  tags: []
-                }
+            }
+          },
+          Qm5: {
+            content: [
+              {
+                hash: 'QmC_new',
+                file: 'file.ext'
               }
-            },
-            Qm4: {
-              content: [
-                {
-                  hash: 'QmC',
-                  file: 'file.ext'
-                }
-              ],
-              metadata: {
-                id: 'urn:decentraland:matic:collections-v2:TPAddress:anotherDifferentTPTokenId',
-                name: 'pepito',
-                description: 'pepito hat very nice',
-                data: {
-                  category: WearableCategory.HAT,
-                  replaces: [],
-                  hides: [],
-                  representations: [],
-                  tags: []
-                }
-              }
-            },
-            Qm5: {
-              content: [
-                {
-                  hash: 'QmC_new',
-                  file: 'file.ext'
-                }
-              ],
-              metadata: {
-                id: 'urn:decentraland:matic:collections-v2:TPAddress:yetAnotherDifferentTPTokenId',
-                name: 'pepito',
-                description: 'pepito hat very nice',
-                data: {
-                  category: WearableCategory.HAT,
-                  replaces: [],
-                  hides: [],
-                  representations: [],
-                  tags: []
-                }
+            ],
+            metadata: {
+              id: 'urn:decentraland:matic:collections-v2:TPAddress:yetAnotherDifferentTPTokenId',
+              name: 'pepito',
+              description: 'pepito hat very nice',
+              data: {
+                category: WearableCategory.HAT,
+                replaces: [],
+                hides: [],
+                representations: [],
+                tags: []
               }
             }
           }
         }
       }
+    }
+    it('should return the status by id for each published item', () => {
       expect(getStatusByItemId((mockState as unknown) as RootState)).toEqual({
         '0': SyncStatus.UNDER_REVIEW,
         '1': SyncStatus.SYNCED,
@@ -500,6 +501,14 @@ describe('Item selectors', () => {
         '6': SyncStatus.LOADING, // TP with item curation in APPROVED and no Entity,
         '7': SyncStatus.UNSYNCED, // TP with item curation in APPROVED with entity but NOT synced,
         '8': SyncStatus.SYNCED // TP with item curation in APPROVED with entity and synced,
+      })
+    })
+    it('should return the status by id for a list of item Ids', () => {
+      expect(getStatusForItemIds((mockState as unknown) as RootState, ['2', '4', '6', '7'])).toEqual({
+        '2': SyncStatus.UNSYNCED,
+        '4': SyncStatus.UNPUBLISHED,
+        '6': SyncStatus.LOADING,
+        '7': SyncStatus.UNSYNCED
       })
     })
   })

--- a/src/modules/item/selectors.ts
+++ b/src/modules/item/selectors.ts
@@ -153,6 +153,23 @@ export const getStatusByItemId = createSelector<
   }
 )
 
+export const getStatusForItemIds = createSelector<
+  RootState,
+  Item['id'][],
+  Item['id'][],
+  Record<string, SyncStatus>,
+  Record<string, SyncStatus>
+>(
+  (_state: RootState, itemIds: Item['id'][]) => itemIds,
+  getStatusByItemId,
+  (itemIds, statusByItemId) => {
+    return itemIds.reduce((acc, currItemId) => {
+      acc[currItemId] = statusByItemId[currItemId]
+      return acc
+    }, {} as Record<string, SyncStatus>)
+  }
+)
+
 export const isDownloading = (state: RootState) => isLoadingType(getLoading(state), DOWNLOAD_ITEM_REQUEST)
 
 export const hasViewAndEditRights = (state: RootState, address: string, collection: Collection | null, item: Item): boolean => {

--- a/src/modules/item/utils.ts
+++ b/src/modules/item/utils.ts
@@ -408,6 +408,10 @@ export function areSynced(item: Item, entity: Entity) {
   return true
 }
 
+export function isStatusAllowedToPushChanges(status: SyncStatus) {
+  return [SyncStatus.UNDER_REVIEW, SyncStatus.UNSYNCED, SyncStatus.SYNCED].includes(status)
+}
+
 export function buildZipContents(contents: Record<string, Blob | string>, areEqual: boolean) {
   const newContents: Record<string, Blob | string> = {}
   const paths = Object.keys(contents)

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -1023,7 +1023,10 @@
     "start_adding_items": "Looking good! Start adding items to your new collection",
     "cant_remove": "You will not be able to add or remove items after publishing them.",
     "publish_items": "Publish {count, plural, =0 {} one {# item} other {# items}}",
-    "new_items": "New Items"
+    "new_items": "New Items",
+    "publish": "Publish",
+    "push_changes": "Push changes",
+    "publish_and_push_changes": "Publish & push changes"
   },
   "collection_detail_page": {
     "new_item": "New Item",
@@ -1124,7 +1127,9 @@
   },
   "publish_third_party_collection_modal": {
     "title": "Publish Third Party Items",
-    "description": "About to use {slotsToUse, plural, one {# slot} other {# slots}} slots from {availableSlots} to publish \"{collectionName}\""
+    "publish_description": "About to use {slotsToUse, plural, one {# slot} other {# slots}} from {availableSlots} available slots to publish \"{collectionName}\".",
+    "push_changes_description": "About to push changes to {itemsWithChanges, plural, one {# item} other {# items}} for \"{collectionName}\".",
+    "publish_and_push_changes_description": "About to use {slotsToUse, plural, one {# slot} other {# slots}} from {availableSlots} available slots to publish \"{collectionName}\" and changes will be pushed to {itemsWithChanges, plural, one {# item} other {# items}}."
   },
   "mint_items_modal": {
     "title": "Mint Items",

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -256,10 +256,10 @@
     "title": "Slots",
     "description_line_one": "Compra slots para publicar tus items!",
     "description_line_two": "Por favor selecciona cuántos quieres comprar.",
-    "not_enough_mana": "No tienes suficiente {symbol} para comprar esa cantidad de espacios.",
+    "not_enough_mana": "No tienes suficiente {symbol} para comprar esa cantidad de slots.",
     "get_mana": "Puedes conseguir más utilizando la {link} dapp.",
     "buy_slots": "Comprar espacio",
-    "how_many_slots_title": "Cuántos espacios?",
+    "how_many_slots_title": "Cuántos slots?",
     "slots_value": "El costo aproximado de cada espacio es {symbol}{slot_cost}"
   },
   "share_modal": {
@@ -905,7 +905,7 @@
     "disallowed_claim_mana": "No permitió el uso de MANA para reclamar un nuevo nombre",
     "claim_name": "Haz reclamado el nombre: \"{name}\".",
     "publish_third_party_items": "Has publicado {count, plural, one {# item} other {# items}} para {collectionName}",
-    "buy_third_party_item_slots": "Has comprado {count} {count, plural, one {espacio} other {espacios}} para el registro externo \"{name}\"",
+    "buy_third_party_item_slots": "Has comprado {count} {count, plural, one {slot} other {slots}} para el registro externo \"{name}\"",
     "rescue_items": "Has aprobado el contenido de {count} {count, plural, one {item} other {items}} para la collección {collectionName}"
   },
   "transfer_page": {
@@ -1033,7 +1033,10 @@
     "start_adding_items": "¡Se ve bien! Ahora puedes comenzar a agregar items a tu colección.",
     "cant_remove": "No podrás agregar o remover items una vez que estén publicados.",
     "publish_items": "Publicar {count, plural, =0 {} one {# item} other {# items}}",
-    "new_items": "Nuevos items"
+    "new_items": "Nuevos items",
+    "publish": "Publicar",
+    "push_changes": "Subir cambios",
+    "publish_and_push_changes": "Publicar y subir cambios"
   },
   "collection_detail_page": {
     "new_item": "Nuevo Item",
@@ -1142,7 +1145,9 @@
   },
   "publish_third_party_collection_modal": {
     "title": "Publicar Items externos",
-    "description": "Está por usar {slotsToUse, plural, one {# slot} other {# slots}} de {availableSlots} disponibles para publicar \"{collectionName}\""
+    "publish_description": "Está por usar {slotsToUse, plural, one {# slot} other {# slots}} de {availableSlots} slots disponibles para publicar \"{collectionName}\"",
+    "push_changes_description": "Está por subir cambios a {itemsWithChanges, plural, one {# item} other {# items}} for \"{collectionName}\".",
+    "publish_and_push_changes_description": "Está por usar {slotsToUse, plural, one {# slot} other {# slots}} slots de {availableSlots} disponibles para publicar \"{collectionName}\" y subir cambios a {itemsWithChanges, plural, one {# item} other {# items}}."
   },
   "mint_items_modal": {
     "title": "Crear Items",

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -1014,7 +1014,10 @@
     "start_adding_items": "看起来不错！ 现在您可以开始将项目添加到您的收藏中了。",
     "cant_remove": "发布项目后，您将无法添加或删除项目。",
     "publish_items": "发布 {count, plural, =0 {} other {# 项}}",
-    "new_items": "新的可穿戴物品"
+    "new_items": "新的可穿戴物品",
+    "publish": "发布",
+    "push_changes": "推送更改",
+    "publish_and_push_changes": "发布和推送更改"
   },
   "collection_detail_page": {
     "new_item": "新物品",
@@ -1145,7 +1148,9 @@
   },
   "publish_third_party_collection_modal": {
     "title": "发布第三方项目",
-    "description": "即将使用来自 {availableSlots} 的 {slotsToUse, plural, one {# 投币口} other {# 插槽}} 个插槽来发布 \"{collectionName}\""
+    "publish_description": "即将使用 {availableSlots} 个可用插槽中的 {slotsToUse，复数，一个 {# slot} 其他 {# slot}} 来发布 \"{collectionName}\"。",
+    "push_changes_description": "即将对 \"{collectionName}\" 推送对 {itemsWithChanges, 复数，一个 {# item} 其他 {# items}} 的更改。",
+    "publish_and_push_changes_description": "即将使用 {slotsToUse，复数，一个 {# slot} 其他 {# slot}} 来自 {availableSlots} 可用插槽来发布 \"{collectionName}\"，并且更改将被推送到 {itemsWithChanges，复数，一个 {# item}其他项目}}。"
   },
   "mint_items_modal": {
     "title": "薄荷项目",


### PR DESCRIPTION
* feat: Make the TP items updatable after being published

* chore: fix broken test

* feat: Add onPushChanges prop to TP publish modal

* feat: Add getStatusForItemIds selector

* feat: Add onPublishAndPushChanges prop

* chore: update broken test

* feat: Add logic to PublishTPCollectionModal to support different actions

* chore: move import to right place

* chore: fixes translation

* feat: Remove DCL logic from TP button

* chore: Remove old TODO

* feat: Update translations

* feat: Add isStatusAllowedToPushChanges util method