### PR TITLE
feat: Add scroll to assignee filter and contrast to selected option

### DIFF
--- a/src/components/CurationPage/CurationPage.css
+++ b/src/components/CurationPage/CurationPage.css
@@ -17,7 +17,7 @@
 }
 
 .CurationPage .filters .dropdown.assignees .menu {
-  max-height: 500px;
+  max-height: 300px;
   overflow-y: scroll;
 }
 

--- a/src/components/CurationPage/CurationPage.css
+++ b/src/components/CurationPage/CurationPage.css
@@ -15,3 +15,13 @@
   display: flex;
   justify-content: center;
 }
+
+.CurationPage .filters .dropdown.assignees .menu {
+  max-height: 500px;
+  overflow-y: scroll;
+}
+
+.CurationPage .filters .dropdown.assignees .menu .selected.item,
+.ui.dropdown.selected {
+  color: var(--primary);
+}

--- a/src/components/CurationPage/CurationPage.tsx
+++ b/src/components/CurationPage/CurationPage.tsx
@@ -63,6 +63,7 @@ export default class CurationPage extends React.PureComponent<Props, State> {
     const { assigneeFilter } = this.state
     return (
       <Dropdown
+        className="assignees"
         direction="left"
         value={assigneeFilter}
         options={[


### PR DESCRIPTION
Closes #2016

Scroll:
<img width="572" alt="image" src="https://user-images.githubusercontent.com/8763687/166292959-e2a20411-a063-4902-be2b-1191181f01dd.png">


## Selected option:

<img width="253" alt="image" src="https://user-images.githubusercontent.com/8763687/166292304-a6d895bb-4272-423d-9c4b-b0bc4c580b4b.png">
