### PR TITLE
fix: Don't request all items at once

### DIFF
--- a/src/components/CollectionImage/CollectionImage.container.ts
+++ b/src/components/CollectionImage/CollectionImage.container.ts
@@ -4,7 +4,7 @@ import { RootState } from 'modules/common/types'
 import { getCollectionItems, getLoading as getLoadingItem } from 'modules/item/selectors'
 import { getLoading as getLoadingCollection } from 'modules/collection/selectors'
 import { FETCH_COLLECTIONS_REQUEST } from 'modules/collection/actions'
-import { FETCH_ITEMS_REQUEST } from 'modules/item/actions'
+import { FETCH_COLLECTION_ITEMS_REQUEST, FETCH_ITEMS_REQUEST } from 'modules/item/actions'
 import { OwnProps, MapStateProps } from './CollectionImage.types'
 import CollectionImage from './CollectionImage'
 
@@ -14,7 +14,9 @@ const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
   return {
     items,
     isLoading:
-      isLoadingType(getLoadingCollection(state), FETCH_COLLECTIONS_REQUEST) || isLoadingType(getLoadingItem(state), FETCH_ITEMS_REQUEST)
+      isLoadingType(getLoadingCollection(state), FETCH_COLLECTIONS_REQUEST) ||
+      isLoadingType(getLoadingItem(state), FETCH_ITEMS_REQUEST) ||
+      isLoadingType(getLoadingItem(state), FETCH_COLLECTION_ITEMS_REQUEST)
   }
 }
 

--- a/src/components/CollectionImage/CollectionImage.css
+++ b/src/components/CollectionImage/CollectionImage.css
@@ -4,6 +4,13 @@
   align-items: center;
 }
 
+.CollectionImage .item-row.loading {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
+}
+
 .CollectionImage .item-row.empty {
   display: flex;
   flex-direction: column;

--- a/src/components/CollectionImage/CollectionImage.tsx
+++ b/src/components/CollectionImage/CollectionImage.tsx
@@ -21,7 +21,9 @@ export default class CollectionImage extends React.PureComponent<Props> {
     return (
       <div className="CollectionImage is-image">
         {isLoading ? (
-          <Loader active size="tiny" />
+          <div className='item-row loading'>
+            <Loader active size="tiny" inline />
+          </div>
         ) : items.length === 0 ? (
           <div className="item-row empty">
             <div className="sparkles" />

--- a/src/components/CurationPage/CollectionRow/CollectionRow.container.ts
+++ b/src/components/CurationPage/CollectionRow/CollectionRow.container.ts
@@ -2,6 +2,7 @@ import { connect } from 'react-redux'
 import { push } from 'connected-react-router'
 import { RootState } from 'modules/common/types'
 import { getCollectionItems } from 'modules/item/selectors'
+import { fetchCollectionItemsRequest } from 'modules/item/actions'
 import { OwnProps, MapStateProps, MapDispatchProps, MapDispatch } from './CollectionRow.types'
 import CollectionRow from './CollectionRow'
 
@@ -10,6 +11,7 @@ const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => ({
 })
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
+  onFetchCollectionItems: collectionId => dispatch(fetchCollectionItemsRequest(collectionId)),
   onNavigate: path => dispatch(push(path))
 })
 

--- a/src/components/CurationPage/CollectionRow/CollectionRow.tsx
+++ b/src/components/CurationPage/CollectionRow/CollectionRow.tsx
@@ -14,6 +14,11 @@ import { Props } from './CollectionRow.types'
 import './CollectionRow.css'
 
 export default class CollectionRow extends React.PureComponent<Props> {
+  componentDidMount = () => {
+    const { collection, onFetchCollectionItems } = this.props
+    onFetchCollectionItems(collection.id)
+  }
+
   handleNavigateToForum = (event: React.MouseEvent<HTMLSpanElement, MouseEvent>) => {
     const { collection } = this.props
     window.open(collection.forumLink!, '_blank')

--- a/src/components/CurationPage/CollectionRow/CollectionRow.tsx
+++ b/src/components/CurationPage/CollectionRow/CollectionRow.tsx
@@ -15,8 +15,14 @@ import './CollectionRow.css'
 
 export default class CollectionRow extends React.PureComponent<Props> {
   componentDidMount = () => {
-    const { collection, onFetchCollectionItems } = this.props
-    onFetchCollectionItems(collection.id)
+    const { collection, items, onFetchCollectionItems } = this.props
+    // Only refetch when the collection has no items in store
+    // This way we avoid fetching data too many times
+    // Beware that as data is not refreshed, new changes done by another user
+    // will not be seen and a manual browser refresh will be required.
+    if (items.length === 0) {
+      onFetchCollectionItems(collection.id)
+    }
   }
 
   handleNavigateToForum = (event: React.MouseEvent<HTMLSpanElement, MouseEvent>) => {

--- a/src/components/CurationPage/CollectionRow/CollectionRow.types.ts
+++ b/src/components/CurationPage/CollectionRow/CollectionRow.types.ts
@@ -8,9 +8,10 @@ export type Props = {
   curation: CollectionCuration | null
   items: Item[]
   onNavigate: (path: string) => void
+  onFetchCollectionItems: (collectionId: string) => void
 }
 
 export type MapStateProps = Pick<Props, 'items'>
-export type MapDispatchProps = Pick<Props, 'onNavigate'>
+export type MapDispatchProps = Pick<Props, 'onNavigate' | 'onFetchCollectionItems'>
 export type MapDispatch = Dispatch
 export type OwnProps = Pick<Props, 'collection' | 'curation'>

--- a/src/components/CurationPage/CurationPage.css
+++ b/src/components/CurationPage/CurationPage.css
@@ -9,3 +9,9 @@
 .CurationPage .filters .text-filter-row {
   width: 100%;
 }
+
+.CurationPage .pagination {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}

--- a/src/components/CurationPage/CurationPage.tsx
+++ b/src/components/CurationPage/CurationPage.tsx
@@ -172,15 +172,14 @@ export default class CurationPage extends React.PureComponent<Props, State> {
             </Table>
           </Section>
           {totalPages > 1 && (
-            <div className="pagination">
-              <Pagination
-                firstItem={null}
-                lastItem={null}
-                totalPages={totalPages}
-                activePage={page}
-                onPageChange={(_event, props) => this.setState({ page: +props.activePage! })}
-              />
-            </div>
+            <Pagination
+              className="pagination"
+              firstItem={null}
+              lastItem={null}
+              totalPages={totalPages}
+              activePage={page}
+              onPageChange={(_event, props) => this.setState({ page: +props.activePage! })}
+            />
           )}
         </Container>
       </>

--- a/src/components/CurationPage/CurationPage.tsx
+++ b/src/components/CurationPage/CurationPage.tsx
@@ -158,8 +158,8 @@ export default class CurationPage extends React.PureComponent<Props, State> {
 
               <Table.Body>
                 {collections.length > 0 ? (
-                  paginatedCollections.map((collection, index) => (
-                    <CollectionRow key={index} collection={collection} curation={curationsByCollectionId[collection.id] || null} />
+                  paginatedCollections.map((collection) => (
+                    <CollectionRow key={collection.id} collection={collection} curation={curationsByCollectionId[collection.id] || null} />
                   ))
                 ) : (
                   <Empty height={200}>

--- a/src/components/CurationPage/CurationPage.tsx
+++ b/src/components/CurationPage/CurationPage.tsx
@@ -158,7 +158,7 @@ export default class CurationPage extends React.PureComponent<Props, State> {
 
               <Table.Body>
                 {collections.length > 0 ? (
-                  paginatedCollections.map((collection) => (
+                  paginatedCollections.map(collection => (
                     <CollectionRow key={collection.id} collection={collection} curation={curationsByCollectionId[collection.id] || null} />
                   ))
                 ) : (
@@ -172,13 +172,15 @@ export default class CurationPage extends React.PureComponent<Props, State> {
             </Table>
           </Section>
           {totalPages > 1 && (
-            <Pagination
-              firstItem={null}
-              lastItem={null}
-              totalPages={totalPages}
-              activePage={page}
-              onPageChange={(_event, props) => this.setState({ page: +props.activePage! })}
-            />
+            <div className="pagination">
+              <Pagination
+                firstItem={null}
+                lastItem={null}
+                totalPages={totalPages}
+                activePage={page}
+                onPageChange={(_event, props) => this.setState({ page: +props.activePage! })}
+              />
+            </div>
           )}
         </Container>
       </>

--- a/src/modules/collection/sagas.spec.ts
+++ b/src/modules/collection/sagas.spec.ts
@@ -15,7 +15,12 @@ import { buildItemEntity } from 'modules/item/export'
 import { getEntityByItemId, getItems, getData as getItemsById } from 'modules/item/selectors'
 import { Item, WearableCategory } from 'modules/item/types'
 import { openModal, closeModal } from 'modules/modal/actions'
-import { fetchItemsRequest, fetchItemsSuccess, rescueItemsFailure, rescueItemsSuccess } from 'modules/item/actions'
+import {
+  fetchCollectionItemsRequest,
+  fetchCollectionItemsSuccess,
+  rescueItemsFailure,
+  rescueItemsSuccess
+} from 'modules/item/actions'
 import { deployEntitiesFailure, deployEntitiesSuccess } from 'modules/entity/actions'
 import {
   approveCollectionCurationFailure,
@@ -162,8 +167,8 @@ describe('when executing the approval flow', () => {
           } as ApprovalFlowModalMetadata)
         )
         .dispatch(rescueItemsSuccess(collection, [updatedItem], [updatedItem.blockchainContentHash!], ChainId.MATIC_MAINNET, ['0xhash']))
-        .put(fetchItemsRequest())
-        .dispatch(fetchItemsSuccess([syncedItem, updatedItem]))
+        .put(fetchCollectionItemsRequest(collection.id))
+        .dispatch(fetchCollectionItemsSuccess(collection.id, [syncedItem, updatedItem]))
         .put(
           openModal('ApprovalFlowModal', {
             view: ApprovalFlowModalView.DEPLOY,
@@ -234,8 +239,8 @@ describe('when executing the approval flow', () => {
           } as ApprovalFlowModalMetadata)
         )
         .dispatch(rescueItemsSuccess(collection, [updatedItem], [updatedItem.blockchainContentHash!], ChainId.MATIC_MAINNET, ['0xhash']))
-        .put(fetchItemsRequest())
-        .dispatch(fetchItemsSuccess([syncedItem, updatedItem]))
+        .put(fetchCollectionItemsRequest(collection.id))
+        .dispatch(fetchCollectionItemsSuccess(collection.id, [syncedItem, updatedItem]))
         .put(
           openModal('ApprovalFlowModal', {
             view: ApprovalFlowModalView.DEPLOY,
@@ -385,8 +390,8 @@ describe('when executing the approval flow', () => {
           } as ApprovalFlowModalMetadata)
         )
         .dispatch(rescueItemsSuccess(collection, [updatedItem], [updatedItem.blockchainContentHash!], ChainId.MATIC_MAINNET, ['0xhash']))
-        .put(fetchItemsRequest())
-        .dispatch(fetchItemsSuccess([syncedItem, updatedItem]))
+        .put(fetchCollectionItemsRequest(collection.id))
+        .dispatch(fetchCollectionItemsSuccess(collection.id, [syncedItem, updatedItem]))
         .put(
           openModal('ApprovalFlowModal', {
             view: ApprovalFlowModalView.DEPLOY,
@@ -450,8 +455,8 @@ describe('when executing the approval flow', () => {
           } as ApprovalFlowModalMetadata)
         )
         .dispatch(rescueItemsSuccess(collection, [updatedItem], [updatedItem.blockchainContentHash!], ChainId.MATIC_MAINNET, ['0xhash']))
-        .put(fetchItemsRequest())
-        .dispatch(fetchItemsSuccess([syncedItem, updatedItem]))
+        .put(fetchCollectionItemsRequest(collection.id))
+        .dispatch(fetchCollectionItemsSuccess(collection.id, [syncedItem, updatedItem]))
         .put(
           openModal('ApprovalFlowModal', {
             view: ApprovalFlowModalView.DEPLOY,
@@ -525,8 +530,8 @@ describe('when executing the approval flow', () => {
           } as ApprovalFlowModalMetadata)
         )
         .dispatch(rescueItemsSuccess(collection, [updatedItem], [updatedItem.blockchainContentHash!], ChainId.MATIC_MAINNET, ['0xhash']))
-        .put(fetchItemsRequest())
-        .dispatch(fetchItemsSuccess([syncedItem, updatedItem]))
+        .put(fetchCollectionItemsRequest(collection.id))
+        .dispatch(fetchCollectionItemsSuccess(collection.id, [syncedItem, updatedItem]))
         .put(
           openModal('ApprovalFlowModal', {
             view: ApprovalFlowModalView.DEPLOY,

--- a/src/modules/collection/sagas.ts
+++ b/src/modules/collection/sagas.ts
@@ -715,7 +715,7 @@ export function* collectionSaga(builder: BuilderAPI, catalyst: CatalystClient) {
     const itemIds = items.map(item => item.id)
     while (!isIndexed) {
       yield delay(1000)
-      yield put(fetchItemsRequest())
+      yield put(fetchItemsRequest({ itemIds: items.map(i => i.id) }))
       yield race({
         success: take(FETCH_ITEMS_SUCCESS),
         failure: take(FETCH_ITEMS_FAILURE)

--- a/src/modules/committee/sagas.ts
+++ b/src/modules/committee/sagas.ts
@@ -2,7 +2,6 @@ import { call, put, select, takeEvery, takeLatest } from 'redux-saga/effects'
 import { CONNECT_WALLET_SUCCESS } from 'decentraland-dapps/dist/modules/wallet/actions'
 import { BuilderAPI } from 'lib/api/builder'
 import { fetchCollectionsRequest } from 'modules/collection/actions'
-import { fetchItemsRequest } from 'modules/item/actions'
 import {
   fetchCommitteeMembersRequest,
   fetchCommitteeMembersFailure,
@@ -33,7 +32,6 @@ function* handleFetchCommitteeMembersSuccess() {
   const isCommitteeMember: boolean = yield select(isWalletCommitteeMember)
   if (isCommitteeMember) {
     yield put(fetchCollectionsRequest())
-    yield put(fetchItemsRequest())
   }
 }
 

--- a/src/modules/item/actions.ts
+++ b/src/modules/item/actions.ts
@@ -10,7 +10,8 @@ export const FETCH_ITEMS_REQUEST = '[Request] Fetch Items'
 export const FETCH_ITEMS_SUCCESS = '[Success] Fetch Items'
 export const FETCH_ITEMS_FAILURE = '[Failure] Fetch Items'
 
-export const fetchItemsRequest = (address?: string) => action(FETCH_ITEMS_REQUEST, { address })
+export const fetchItemsRequest = ({ address, itemIds }: { address?: string; itemIds?: string[] } = {}) =>
+  action(FETCH_ITEMS_REQUEST, { address, itemIds })
 export const fetchItemsSuccess = (items: Item[]) => action(FETCH_ITEMS_SUCCESS, { items })
 export const fetchItemsFailure = (error: string) => action(FETCH_ITEMS_FAILURE, { error })
 

--- a/src/modules/item/actions.ts
+++ b/src/modules/item/actions.ts
@@ -10,8 +10,7 @@ export const FETCH_ITEMS_REQUEST = '[Request] Fetch Items'
 export const FETCH_ITEMS_SUCCESS = '[Success] Fetch Items'
 export const FETCH_ITEMS_FAILURE = '[Failure] Fetch Items'
 
-export const fetchItemsRequest = ({ address, itemIds }: { address?: string; itemIds?: string[] } = {}) =>
-  action(FETCH_ITEMS_REQUEST, { address, itemIds })
+export const fetchItemsRequest = (address?: string) => action(FETCH_ITEMS_REQUEST, { address })
 export const fetchItemsSuccess = (items: Item[]) => action(FETCH_ITEMS_SUCCESS, { items })
 export const fetchItemsFailure = (error: string) => action(FETCH_ITEMS_FAILURE, { error })
 

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -137,9 +137,16 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
   }
 
   function* handleFetchItemsRequest(action: FetchItemsRequestAction) {
-    const { address } = action.payload
+    const { address, itemIds } = action.payload
     try {
-      const items: Item[] = yield call(() => legacyBuilder.fetchItems(address))
+      let items: Item[]
+
+      if (itemIds) {
+        items = yield call([Promise, 'all'], [itemIds.map(id => legacyBuilder.fetchItem(id))])
+      } else {
+        items = yield call([legacyBuilder, 'fetchItems'], address)
+      }
+
       yield put(fetchItemsSuccess(items))
     } catch (error) {
       yield put(fetchItemsFailure(error.message))
@@ -288,7 +295,7 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
 
   function* handleLoginSuccess(action: LoginSuccessAction) {
     const { wallet } = action.payload
-    yield put(fetchItemsRequest(wallet.address))
+    yield put(fetchItemsRequest({ address: wallet.address }))
   }
 
   function* handleSetCollection(action: SetCollectionAction) {


### PR DESCRIPTION
Absolutely every item is being requested when opening the curation page and approving a collection.
Now only required items for the moment are fetched.