### PR TITLE
fix: Add safe operator to access item curations

### DIFF
--- a/src/components/ThirdPartyCollectionDetailPage/CollectionPublishButton/CollectionPublishButton.tsx
+++ b/src/components/ThirdPartyCollectionDetailPage/CollectionPublishButton/CollectionPublishButton.tsx
@@ -61,7 +61,7 @@ const CollectionPublishButton = (props: Props) => {
   }, [collection, items, buttonAction])
 
   const itemsTryingToPublish = useMemo(
-    () => items.filter(item => !itemCurations.find(itemCuration => itemCuration.itemId === item.id)).length,
+    () => items.filter(item => !itemCurations?.find(itemCuration => itemCuration.itemId === item.id)).length,
     [items, itemCurations]
   )
 


### PR DESCRIPTION
## Description

The server is returning a 409 so `itemCurations`  is `undefined` instead of an array. This might be a temporary solution, we need to define if the server is returning the proper respose.
<img width="973" alt="image" src="https://user-images.githubusercontent.com/8763687/158990752-c1f550bb-57c8-4fb2-b6fa-1bddb73b2bb6.png">

Closes #1868