### PR TITLE
fix: Show error when editing a URN fails

### DIFF
--- a/src/components/Modals/EditURNModals/EditCollectionURNModal/EditCollectionURNModal.container.ts
+++ b/src/components/Modals/EditURNModals/EditCollectionURNModal/EditCollectionURNModal.container.ts
@@ -2,7 +2,7 @@ import { connect } from 'react-redux'
 import { RootState } from 'modules/common/types'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 import { buildThirdPartyURN, DecodedURN, URNType } from 'lib/urn'
-import { getLoading as getCollectionLoading } from 'modules/collection/selectors'
+import { getLoading as getCollectionLoading, getError } from 'modules/collection/selectors'
 import { saveCollectionRequest, SAVE_COLLECTION_REQUEST } from 'modules/collection/actions'
 import { MapStateProps, MapDispatchProps, MapDispatch, OwnProps } from './EditCollectionURNModal.types'
 import EditURNModal from '../EditURNModal'
@@ -12,6 +12,7 @@ const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
   return {
     elementName: collection.name,
     urn: collection.urn,
+    error: getError(state),
     isLoading: isLoadingType(getCollectionLoading(state), SAVE_COLLECTION_REQUEST)
   }
 }

--- a/src/components/Modals/EditURNModals/EditCollectionURNModal/EditCollectionURNModal.types.ts
+++ b/src/components/Modals/EditURNModals/EditCollectionURNModal/EditCollectionURNModal.types.ts
@@ -9,6 +9,7 @@ export type Props = ModalProps & {
   urn: URN
   isLoading: boolean
   metadata: EditURNModalMetadata
+  error: string | null
   onSave: (urn: string) => ReturnType<typeof saveCollectionRequest>
   onBuildURN: (decodedURN: DecodedURN<URNType.COLLECTIONS_THIRDPARTY>, collectionId: string) => string
 }
@@ -18,6 +19,6 @@ export type EditURNModalMetadata = {
 }
 
 export type OwnProps = Pick<Props, 'metadata'>
-export type MapStateProps = Pick<Props, 'elementName' | 'urn' | 'isLoading'>
+export type MapStateProps = Pick<Props, 'elementName' | 'urn' | 'isLoading' | 'error'>
 export type MapDispatchProps = Pick<Props, 'onSave' | 'onBuildURN'>
 export type MapDispatch = Dispatch<SaveCollectionRequestAction>

--- a/src/components/Modals/EditURNModals/EditItemURNModal/EditItemURNModal.container.ts
+++ b/src/components/Modals/EditURNModals/EditItemURNModal/EditItemURNModal.container.ts
@@ -2,7 +2,7 @@ import { connect } from 'react-redux'
 import { RootState } from 'modules/common/types'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 import { buildThirdPartyURN, DecodedURN, URNType } from 'lib/urn'
-import { getLoading as getItemLoading } from 'modules/item/selectors'
+import { getError, getLoading as getItemLoading } from 'modules/item/selectors'
 import { saveItemRequest, SAVE_ITEM_REQUEST } from 'modules/item/actions'
 import { MapStateProps, MapDispatchProps, MapDispatch, OwnProps } from './EditItemURNModal.types'
 import EditURNModal from '../EditURNModal'
@@ -12,6 +12,7 @@ const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
   return {
     elementName: item.name,
     urn: item.urn,
+    error: getError(state),
     isLoading: isLoadingType(getItemLoading(state), SAVE_ITEM_REQUEST)
   }
 }

--- a/src/components/Modals/EditURNModals/EditItemURNModal/EditItemURNModal.types.ts
+++ b/src/components/Modals/EditURNModals/EditItemURNModal/EditItemURNModal.types.ts
@@ -9,6 +9,7 @@ export type Props = ModalProps & {
   urn: URN
   isLoading: boolean
   metadata: EditURNModalMetadata
+  error: string | null
   onSave: (urn: string) => ReturnType<typeof saveItemRequest>
   onBuildURN: (decodedURN: DecodedURN<URNType.COLLECTIONS_THIRDPARTY>, tokenId: string) => string
 }
@@ -18,6 +19,6 @@ export type EditURNModalMetadata = {
 }
 
 export type OwnProps = Pick<Props, 'metadata'>
-export type MapStateProps = Pick<Props, 'elementName' | 'urn' | 'isLoading'>
+export type MapStateProps = Pick<Props, 'elementName' | 'urn' | 'isLoading' | 'error'>
 export type MapDispatchProps = Pick<Props, 'onSave' | 'onBuildURN'>
 export type MapDispatch = Dispatch<SaveItemRequestAction>

--- a/src/components/Modals/EditURNModals/EditURNModal/EditURNModal.tsx
+++ b/src/components/Modals/EditURNModals/EditURNModal/EditURNModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { ModalNavigation, ModalContent, ModalActions, Button, Field, InputOnChangeData, Form } from 'decentraland-ui'
+import { ModalNavigation, ModalContent, ModalActions, Button, Field, InputOnChangeData, Form, Message } from 'decentraland-ui'
 import Modal from 'decentraland-dapps/dist/containers/Modal'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { DecodedURN, decodeURN, URNType } from 'lib/urn'
@@ -44,7 +44,7 @@ export default class EditURNModal extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { name, elementName, onClose, isLoading } = this.props
+    const { name, elementName, onClose, isLoading, error } = this.props
     const { newURNSection } = this.state
 
     return (
@@ -56,6 +56,9 @@ export default class EditURNModal extends React.PureComponent<Props, State> {
         />
         <Form onSubmit={this.handleSubmit}>
           <ModalContent>
+            {error ? (
+              <Message error size="tiny" visible className="warning-rescue-message" content={error} header={t('global.error_ocurred')} />
+            ) : null}
             <Field label={t('global.urn')} message={this.getUpdatedURN()} value={newURNSection} onChange={this.handleURNChange} />
           </ModalContent>
           <ModalActions>

--- a/src/components/Modals/EditURNModals/EditURNModal/EditURNModal.types.ts
+++ b/src/components/Modals/EditURNModals/EditURNModal/EditURNModal.types.ts
@@ -9,6 +9,7 @@ export type Props = ModalProps & {
   elementName: string
   urn: URN
   isLoading: boolean
+  error: string | null
   onBuildURN: (decodedURN: DecodedURN<URNType.COLLECTIONS_THIRDPARTY>, newURNSection: string) => string
   onSave: (newURN: string) => void
 }


### PR DESCRIPTION
We need better errors for the case that the URN is already in use and we should think about internationalizing the server errors.

![Screen Shot 2022-04-08 at 15 41 41](https://user-images.githubusercontent.com/1120791/162502995-c5aa112e-b235-45de-91c9-0e59e5ea6f90.png)

![Screen Shot 2022-04-08 at 15 40 13](https://user-images.githubusercontent.com/1120791/162503021-373bddf7-b129-403c-ae90-87ae085c773c.png)

Closes #1936