### PR TITLE
fix: Allow user to push changes even if there are no slots

### DIFF
--- a/src/components/ThirdPartyCollectionDetailPage/CollectionPublishButton/CollectionPublishButton.tsx
+++ b/src/components/ThirdPartyCollectionDetailPage/CollectionPublishButton/CollectionPublishButton.tsx
@@ -110,7 +110,7 @@ const CollectionPublishButton = (props: Props) => {
           <NetworkButton
             loading={isLoadingItemCurations}
             disabled={
-              (isTryingToPublish && slots === 0) || !hasEnoughSlots || items.length === 0 || buttonAction === PublishButtonAction.NONE
+              (isTryingToPublish && (slots === 0 || !hasEnoughSlots)) || items.length === 0 || buttonAction === PublishButtonAction.NONE
             }
             primary
             compact
@@ -122,7 +122,7 @@ const CollectionPublishButton = (props: Props) => {
         </div>
       }
       hideOnScroll={true}
-      disabled={hasEnoughSlots}
+      disabled={!isTryingToPublish || (isTryingToPublish && hasEnoughSlots)}
       on="hover"
       inverted
     />


### PR DESCRIPTION
Closes #1935 

### Test scenarios:

### 0 slots but changes to push
![image](https://user-images.githubusercontent.com/8763687/162228377-f0e46ed5-bca3-4149-b776-5de0d08b68d1.png)


### 0 slots and trying to push changes and publish
![image](https://user-images.githubusercontent.com/8763687/162228405-cc70b365-0ab0-4b68-ba2b-7fdc543b776b.png)

### 0 slots and trying to publish
![image](https://user-images.githubusercontent.com/8763687/162228554-139068fa-0e2f-481f-9993-6d8182c9e30d.png)

### 3 slots and trying to push changes

![image](https://user-images.githubusercontent.com/8763687/162230199-a7661e1f-e310-4acc-891c-2cb6c8140eb4.png)


### 3 slots and trying to publish 

![image](https://user-images.githubusercontent.com/8763687/162230111-61ec667e-d87c-4e74-a413-ba50fa1a03db.png)

### 3 slots and trying to publish & push changes 
![image](https://user-images.githubusercontent.com/8763687/162230058-14874d79-015e-448d-ac68-18abefbba846.png)
