### PR TITLE
fix: Curation Page pagination issue

### DIFF
--- a/src/components/CurationPage/CurationPage.tsx
+++ b/src/components/CurationPage/CurationPage.tsx
@@ -6,6 +6,7 @@ import Profile from 'components/Profile'
 import NotFound from 'components/NotFound'
 import LoggedInDetailPage from 'components/LoggedInDetailPage'
 import { NavigationTab } from 'components/Navigation/Navigation.types'
+import { Collection } from 'modules/collection/types'
 import CollectionRow from './CollectionRow'
 import { Props, State, SortBy, CurationFilterOptions, CurationExtraStatuses, Filters } from './CurationPage.types'
 import { CurationStatus } from 'modules/curations/types'
@@ -74,9 +75,9 @@ export default class CurationPage extends React.PureComponent<Props, State> {
     )
   }
 
-  paginate = () => {
+  sortAndFilter = () => {
     const { collections, curationsByCollectionId } = this.props
-    const { page, filterBy, sortBy, searchText, assigneeFilter } = this.state
+    const { filterBy, sortBy, searchText, assigneeFilter } = this.state
 
     return collections
       .filter(
@@ -144,7 +145,11 @@ export default class CurationPage extends React.PureComponent<Props, State> {
           }
         }
       })
-      .slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
+  }
+
+  paginate = (collections: Collection[]) => {
+    const { page } = this.state
+    return collections.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
   }
 
   handleSearchChange = (value: string): void => {
@@ -155,9 +160,10 @@ export default class CurationPage extends React.PureComponent<Props, State> {
     const { collections, curationsByCollectionId } = this.props
     const { page, searchText } = this.state
 
-    const total = collections.length
+    const sortedAndFiltered = this.sortAndFilter()
+    const total = sortedAndFiltered.length
     const totalPages = Math.ceil(total / PAGE_SIZE)
-    const paginatedCollections = this.paginate()
+    const paginatedCollections = this.paginate(sortedAndFiltered)
 
     return (
       <>


### PR DESCRIPTION
Closes #2011

Example with pagination page 1, so it's clear that now the total is calculated based on the filtered ones:

## No filters, should show 2 pages

<img width="1089" alt="image" src="https://user-images.githubusercontent.com/8763687/166228671-c98e2c31-3d6e-4284-9fe2-c5b65438d6f1.png">

## Filtering just to get 1, should show just 1 page

<img width="1049" alt="image" src="https://user-images.githubusercontent.com/8763687/166228721-d83750a6-e74c-4d03-9734-2e0ffe958db6.png">

