### PR TITLE
fix: allow editing estates with size > 100 (<1000)

### DIFF
--- a/src/components/LandDetailPage/LandDetailPage.tsx
+++ b/src/components/LandDetailPage/LandDetailPage.tsx
@@ -214,6 +214,7 @@ export default class LandDetailPage extends React.PureComponent<Props, State> {
                 <div className="deployments">
                   {deployments.map(deployment => (
                     <Scene
+                      key={deployment.id}
                       deployment={deployment}
                       onMouseEnter={this.handleMouseEnter}
                       onMouseLeave={this.handleMouseLeave}
@@ -236,7 +237,7 @@ export default class LandDetailPage extends React.PureComponent<Props, State> {
               </Header>
               <div className="ens-list">
                 {ensList.map(ens => (
-                  <ENSChip key={ens.subdomain} ens={ens} onIconClick={() => onOpenModal('UnsetENSContentModal', { ens, land })}/>
+                  <ENSChip key={ens.subdomain} ens={ens} onIconClick={() => onOpenModal('UnsetENSContentModal', { ens, land })} />
                 ))}
               </div>
             </Section>

--- a/src/lib/api/manager.ts
+++ b/src/lib/api/manager.ts
@@ -32,10 +32,10 @@ const getLandQuery = () => gql`
     operatorAuthorizations: authorizations(first: 1000, where: { operator: $address, type: "UpdateManager" }) {
       owner {
         address
-        parcels(where: { estate: null }) {
+        parcels(first: 1000, where: { estate: null }) {
           ...parcelFields
         }
-        estates {
+        estates(first: 1000) {
           ...estateFields
         }
       }

--- a/src/modules/land/types.ts
+++ b/src/modules/land/types.ts
@@ -68,7 +68,7 @@ export const estateFields = () => gql`
     }
     updateOperator
     size
-    parcels {
+    parcels(first: 1000) {
       x
       y
       tokenId


### PR DESCRIPTION
From trying to edit a estate looking like this:
![image](https://user-images.githubusercontent.com/692077/165975866-fe4f2fb3-38da-4501-8cc5-b4b0d90003ac.png)


to this:

<img width="308" alt="image" src="https://user-images.githubusercontent.com/692077/165975910-d25d6078-af8a-440f-823d-540e3a2e8690.png">
