### PR TITLE
fix: Uses whenReadyAsync to generate screenshots in parallel

### DIFF
--- a/src/lib/getScreenshot.ts
+++ b/src/lib/getScreenshot.ts
@@ -69,7 +69,7 @@ export async function getScreenshot(url: string, options: Partial<Options> = {})
   scene.autoClear = true
   scene.clearColor = new Color4(0, 0, 0, 0)
 
-  SceneLoader.Append(url, '', scene, undefined, null, null, extension)
+  await SceneLoader.AppendAsync(url, '', scene, undefined, extension)
   await scene.whenReadyAsync()
 
   // check if it's emote

--- a/src/lib/getScreenshot.ts
+++ b/src/lib/getScreenshot.ts
@@ -69,20 +69,8 @@ export async function getScreenshot(url: string, options: Partial<Options> = {})
   scene.autoClear = true
   scene.clearColor = new Color4(0, 0, 0, 0)
 
-  await new Promise<void>(resolve => {
-    SceneLoader.Append(
-      url,
-      '',
-      scene,
-      async () => {
-        await scene.whenReadyAsync()
-        resolve()
-      },
-      null,
-      null,
-      extension
-    )
-  })
+  SceneLoader.Append(url, '', scene, undefined, null, null, extension)
+  await scene.whenReadyAsync()
 
   // check if it's emote
   if (scene.animationGroups.length > 0) {


### PR DESCRIPTION
<img width="657" alt="image" src="https://user-images.githubusercontent.com/8763687/167668263-72843f6d-97b7-4cdc-a85c-99c711523535.png">

generated in parallel using the code in this PR