### PR TITLE
fix: Change comparison on consumed slots

### DIFF
--- a/src/components/ThirdPartyCollectionDetailPage/CollectionPublishButton/CollectionPublishButton.tsx
+++ b/src/components/ThirdPartyCollectionDetailPage/CollectionPublishButton/CollectionPublishButton.tsx
@@ -84,7 +84,7 @@ const CollectionPublishButton = (props: Props) => {
 
   const hasPendingItemCurations = itemCurations && !!itemCurations.find(ic => ic.status === CurationStatus.PENDING)
   const isTryingToPublish = [PublishButtonAction.PUBLISH, PublishButtonAction.PUBLISH_AND_PUSH_CHANGES].includes(buttonAction)
-  const hasEnoughSlots = slots > items.length
+  const hasEnoughSlots = slots >= items.length
 
   return !isLoadingItemCurations && hasPendingItemCurations && (isTryingToPublish || buttonAction === PublishButtonAction.NONE) ? (
     <Popup


### PR DESCRIPTION
The greater comparison was preventing collections with the exact number of items from being published.