### PR TITLE
feat: support creation of emotes

### DIFF
--- a/src/components/CollectionDetailPage/CollectionItem/CollectionItem.tsx
+++ b/src/components/CollectionDetailPage/CollectionItem/CollectionItem.tsx
@@ -85,7 +85,7 @@ export default class CollectionItem extends React.PureComponent<Props> {
             <Grid.Column className={styles.column}>
               {data.category ? (
                 <>
-                  <div>{t(`wearable.category.${data.category}`)}</div>
+                  <div>{t(`${item.type}.category.${data.category}`)}</div>
                   <div className={styles.subtitle}>{t('item.category')}</div>
                 </>
               ) : null}

--- a/src/components/ItemDetailPage/ItemDetailPage.tsx
+++ b/src/components/ItemDetailPage/ItemDetailPage.tsx
@@ -131,7 +131,7 @@ export default class ItemDetailPage extends React.PureComponent<Props> {
               {data.category ? (
                 <Section>
                   <div className="subtitle">{t('item.category')}</div>
-                  <div className="value">{t(`wearable.category.${data.category}`)}</div>
+                  <div className="value">{t(`${item.type}.category.${data.category}`)}</div>
                 </Section>
               ) : null}
               <Section>

--- a/src/components/Modals/ApprovalFlowModal/ApprovalFlowModal.tsx
+++ b/src/components/Modals/ApprovalFlowModal/ApprovalFlowModal.tsx
@@ -92,7 +92,7 @@ export default class ApprovalFlowModal extends React.PureComponent<Props> {
                     <ItemImage item={item} />
                     {item.name}
                   </Table.Cell>
-                  <Table.Cell>{t('wearable.category.' + item.data.category)}</Table.Cell>
+                  <Table.Cell>{t(`${item.type}.category.${item.data.category}`)}</Table.Cell>
                   <Table.Cell>
                     {getBodyShapes(item)
                       .map(bodyShape => t(`body_shapes.${toBodyShapeType(bodyShape)}`))

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.css
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.css
@@ -14,6 +14,16 @@
 
 .CreateSingleItemModal .preview .thumbnail-container {
   position: relative;
+  width: 100%;
+}
+
+.CreateSingleItemModal .preview .thumbnail-container .emote-thumbnail {
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .CreateSingleItemModal .preview .thumbnail-container .thumbnail {

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
@@ -760,7 +760,7 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
 
   renderDetailsView() {
     const { onClose, metadata, error, isLoading } = this.props
-    const { thumbnail, metrics, bodyShape, isRepresentation, item, rarity, type } = this.state
+    const { thumbnail, metrics, bodyShape, isRepresentation, item, rarity } = this.state
 
     const isDisabled = this.isDisabled()
     const isAddingRepresentation = this.isAddingRepresentation()
@@ -776,7 +776,6 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
               <Row className="details">
                 <Column className="preview" width={192} grow={false}>
                   <div className="thumbnail-container">
-                    {type === ItemType.EMOTE ? <div className="emote-thumbnail">{t('global.emote')}</div> : null}
                     <img className="thumbnail" src={thumbnail || undefined} style={thumbnailStyle} />
                     {isRepresentation ? null : (
                       <>

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.types.ts
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.types.ts
@@ -3,7 +3,7 @@ import { ModalProps } from 'decentraland-dapps/dist/providers/ModalProvider/Moda
 import { ModelMetrics } from 'modules/models/types'
 import { Collection } from 'modules/collection/types'
 import { saveItemRequest, SaveItemRequestAction } from 'modules/item/actions'
-import { BodyShapeType, Item, ItemRarity, WearableCategory } from 'modules/item/types'
+import { BodyShapeType, Item, ItemRarity, ItemType } from 'modules/item/types'
 
 export enum CreateItemView {
   IMPORT = 'import',
@@ -23,7 +23,8 @@ export type StateData = {
   id: string
   name: string
   description: string
-  category: WearableCategory
+  type: ItemType
+  category: string
   rarity: ItemRarity
   bodyShape: BodyShapeType
   thumbnail: string

--- a/src/lib/getModelData.ts
+++ b/src/lib/getModelData.ts
@@ -16,7 +16,8 @@ import {
 import { basename } from 'path'
 import { GLTFLoader, GLTF } from 'three/examples/jsm/loaders/GLTFLoader'
 import { ModelMetrics } from 'modules/models/types'
-import { getScreenshot } from './getScreenshot'
+import { EMOTE_ERROR, getScreenshot } from './getScreenshot'
+import { ItemType } from 'modules/item/types'
 
 // transparent 1x1 pixel
 export const TRANSPARENT_PIXEL =
@@ -187,8 +188,8 @@ export async function getModelData(url: string, options: Partial<Options> = {}) 
     }
     const image = engine === EngineType.THREE ? renderer.domElement.toDataURL() : await getScreenshot(url, options)
 
-    return { info, image }
-  } catch (e) {
+    return { info, image, type: ItemType.WEARABLE }
+  } catch (error) {
     // could not render model, default to 0 metrics and default thumnail
     const info: ModelMetrics = {
       triangles: 0,
@@ -199,6 +200,10 @@ export async function getModelData(url: string, options: Partial<Options> = {}) 
       entities: 1
     }
     const image = TRANSPARENT_PIXEL
-    return { info, image }
+    let type = ItemType.WEARABLE
+    if (error instanceof Error && error.message === EMOTE_ERROR) {
+      type = ItemType.EMOTE
+    }
+    return { info, image, type }
   }
 }

--- a/src/lib/getScreenshot.ts
+++ b/src/lib/getScreenshot.ts
@@ -17,6 +17,8 @@ import '@babylonjs/loaders'
 import future from 'fp-future'
 import { defaults, Options, ThumbnailType } from './getModelData'
 
+export const EMOTE_ERROR = 'Model is EMOTE'
+
 function refreshBoundingInfo(parent: Mesh) {
   const children = parent.getChildren().filter(mesh => mesh.id !== '__root__')
 
@@ -71,6 +73,11 @@ export async function getScreenshot(url: string, options: Partial<Options> = {})
   const sceneResolver = (scene: Scene) => scene.onReadyObservable.addOnce(() => sceneFuture.resolve(scene))
   SceneLoader.Append(url, '', root, sceneResolver, null, null, extension)
   const scene = await sceneFuture
+
+  // check if it's emote
+  if (scene.animationGroups.length > 0) {
+    throw new Error(EMOTE_ERROR)
+  }
 
   // Setup Camera
   var camera = new TargetCamera('targetCamera', new Vector3(0, 0, 0), scene)

--- a/src/modules/item/export.ts
+++ b/src/modules/item/export.ts
@@ -8,7 +8,7 @@ import { NO_CACHE_HEADERS } from 'lib/headers'
 import { buildCatalystItemURN } from 'lib/urn'
 import { makeContentFiles, computeHashes } from 'modules/deployment/contentUtils'
 import { Collection } from 'modules/collection/types'
-import { Item, IMAGE_PATH, THUMBNAIL_PATH, TPCatalystItem, StandardCatalystItem } from './types'
+import { Item, IMAGE_PATH, THUMBNAIL_PATH, TPCatalystItem, StandardCatalystItem, ItemType, EmoteData, EmoteCategory } from './types'
 import { generateCatalystImage, generateImage } from './utils'
 
 export async function deployContents(identity: AuthIdentity, collection: Collection, item: Item) {
@@ -148,7 +148,7 @@ function buildItemEntityMetadata(collection: Collection, item: Item): StandardCa
   }
 
   // The order of the metadata properties can't be changed. Changing it will result in a different content hash.
-  return {
+  const catalystItem: StandardCatalystItem = {
     id: buildCatalystItemURN(collection.contractAddress!, item.tokenId!),
     name: item.name,
     description: item.description,
@@ -166,6 +166,14 @@ function buildItemEntityMetadata(collection: Collection, item: Item): StandardCa
     thumbnail: THUMBNAIL_PATH,
     metrics: item.metrics
   }
+
+  if (item.type === ItemType.EMOTE) {
+    catalystItem.emoteDataV0 = {
+      loop: (item.data as EmoteData).category === EmoteCategory.LOOP
+    }
+  }
+
+  return catalystItem
 }
 
 async function buildItemEntityContent(item: Item): Promise<Record<string, string>> {

--- a/src/modules/item/types.ts
+++ b/src/modules/item/types.ts
@@ -5,7 +5,8 @@ import { Cheque } from 'modules/thirdParty/types'
 export type BuiltFile<T extends Content> = BuiltItem<T> & { fileName: string }
 
 export enum ItemType {
-  WEARABLE = 'wearable'
+  WEARABLE = 'wearable',
+  EMOTE = 'emote'
 }
 
 export enum SyncStatus {
@@ -46,9 +47,15 @@ export enum WearableCategory {
   SKIN = 'skin'
 }
 
+export enum EmoteCategory {
+  SIMPLE = 'simple',
+  LOOP = 'loop'
+}
+
 export enum ItemMetadataType {
   WEARABLE = 'w',
-  SMART_WEARABLE = 'sw'
+  SMART_WEARABLE = 'sw',
+  EMOTE = 'e'
 }
 
 export const BODY_SHAPE_CATEGORY = 'body_shape'
@@ -75,6 +82,12 @@ export type WearableRepresentation = {
   contents: string[]
   overrideReplaces: WearableCategory[]
   overrideHides: WearableCategory[]
+}
+
+export type EmoteRepresentation = {
+  bodyShapes: WearableBodyShape[]
+  mainFile: string
+  contents: string[]
 }
 
 export const RARITY_COLOR_LIGHT: Record<ItemRarity, string> = {
@@ -107,6 +120,12 @@ export const RARITY_MAX_SUPPLY: Record<ItemRarity, number> = {
   [ItemRarity.COMMON]: 100000
 }
 
+export type EmoteData = {
+  category?: EmoteCategory
+  representations: WearableRepresentation[]
+  tags: string[]
+}
+
 export type WearableData = {
   category?: WearableCategory
   representations: WearableRepresentation[]
@@ -135,6 +154,7 @@ export type BaseCatalystItem = Omit<BaseItem, 'createdAt' | 'updatedAt' | 'rarit
 export type StandardCatalystItem = BaseCatalystItem &
   Pick<BaseItem, 'rarity'> & {
     collectionAddress: string
+    emoteDataV0?: { loop: boolean }
   }
 
 export type TPCatalystItem = BaseCatalystItem & { merkleProof: TPItemMerkleProof; content: Record<string, string> }
@@ -152,7 +172,7 @@ export type TPItemMerkleProof = {
   entityHash: string
 }
 
-export type Item = BaseItem & {
+export type Item<T = ItemType.WEARABLE> = BaseItem & {
   type: ItemType
   owner: string
   collectionId?: string
@@ -167,7 +187,7 @@ export type Item = BaseItem & {
   contents: Record<string, string>
   blockchainContentHash: string | null
   currentContentHash: string | null
-  data: WearableData
+  data: T extends ItemType.WEARABLE ? WearableData : EmoteData
 }
 
 export type Rarity = {

--- a/src/modules/item/utils.ts
+++ b/src/modules/item/utils.ts
@@ -33,7 +33,9 @@ import {
   ThirdPartyContractItem,
   ItemMetadataType,
   WearableRepresentation,
-  GenerateImageOptions
+  GenerateImageOptions,
+  EmoteCategory,
+  EmoteData
 } from './types'
 
 export const MAX_FILE_SIZE = 2097152 // 2MB
@@ -122,10 +124,17 @@ export function getBackgroundStyle(rarity?: ItemRarity) {
 }
 
 export function getItemMetadataType(item: Item) {
-  if (Object.keys(item.contents).some(path => path.endsWith('.js'))) {
-    return ItemMetadataType.SMART_WEARABLE
+  switch (item.type) {
+    case ItemType.WEARABLE: {
+      if (Object.keys(item.contents).some(path => path.endsWith('.js'))) {
+        return ItemMetadataType.SMART_WEARABLE
+      }
+      return ItemMetadataType.WEARABLE
+    }
+    case ItemType.EMOTE: {
+      return ItemMetadataType.EMOTE
+    }
   }
-  return ItemMetadataType.WEARABLE
 }
 
 export function buildItemMetadata(
@@ -150,6 +159,16 @@ export function getMetadata(item: Item) {
         .map(toWearableBodyShapeType)
         .join(',')
 
+      if (!data.category) {
+        throw new Error(`Unknown item category "${item.data}"`)
+      }
+      return buildItemMetadata(1, getItemMetadataType(item), item.name, item.description, data.category, bodyShapeTypes)
+    }
+    case ItemType.EMOTE: {
+      const data = item.data as EmoteData
+      const bodyShapeTypes = getBodyShapes(item)
+        .map(toWearableBodyShapeType)
+        .join(',')
       if (!data.category) {
         throw new Error(`Unknown item category "${item.data}"`)
       }
@@ -323,6 +342,10 @@ export function getWearableCategories(contents: Record<string, any> | undefined 
   return categories
 }
 
+export function getEmoteCategories() {
+  return Object.values(EmoteCategory)
+}
+
 export function getOverridesCategories(contents: Record<string, any> | undefined = {}, category?: WearableCategory) {
   const overrideCategories = getCategories(contents)
   if (category === WearableCategory.SKIN) {
@@ -389,13 +412,16 @@ export function areEqualRepresentations(a: WearableRepresentation[], b: Wearable
     const repA = a[i]
     const repB = b[i]
     const areEqual =
-      areEqualArrays(repA.bodyShapes, repB.bodyShapes) &&
-      areEqualArrays(repA.contents, repB.contents) &&
-      repA.mainFile === repB.mainFile &&
-      areEqualArrays(repA.overrideHides, repB.overrideHides) &&
-      areEqualArrays(repA.overrideReplaces, repB.overrideReplaces)
+      areEqualArrays(repA.bodyShapes, repB.bodyShapes) && areEqualArrays(repA.contents, repB.contents) && repA.mainFile === repB.mainFile
     if (!areEqual) {
       return false
+    }
+    if (repA.overrideHides && repB.overrideHides && repA.overrideReplaces && repB.overrideReplaces) {
+      const areEqualOverrides =
+        areEqualArrays(repA.overrideHides, repB.overrideHides) && areEqualArrays(repA.overrideReplaces, repB.overrideReplaces)
+      if (!areEqualOverrides) {
+        return false
+      }
     }
   }
   return true
@@ -409,12 +435,17 @@ export function areSynced(item: Item, entity: Entity) {
   // check if metadata is synced
   const catalystItem = entity.metadata! as CatalystItem
   const hasMetadataChanged =
-    item.name !== catalystItem.name ||
-    item.description !== catalystItem.description ||
-    item.data.category !== catalystItem.data.category ||
-    item.data.hides.toString() !== catalystItem.data.hides.toString() ||
-    item.data.replaces.toString() !== catalystItem.data.replaces.toString() ||
-    item.data.tags.toString() !== catalystItem.data.tags.toString()
+    item.type === ItemType.WEARABLE
+      ? item.name !== catalystItem.name ||
+        item.description !== catalystItem.description ||
+        item.data.category !== catalystItem.data.category ||
+        item.data.hides.toString() !== catalystItem.data.hides.toString() ||
+        item.data.replaces.toString() !== catalystItem.data.replaces.toString() ||
+        item.data.tags.toString() !== catalystItem.data.tags.toString()
+      : item.name !== catalystItem.name ||
+        item.description !== catalystItem.description ||
+        item.data.category !== catalystItem.data.category ||
+        item.data.tags.toString() !== catalystItem.data.tags.toString()
   if (hasMetadataChanged) {
     return false
   }

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -533,7 +533,8 @@
     "total": "Total",
     "parcel_plural": "Parcels",
     "estate_plural": "Estates",
-    "none": "None"
+    "none": "None",
+    "emote": "Emote"
   },
   "navigation": {
     "scenes": "Scenes",
@@ -1092,7 +1093,8 @@
     "edit_urn": "Edit URN",
     "copy_urn": "Copy URN",
     "type": {
-      "wearable": "Wearable"
+      "wearable": "Wearable",
+      "emote": "Emote"
     }
   },
   "edit_price_and_beneficiary_modal": {
@@ -1233,6 +1235,12 @@
       "select_placeholder": "Select an option",
       "request_for_changes": "Request for changes",
       "request_for_changes_explanation": "If you want to make changes to {name} please ask a committee member for authorization in the forum"
+    }
+  },
+  "emote": {
+    "category": {
+      "simple": "Simple",
+      "loop": "Loop"
     }
   },
   "wearable": {

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -534,7 +534,8 @@
     "total": "Total",
     "parcel_plural": "Parcelas",
     "estate_plural": "Estates",
-    "none": "Ninguno"
+    "none": "Ninguno",
+    "emote": "Emote"
   },
   "navigation": {
     "scenes": "Escenas",
@@ -1103,7 +1104,8 @@
     "edit_urn": "Editar URN",
     "copy_urn": "Copiar URN",
     "type": {
-      "wearable": "Vestimenta"
+      "wearable": "Vestimenta",
+      "emote": "Emote"
     }
   },
   "edit_price_and_beneficiary_modal": {
@@ -1248,6 +1250,12 @@
       "select_placeholder": "Selecciona una opción",
       "request_for_changes": "Solicitud de cambios",
       "request_for_changes_explanation": "Si desea realizar cambios en {name}, solicite autorización a un miembro del comité en el foro"
+    }
+  },
+  "emote": {
+    "category": {
+      "simple": "Simple",
+      "loop": "Loop"
     }
   },
   "wearable": {

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -526,7 +526,8 @@
     "total": "全部的",
     "parcel_plural": "包裹",
     "estate_plural": "庄园",
-    "none": "没有任何"
+    "none": "没有任何",
+    "emote": "表情"
   },
   "navigation": {
     "scenes": "场景",
@@ -1085,7 +1086,8 @@
     "edit_urn": "编辑 URN",
     "copy_urn": "Copy URN",
     "type": {
-      "wearable": "可穿戴"
+      "wearable": "可穿戴",
+      "emote": "表情"
     }
   },
   "edit_price_and_beneficiary_modal": {
@@ -1232,6 +1234,12 @@
       "select_placeholder": "选择一个选项",
       "request_for_changes": "要求变更",
       "request_for_changes_explanation": "如果您想更改{name}，请在论坛中请求委员会成员的授权"
+    }
+  },
+  "emote": {
+    "category": {
+      "simple": "简单的",
+      "loop": "环形"
     }
   },
   "wearable": {

--- a/src/specs/item.ts
+++ b/src/specs/item.ts
@@ -43,7 +43,7 @@ export const mockedItem: Item = {
 }
 
 export const mockedLocalItem: LocalItem = {
-  type: ItemType.WEARABLE,
+  type: ItemType.WEARABLE as any,
   id: mockedItem.id,
   name: mockedItem.name,
   thumbnail: mockedItem.thumbnail,
@@ -79,7 +79,7 @@ export const mockedLocalItem: LocalItem = {
 }
 
 export const mockedRemoteItem: RemoteItem = {
-  type: ItemType.WEARABLE,
+  type: ItemType.WEARABLE as any,
   id: mockedItem.id,
   name: mockedItem.name,
   thumbnail: mockedItem.thumbnail,


### PR DESCRIPTION
This PR adds support to create items of type `emote`. When the user drops a GLB we check if there are animations inside of it, and if so, assume it's an emote. Emotes are currently stored as a `Wearable` on the catalyst with an extra `emoteDataV0` property. On the blockchain side they are stored with a different type `e` and their own set of categories (`simple` and `loop`). There are several `any` and other castings done on the UI side, specially on the `CreateItemModal` and `RightPanel`, eventually we need to refactor these components in a way to support several item types each with their own schema in a graceful way. 