### PR TITLE
fix: Publish changes without cheques

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11196,9 +11196,9 @@
       }
     },
     "decentraland-transactions": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-1.30.0.tgz",
-      "integrity": "sha512-IPvZohIKzOsrWk8uC6f/3IvOzNaXXsa7gZqKaLJHDeU0te6NoxO+CeCcR2b/zJxX7k2oaBUO69O1uh4F/wKJtg=="
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-1.31.0.tgz",
+      "integrity": "sha512-k1kq3eh2yTMfYnF/hzVTJocQ/y+UClcDQiwYmkC+VMXgKwtogmTq5wLFVUtkBu83AGNjJxmZvN5PDQa3ZuESYw=="
     },
     "decentraland-ui": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "decentraland-dapps": "^12.39.0",
     "decentraland-ecs": "^6.6.1-20201020183014.commit-bdc29ef",
     "decentraland-experiments": "^1.0.2",
-    "decentraland-transactions": "^1.30.0",
+    "decentraland-transactions": "^1.31.0",
     "decentraland-ui": "^3.21.0",
     "dotenv": "6.0.0",
     "dotenv-expand": "4.2.0",

--- a/src/components/Modals/ApprovalFlowModal/ApprovalFlowModal.container.ts
+++ b/src/components/Modals/ApprovalFlowModal/ApprovalFlowModal.container.ts
@@ -8,7 +8,7 @@ import { getPendingTransactions } from 'modules/transaction/selectors'
 import { approveCollectionRequest, APPROVE_COLLECTION_REQUEST, APPROVE_COLLECTION_SUCCESS } from 'modules/collection/actions'
 import { rescueItemsRequest, RESCUE_ITEMS_REQUEST } from 'modules/item/actions'
 import { deployEntitiesRequest, DEPLOY_ENTITIES_REQUEST } from 'modules/entity/actions'
-import { consumeThirdPartyItemSlotsRequest, CONSUME_THIRD_PARTY_ITEM_SLOTS_REQUEST } from 'modules/thirdParty/actions'
+import { reviewThirdPartyRequest, REVIEW_THIRD_PARTY_REQUEST } from 'modules/thirdParty/actions'
 import ApprovalFlowModal from './ApprovalFlowModal'
 
 const mapState = (state: RootState): MapStateProps => {
@@ -18,7 +18,7 @@ const mapState = (state: RootState): MapStateProps => {
   const pendingTransactions = getPendingTransactions(state)
   return {
     isConfirmingRescueTx: loadingItemActions.some(action => action.type === RESCUE_ITEMS_REQUEST),
-    isConfirmingConsumeSlotsTx: loadingItemActions.some(action => action.type === CONSUME_THIRD_PARTY_ITEM_SLOTS_REQUEST),
+    isConfirmingConsumeSlotsTx: loadingItemActions.some(action => action.type === REVIEW_THIRD_PARTY_REQUEST),
     isDeployingItems: loadingEntityActions.some(action => action.type === DEPLOY_ENTITIES_REQUEST),
     isConfirmingApproveTx: loadingCollectionActions.some(action => action.type === APPROVE_COLLECTION_REQUEST),
     isAwaitingApproveTx: pendingTransactions.some(tx => tx.actionType === APPROVE_COLLECTION_SUCCESS)
@@ -29,8 +29,7 @@ const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
   onRescueItems: (collection, items, contentHashes) => dispatch(rescueItemsRequest(collection, items, contentHashes)),
   onDeployItems: entities => dispatch(deployEntitiesRequest(entities)),
   onApproveCollection: collection => dispatch(approveCollectionRequest(collection)),
-  onConsumeTPSlots: (thirdPartyId, slots, merkleTreeRoot) =>
-    dispatch(consumeThirdPartyItemSlotsRequest(thirdPartyId, slots, merkleTreeRoot))
+  onConsumeTPSlots: (thirdPartyId, slots, merkleTreeRoot) => dispatch(reviewThirdPartyRequest(thirdPartyId, slots, merkleTreeRoot))
 })
 
 export default connect(mapState, mapDispatch)(ApprovalFlowModal)

--- a/src/components/Modals/ApprovalFlowModal/ApprovalFlowModal.container.ts
+++ b/src/components/Modals/ApprovalFlowModal/ApprovalFlowModal.container.ts
@@ -18,7 +18,7 @@ const mapState = (state: RootState): MapStateProps => {
   const pendingTransactions = getPendingTransactions(state)
   return {
     isConfirmingRescueTx: loadingItemActions.some(action => action.type === RESCUE_ITEMS_REQUEST),
-    isConfirmingConsumeSlotsTx: loadingItemActions.some(action => action.type === REVIEW_THIRD_PARTY_REQUEST),
+    isConfirmingReviewThirdPartyTx: loadingItemActions.some(action => action.type === REVIEW_THIRD_PARTY_REQUEST),
     isDeployingItems: loadingEntityActions.some(action => action.type === DEPLOY_ENTITIES_REQUEST),
     isConfirmingApproveTx: loadingCollectionActions.some(action => action.type === APPROVE_COLLECTION_REQUEST),
     isAwaitingApproveTx: pendingTransactions.some(tx => tx.actionType === APPROVE_COLLECTION_SUCCESS)
@@ -29,7 +29,7 @@ const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
   onRescueItems: (collection, items, contentHashes) => dispatch(rescueItemsRequest(collection, items, contentHashes)),
   onDeployItems: entities => dispatch(deployEntitiesRequest(entities)),
   onApproveCollection: collection => dispatch(approveCollectionRequest(collection)),
-  onConsumeTPSlots: (thirdPartyId, slots, merkleTreeRoot) => dispatch(reviewThirdPartyRequest(thirdPartyId, slots, merkleTreeRoot))
+  onReviewThirdParty: (thirdPartyId, slots, merkleTreeRoot) => dispatch(reviewThirdPartyRequest(thirdPartyId, slots, merkleTreeRoot))
 })
 
 export default connect(mapState, mapDispatch)(ApprovalFlowModal)

--- a/src/components/Modals/ApprovalFlowModal/ApprovalFlowModal.tsx
+++ b/src/components/Modals/ApprovalFlowModal/ApprovalFlowModal.tsx
@@ -117,7 +117,7 @@ export default class ApprovalFlowModal extends React.PureComponent<Props> {
   }
 
   renderConsumeTPSlotsView() {
-    const { onClose, metadata, isConfirmingConsumeSlotsTx } = this.props
+    const { onClose, metadata, isConfirmingReviewThirdPartyTx } = this.props
     const { items } = metadata as ApprovalFlowModalMetadata<ApprovalFlowModalView.CONSUME_TP_SLOTS>
     const { didApproveConsumeSlots } = this.state
 
@@ -161,7 +161,7 @@ export default class ApprovalFlowModal extends React.PureComponent<Props> {
         <ModalActions>
           <Button
             primary
-            disabled={didApproveConsumeSlots || isConfirmingConsumeSlotsTx}
+            disabled={didApproveConsumeSlots || isConfirmingReviewThirdPartyTx}
             loading={didApproveConsumeSlots}
             onClick={this.handleReviewThirdParty}
           >

--- a/src/components/Modals/ApprovalFlowModal/ApprovalFlowModal.tsx
+++ b/src/components/Modals/ApprovalFlowModal/ApprovalFlowModal.tsx
@@ -28,12 +28,12 @@ export default class ApprovalFlowModal extends React.PureComponent<Props> {
     onRescueItems(collection, items, contentHashes)
   }
 
-  handleConsumeSlots = () => {
-    const { metadata, onConsumeTPSlots } = this.props
+  handleReviewThirdParty = () => {
+    const { metadata, onReviewThirdParty } = this.props
     const { collection, merkleTreeRoot, slots } = metadata as ApprovalFlowModalMetadata<ApprovalFlowModalView.CONSUME_TP_SLOTS>
     this.setState({ didApproveConsumeSlots: true })
     const thirdPartyId = extractThirdPartyId(collection.urn)
-    onConsumeTPSlots(thirdPartyId, slots, merkleTreeRoot)
+    onReviewThirdParty(thirdPartyId, slots, merkleTreeRoot)
   }
 
   renderHash(hash: string) {
@@ -163,7 +163,7 @@ export default class ApprovalFlowModal extends React.PureComponent<Props> {
             primary
             disabled={didApproveConsumeSlots || isConfirmingConsumeSlotsTx}
             loading={didApproveConsumeSlots}
-            onClick={this.handleConsumeSlots}
+            onClick={this.handleReviewThirdParty}
           >
             {t('approval_flow.rescue.confirm')}
           </Button>

--- a/src/components/Modals/ApprovalFlowModal/ApprovalFlowModal.types.ts
+++ b/src/components/Modals/ApprovalFlowModal/ApprovalFlowModal.types.ts
@@ -39,7 +39,7 @@ export type Props = ModalProps & {
   onApproveCollection: typeof approveCollectionRequest
   onReviewThirdParty: typeof reviewThirdPartyRequest
   isConfirmingRescueTx: boolean
-  isConfirmingConsumeSlotsTx: boolean
+  isConfirmingReviewThirdPartyTx: boolean
   isDeployingItems: boolean
   isConfirmingApproveTx: boolean
   isAwaitingApproveTx: boolean
@@ -52,7 +52,7 @@ export type State = {
 
 export type MapStateProps = Pick<
   Props,
-  'isConfirmingRescueTx' | 'isConfirmingConsumeSlotsTx' | 'isDeployingItems' | 'isAwaitingApproveTx' | 'isConfirmingApproveTx'
+  'isConfirmingRescueTx' | 'isConfirmingReviewThirdPartyTx' | 'isDeployingItems' | 'isAwaitingApproveTx' | 'isConfirmingApproveTx'
 >
 export type MapDispatchProps = Pick<Props, 'onRescueItems' | 'onDeployItems' | 'onApproveCollection' | 'onReviewThirdParty'>
 export type MapDispatch = Dispatch<

--- a/src/components/Modals/ApprovalFlowModal/ApprovalFlowModal.types.ts
+++ b/src/components/Modals/ApprovalFlowModal/ApprovalFlowModal.types.ts
@@ -7,7 +7,7 @@ import { Collection } from 'modules/collection/types'
 import { rescueItemsRequest, RescueItemsRequestAction } from 'modules/item/actions'
 import { Item } from 'modules/item/types'
 import { deployEntitiesRequest, DeployEntitiesRequestAction } from 'modules/entity/actions'
-import { consumeThirdPartyItemSlotsRequest, ConsumeThirdPartyItemSlotsRequestAction } from 'modules/thirdParty/actions'
+import { reviewThirdPartyRequest, ReviewThirdPartyRequestAction } from 'modules/thirdParty/actions'
 import { Slot } from 'modules/thirdParty/types'
 
 export enum ApprovalFlowModalView {
@@ -37,7 +37,7 @@ export type Props = ModalProps & {
   onRescueItems: typeof rescueItemsRequest
   onDeployItems: typeof deployEntitiesRequest
   onApproveCollection: typeof approveCollectionRequest
-  onConsumeTPSlots: typeof consumeThirdPartyItemSlotsRequest
+  onReviewThirdParty: typeof reviewThirdPartyRequest
   isConfirmingRescueTx: boolean
   isConfirmingConsumeSlotsTx: boolean
   isDeployingItems: boolean
@@ -54,7 +54,7 @@ export type MapStateProps = Pick<
   Props,
   'isConfirmingRescueTx' | 'isConfirmingConsumeSlotsTx' | 'isDeployingItems' | 'isAwaitingApproveTx' | 'isConfirmingApproveTx'
 >
-export type MapDispatchProps = Pick<Props, 'onRescueItems' | 'onDeployItems' | 'onApproveCollection' | 'onConsumeTPSlots'>
+export type MapDispatchProps = Pick<Props, 'onRescueItems' | 'onDeployItems' | 'onApproveCollection' | 'onReviewThirdParty'>
 export type MapDispatch = Dispatch<
-  RescueItemsRequestAction | DeployEntitiesRequestAction | ApproveCollectionRequestAction | ConsumeThirdPartyItemSlotsRequestAction
+  RescueItemsRequestAction | DeployEntitiesRequestAction | ApproveCollectionRequestAction | ReviewThirdPartyRequestAction
 >

--- a/src/modules/collection/sagas.ts
+++ b/src/modules/collection/sagas.ts
@@ -111,11 +111,7 @@ import {
 import { CollectionCuration } from 'modules/curations/collectionCuration/types'
 import { CurationStatus } from 'modules/curations/types'
 import { ItemCuration } from 'modules/curations/itemCuration/types'
-import {
-  ConsumeThirdPartyItemSlotsFailureAction,
-  CONSUME_THIRD_PARTY_ITEM_SLOTS_FAILURE,
-  CONSUME_THIRD_PARTY_ITEM_SLOTS_SUCCESS
-} from 'modules/thirdParty/actions'
+import { ReviewThirdPartyFailureAction, REVIEW_THIRD_PARTY_FAILURE, REVIEW_THIRD_PARTY_SUCCESS } from 'modules/thirdParty/actions'
 import {
   DeployEntitiesFailureAction,
   DeployEntitiesSuccessAction,
@@ -619,7 +615,10 @@ export function* collectionSaga(builder: BuilderAPI, catalyst: CatalystClient) {
 
       // 2. Get the approval data from the server
       // TODO: Use the builder client. Tracked here: https://github.com/decentraland/builder/issues/1855
-      const { cheque, content_hashes: contentHashes }: ItemApprovalData = yield call([builder, 'fetchApprovalData'], collection.id)
+      const { cheque, content_hashes: contentHashes, chequeWasConsumed }: ItemApprovalData = yield call(
+        [builder, 'fetchApprovalData'],
+        collection.id
+      )
 
       // 3. Compute the merkle tree root & create slot to consume
       const tree = generateTree(Object.values(contentHashes))
@@ -628,31 +627,32 @@ export function* collectionSaga(builder: BuilderAPI, catalyst: CatalystClient) {
         throw Error('Invalid qty of items to approve in the cheque')
       }
 
-      const { r, s, v } = ethers.utils.splitSignature(cheque.signature)
-      const slot: Slot = {
-        qty: cheque.qty,
-        salt: cheque.salt,
-        sigR: r,
-        sigS: s,
-        sigV: v
-      }
       // Open the ApprovalFlowModal with the items to be approved
       // 4. Make the transaction to the contract (update of the merkle tree root with the signature and its parameters)
 
       if (itemsToApprove.length > 0) {
+        const { r, s, v } = ethers.utils.splitSignature(cheque.signature)
+        const slot: Slot = {
+          qty: cheque.qty,
+          salt: cheque.salt,
+          sigR: r,
+          sigS: s,
+          sigV: v
+        }
+
         const modalMetadata: ApprovalFlowModalMetadata<ApprovalFlowModalView.CONSUME_TP_SLOTS> = {
           view: ApprovalFlowModalView.CONSUME_TP_SLOTS,
           items: itemsToApprove,
           collection,
           merkleTreeRoot: tree.merkleRoot,
-          slots: [slot]
+          slots: chequeWasConsumed ? [] : [slot]
         }
         yield put(openModal('ApprovalFlowModal', modalMetadata))
 
         // Wait for actions...
-        const { failure, cancel }: { failure: ConsumeThirdPartyItemSlotsFailureAction; cancel: CloseModalAction } = yield race({
-          success: take(CONSUME_THIRD_PARTY_ITEM_SLOTS_SUCCESS),
-          failure: take(CONSUME_THIRD_PARTY_ITEM_SLOTS_FAILURE),
+        const { failure, cancel }: { failure: ReviewThirdPartyFailureAction; cancel: CloseModalAction } = yield race({
+          success: take(REVIEW_THIRD_PARTY_SUCCESS),
+          failure: take(REVIEW_THIRD_PARTY_FAILURE),
           cancel: take(CLOSE_MODAL)
         })
 

--- a/src/modules/item/types.ts
+++ b/src/modules/item/types.ts
@@ -164,6 +164,7 @@ export type CatalystItem = StandardCatalystItem | TPCatalystItem
 export type ItemApprovalData = {
   cheque: Omit<Cheque, 'signedMessage'>
   content_hashes: Record<string, string>
+  chequeWasConsumed: boolean
 }
 export type TPItemMerkleProof = {
   index: number

--- a/src/modules/thirdParty/actions.ts
+++ b/src/modules/thirdParty/actions.ts
@@ -72,31 +72,31 @@ export type BuyThirdPartyItemSlotRequestAction = ReturnType<typeof buyThirdParty
 export type BuyThirdPartyItemSlotSuccessAction = ReturnType<typeof buyThirdPartyItemSlotSuccess>
 export type BuyThirdPartyItemSlotFailureAction = ReturnType<typeof buyThirdPartyItemSlotFailure>
 
-// Consume a third party slots
+// Review a third party
 
-export const CONSUME_THIRD_PARTY_ITEM_SLOTS_REQUEST = '[Request] Consume a third party item slots'
-export const CONSUME_THIRD_PARTY_ITEM_SLOTS_SUCCESS = '[Success] Consume a third party item slots'
-export const CONSUME_THIRD_PARTY_ITEM_SLOTS_FAILURE = '[Failure] Consume a third party item slots'
-export const CONSUME_THIRD_PARTY_ITEM_SLOTS_TX_SUCCESS = '[Tx Success] Consume a third party item slots'
+export const REVIEW_THIRD_PARTY_REQUEST = '[Request] Consume a third party item slots'
+export const REVIEW_THIRD_PARTY_SUCCESS = '[Success] Consume a third party item slots'
+export const REVIEW_THIRD_PARTY_FAILURE = '[Failure] Consume a third party item slots'
+export const REVIEW_THIRD_PARTY_TX_SUCCESS = '[Tx Success] Consume a third party item slots'
 
-export const consumeThirdPartyItemSlotsRequest = (
+export const reviewThirdPartyRequest = (
   thirdPartyId: ThirdParty['id'],
   slots: Slot[],
   merkleTreeRoot: MerkleDistributorInfo['merkleRoot']
-) => action(CONSUME_THIRD_PARTY_ITEM_SLOTS_REQUEST, { thirdPartyId, slots, merkleTreeRoot })
+) => action(REVIEW_THIRD_PARTY_REQUEST, { thirdPartyId, slots, merkleTreeRoot })
 
-export const consumeThirdPartyItemSlotsTxSuccess = (txHash: string, chainId: ChainId) =>
-  action(CONSUME_THIRD_PARTY_ITEM_SLOTS_TX_SUCCESS, {
+export const reviewThirdPartyTxSuccess = (txHash: string, chainId: ChainId) =>
+  action(REVIEW_THIRD_PARTY_TX_SUCCESS, {
     ...buildTransactionPayload(chainId, txHash)
   })
 
-export const consumeThirdPartyItemSlotsSuccess = () => action(CONSUME_THIRD_PARTY_ITEM_SLOTS_SUCCESS)
-export const consumeThirdPartyItemSlotsFailure = (error: string) => action(CONSUME_THIRD_PARTY_ITEM_SLOTS_FAILURE, { error })
+export const reviewThirdPartySuccess = () => action(REVIEW_THIRD_PARTY_SUCCESS)
+export const reviewThirdPartyFailure = (error: string) => action(REVIEW_THIRD_PARTY_FAILURE, { error })
 
-export type ConsumeThirdPartyItemSlotsRequestAction = ReturnType<typeof consumeThirdPartyItemSlotsRequest>
-export type ConsumeThirdPartyItemSlotsSuccessAction = ReturnType<typeof consumeThirdPartyItemSlotsSuccess>
-export type ConsumeThirdPartyItemSlotsTxSuccessAction = ReturnType<typeof consumeThirdPartyItemSlotsTxSuccess>
-export type ConsumeThirdPartyItemSlotsFailureAction = ReturnType<typeof consumeThirdPartyItemSlotsFailure>
+export type ReviewThirdPartyRequestAction = ReturnType<typeof reviewThirdPartyRequest>
+export type ReviewThirdPartySuccessAction = ReturnType<typeof reviewThirdPartySuccess>
+export type ReviewThirdPartyTxSuccessAction = ReturnType<typeof reviewThirdPartyTxSuccess>
+export type ReviewThirdPartyFailureAction = ReturnType<typeof reviewThirdPartyFailure>
 
 // Publish Third Party Item
 

--- a/src/modules/thirdParty/sagas.ts
+++ b/src/modules/thirdParty/sagas.ts
@@ -48,11 +48,11 @@ import {
   PublishThirdPartyItemsSuccessAction,
   publishAndPushChangesThirdPartyItemsSuccess,
   publishAndPushChangesThirdPartyItemsFailure,
-  ConsumeThirdPartyItemSlotsRequestAction,
-  consumeThirdPartyItemSlotsSuccess,
-  consumeThirdPartyItemSlotsFailure,
-  CONSUME_THIRD_PARTY_ITEM_SLOTS_REQUEST,
-  consumeThirdPartyItemSlotsTxSuccess
+  ReviewThirdPartyRequestAction,
+  reviewThirdPartySuccess,
+  reviewThirdPartyFailure,
+  REVIEW_THIRD_PARTY_REQUEST,
+  reviewThirdPartyTxSuccess
 } from './actions'
 import { applySlotBuySlippage, getPublishItemsSignature } from './utils'
 import { ThirdParty } from './types'
@@ -78,7 +78,7 @@ export function* thirdPartySaga(builder: BuilderAPI) {
   yield takeEvery(PUSH_CHANGES_THIRD_PARTY_ITEMS_REQUEST, handlePushChangesThirdPartyItemRequest)
   yield takeEvery(PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_REQUEST, handlePublishAndPushChangesThirdPartyItemRequest)
   yield takeEvery(PUBLISH_THIRD_PARTY_ITEMS_SUCCESS, handlePublishThirdPartyItemSuccess)
-  yield takeLatest(CONSUME_THIRD_PARTY_ITEM_SLOTS_REQUEST, handleConsumeSlotsRequest)
+  yield takeLatest(REVIEW_THIRD_PARTY_REQUEST, handleReviewThirdPartyRequest)
 
   function* handleLoginSuccess(action: LoginSuccessAction) {
     const { wallet } = action.payload
@@ -255,7 +255,7 @@ export function* thirdPartySaga(builder: BuilderAPI) {
     }
   }
 
-  function* handleConsumeSlotsRequest(action: ConsumeThirdPartyItemSlotsRequestAction) {
+  function* handleReviewThirdPartyRequest(action: ReviewThirdPartyRequestAction) {
     const { thirdPartyId, slots, merkleTreeRoot } = action.payload
     try {
       const maticChainId: ChainId = yield call(getChainIdByNetwork, Network.MATIC)
@@ -268,11 +268,11 @@ export function* thirdPartySaga(builder: BuilderAPI) {
         merkleTreeRoot,
         slots.map(slot => [slot.qty, slot.salt, slot.sigR, slot.sigS, slot.sigV])
       )
-      yield put(consumeThirdPartyItemSlotsTxSuccess(txHash, maticChainId))
+      yield put(reviewThirdPartyTxSuccess(txHash, maticChainId))
       yield call(waitForTx, txHash)
-      yield put(consumeThirdPartyItemSlotsSuccess())
+      yield put(reviewThirdPartySuccess())
     } catch (error) {
-      yield put(consumeThirdPartyItemSlotsFailure(error))
+      yield put(reviewThirdPartyFailure(error))
     }
   }
 }


### PR DESCRIPTION
This PR changes the `handleInitiateTPItemsApprovalFlow` so when the curator approves the TP items using an already consumed cheque, the cheque is not sent in the meta transaction to the ThirdParty registry.

Closes #1879