### PR TITLE
feat: Add open in world in the collection detail for items

### DIFF
--- a/src/components/CollectionDetailPage/CollectionContextMenu/CollectionContextMenu.tsx
+++ b/src/components/CollectionDetailPage/CollectionContextMenu/CollectionContextMenu.tsx
@@ -19,7 +19,7 @@ export default class CollectionContextMenu extends React.PureComponent<Props> {
 
   handleNavigateToExplorer = () => {
     const { collection } = this.props
-    this.navigateTo(getExplorerURL(collection), '_blank')
+    this.navigateTo(getExplorerURL({ collection }), '_blank')
   }
 
   handleNavigateToEditor = () => {

--- a/src/components/CollectionDetailPage/CollectionItem/CollectionItem.tsx
+++ b/src/components/CollectionDetailPage/CollectionItem/CollectionItem.tsx
@@ -8,7 +8,7 @@ import { locations } from 'routing/locations'
 import { preventDefault } from 'lib/preventDefault'
 import { isComplete, isFree, canMintItem, canManageItem, getMaxSupply } from 'modules/item/utils'
 import ItemStatus from 'components/ItemStatus'
-import { isLocked } from 'modules/collection/utils'
+import { getExplorerURL, isLocked } from 'modules/collection/utils'
 import { WearableData } from 'modules/item/types'
 import ItemImage from 'components/ItemImage'
 import { Props } from './CollectionItem.types'
@@ -19,6 +19,14 @@ export default class CollectionItem extends React.PureComponent<Props> {
   handleEditPriceAndBeneficiary = () => {
     const { onOpenModal, item } = this.props
     onOpenModal('EditPriceAndBeneficiaryModal', { itemId: item.id })
+  }
+
+  handleNavigateToExplorer = () => {
+    const { item } = this.props
+    const newWindow = window.open(getExplorerURL({ item_ids: [item.id] }), '_blank')
+    if (newWindow) {
+      newWindow.focus()
+    }
   }
 
   handleMintItem = () => {
@@ -137,6 +145,7 @@ export default class CollectionItem extends React.PureComponent<Props> {
                 >
                   <Dropdown.Menu>
                     <Dropdown.Item text={t('collection_item.see_details')} as={Link} to={locations.itemDetail(item.id)} />
+                    <Dropdown.Item text={t('collection_context_menu.see_in_world')} onClick={this.handleNavigateToExplorer} />
                     <Dropdown.Item text={t('global.open_in_editor')} onClick={this.handleNavigateToEditor} />
                     {canManageItem(collection, item, ethAddress) && !isLocked(collection) ? (
                       <>

--- a/src/components/ItemEditorPage/TopPanel/TopPanel.tsx
+++ b/src/components/ItemEditorPage/TopPanel/TopPanel.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Button, Loader } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { locations } from 'routing/locations'
-import { Collection, CollectionType } from 'modules/collection/types'
+import { Collection } from 'modules/collection/types'
 import { CollectionCuration } from 'modules/curations/collectionCuration/types'
 import { ItemCuration } from 'modules/curations/itemCuration/types'
 import { CurationStatus } from 'modules/curations/types'
@@ -14,6 +14,7 @@ import RejectionModal from './RejectionModal'
 import { RejectionType } from './RejectionModal/RejectionModal.types'
 import { ButtonType, Props, State } from './TopPanel.types'
 import './TopPanel.css'
+import { Item } from 'modules/item/types'
 
 export default class TopPanel extends React.PureComponent<Props, State> {
   state: State = {
@@ -35,7 +36,7 @@ export default class TopPanel extends React.PureComponent<Props, State> {
 
   setShowRejectionModal = (showRejectionModal: RejectionType | null) => this.setState({ showRejectionModal })
 
-  renderPage = (collection: Collection, curation: CollectionCuration | null, itemsCuration: ItemCuration[] | null) => {
+  renderPage = (collection: Collection, items: Item[], curation: CollectionCuration | null, itemsCuration: ItemCuration[] | null) => {
     const { showRejectionModal, showApproveConfirmModal } = this.state
     const { chainId } = this.props
     const type = getCollectionType(collection)
@@ -49,11 +50,11 @@ export default class TopPanel extends React.PureComponent<Props, State> {
           {collection.name}
           &nbsp;·&nbsp;
           {t(`collection.type.${type}`)}
-          <JumpIn size="small" collection={collection} chainId={chainId} />
+          <JumpIn size="small" collection={collection} chainId={chainId} items={isTPCollection(collection) ? items : undefined} />
         </div>
         <div className="actions">
           <span className="button-container">
-            {type === CollectionType.THIRD_PARTY
+            {isTPCollection(collection)
               ? this.renderTPButtons(collection, curation, itemsCuration)
               : this.renderButtons(collection, curation)}
           </span>
@@ -165,11 +166,11 @@ export default class TopPanel extends React.PureComponent<Props, State> {
 
     return isCommitteeMember && isReviewing && isConnected ? (
       <div className="TopPanel">
-        <CollectionProvider id={selectedCollectionId}>
+        <CollectionProvider id={selectedCollectionId} status={isReviewing ? CurationStatus.PENDING : undefined}>
           {({ collection, items, itemCurations, curation, isLoading }) => {
             // Show loader only while loading the first page of items
             const showLoader = !collection || (isLoading && !items.length)
-            return showLoader ? <Loader size="small" active /> : this.renderPage(collection, curation, itemCurations)
+            return showLoader ? <Loader size="small" active /> : this.renderPage(collection, items, curation, itemCurations)
           }}
         </CollectionProvider>
       </div>

--- a/src/components/ItemEditorPage/TopPanel/TopPanel.tsx
+++ b/src/components/ItemEditorPage/TopPanel/TopPanel.tsx
@@ -3,6 +3,7 @@ import { Button, Loader } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { locations } from 'routing/locations'
 import { Collection } from 'modules/collection/types'
+import { Item } from 'modules/item/types'
 import { CollectionCuration } from 'modules/curations/collectionCuration/types'
 import { ItemCuration } from 'modules/curations/itemCuration/types'
 import { CurationStatus } from 'modules/curations/types'
@@ -14,7 +15,6 @@ import RejectionModal from './RejectionModal'
 import { RejectionType } from './RejectionModal/RejectionModal.types'
 import { ButtonType, Props, State } from './TopPanel.types'
 import './TopPanel.css'
-import { Item } from 'modules/item/types'
 
 export default class TopPanel extends React.PureComponent<Props, State> {
   state: State = {

--- a/src/components/JumpIn/JumpIn.tsx
+++ b/src/components/JumpIn/JumpIn.tsx
@@ -11,7 +11,7 @@ export default class JumpIn extends React.PureComponent<Props> {
     let url = ''
 
     if (collection) {
-      url = getCollectionURL(collection)
+      url = getCollectionURL({ collection })
     } else if (land) {
       const selection = getSelection(land)
       const [x, y] = getCenter(selection)

--- a/src/components/JumpIn/JumpIn.tsx
+++ b/src/components/JumpIn/JumpIn.tsx
@@ -6,11 +6,12 @@ import './JumpIn.css'
 
 export default class JumpIn extends React.PureComponent<Props> {
   render() {
-    const { size = 'medium', land, collection } = this.props
+    const { size = 'medium', land, collection, items } = this.props
 
     let url = ''
-
-    if (collection) {
+    if (items) {
+      url = getCollectionURL({ item_ids: items.map(item => item.id) })
+    } else if (collection) {
       url = getCollectionURL({ collection })
     } else if (land) {
       const selection = getSelection(land)

--- a/src/components/JumpIn/JumpIn.types.ts
+++ b/src/components/JumpIn/JumpIn.types.ts
@@ -1,10 +1,12 @@
 import { ChainId } from '@dcl/schemas'
 import { Collection } from 'modules/collection/types'
+import { Item } from 'modules/item/types'
 import { Land } from 'modules/land/types'
 
 export type Props = {
   size?: 'small' | 'medium' | 'big'
   land?: Land
   collection?: Collection
+  items?: Item[]
   chainId?: ChainId
 }

--- a/src/components/ThirdPartyCollectionDetailPage/CollectionContextMenu/CollectionContextMenu.container.ts
+++ b/src/components/ThirdPartyCollectionDetailPage/CollectionContextMenu/CollectionContextMenu.container.ts
@@ -4,12 +4,10 @@ import { RootState } from 'modules/common/types'
 import { deleteCollectionRequest } from 'modules/collection/actions'
 import { getName } from 'modules/profile/selectors'
 import { openModal } from 'modules/modal/actions'
-import { getCollectionItems } from 'modules/item/selectors'
-import { MapDispatchProps, MapDispatch, MapStateProps, OwnProps } from './CollectionContextMenu.types'
+import { MapDispatchProps, MapDispatch, MapStateProps } from './CollectionContextMenu.types'
 import CollectionContextMenu from './CollectionContextMenu'
 
-const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => ({
-  items: getCollectionItems(state, ownProps.collection.id),
+const mapState = (state: RootState): MapStateProps => ({
   name: getName(state) || ''
 })
 

--- a/src/components/ThirdPartyCollectionDetailPage/CollectionContextMenu/CollectionContextMenu.tsx
+++ b/src/components/ThirdPartyCollectionDetailPage/CollectionContextMenu/CollectionContextMenu.tsx
@@ -19,9 +19,9 @@ export default class CollectionContextMenu extends React.PureComponent<Props> {
   }
 
   handleNavigateToExplorer = () => {
-    const { collection } = this.props
+    const { items } = this.props
     this.analytics.track('See in world')
-    this.navigateTo(getExplorerURL({ collection }), '_blank')
+    this.navigateTo(getExplorerURL({ item_ids: items.map(item => item.id) }), '_blank')
   }
 
   handleNavigateToEditor = () => {

--- a/src/components/ThirdPartyCollectionDetailPage/CollectionContextMenu/CollectionContextMenu.tsx
+++ b/src/components/ThirdPartyCollectionDetailPage/CollectionContextMenu/CollectionContextMenu.tsx
@@ -21,7 +21,7 @@ export default class CollectionContextMenu extends React.PureComponent<Props> {
   handleNavigateToExplorer = () => {
     const { collection } = this.props
     this.analytics.track('See in world')
-    this.navigateTo(getExplorerURL(collection), '_blank')
+    this.navigateTo(getExplorerURL({ collection }), '_blank')
   }
 
   handleNavigateToEditor = () => {

--- a/src/components/ThirdPartyCollectionDetailPage/CollectionContextMenu/CollectionContextMenu.types.ts
+++ b/src/components/ThirdPartyCollectionDetailPage/CollectionContextMenu/CollectionContextMenu.types.ts
@@ -14,7 +14,7 @@ export type Props = {
   onNavigate: (path: string) => void
 }
 
-export type OwnProps = Pick<Props, 'collection'>
-export type MapStateProps = Pick<Props, 'items' | 'name'>
+export type OwnProps = Pick<Props, 'collection' | 'items'>
+export type MapStateProps = Pick<Props, 'name'>
 export type MapDispatchProps = Pick<Props, 'onNavigate' | 'onOpenModal' | 'onDelete'>
 export type MapDispatch = Dispatch<CallHistoryMethodAction | OpenModalAction | DeleteCollectionRequestAction>

--- a/src/components/ThirdPartyCollectionDetailPage/CollectionItem/CollectionItem.tsx
+++ b/src/components/ThirdPartyCollectionDetailPage/CollectionItem/CollectionItem.tsx
@@ -8,6 +8,7 @@ import { decodeURN, URNType } from 'lib/urn'
 import ItemStatus from 'components/ItemStatus'
 import { WearableData } from 'modules/item/types'
 import { getBodyShapeType } from 'modules/item/utils'
+import { getExplorerURL } from 'modules/collection/utils'
 import ConfirmDelete from 'components/ConfirmDelete'
 import ItemImage from 'components/ItemImage'
 import { Props } from './CollectionItem.types'
@@ -17,6 +18,14 @@ export default class CollectionItem extends React.PureComponent<Props> {
   handleCheckboxChange = (_event: React.MouseEvent<HTMLInputElement>, data: CheckboxProps) => {
     const { item, onSelect } = this.props
     onSelect(item, data.checked!)
+  }
+
+  handleNavigateToExplorer = () => {
+    const { item } = this.props
+    const newWindow = window.open(getExplorerURL({ item_ids: [item.id] }), '_blank')
+    if (newWindow) {
+      newWindow.focus()
+    }
   }
 
   handleEditURN = () => {
@@ -86,6 +95,7 @@ export default class CollectionItem extends React.PureComponent<Props> {
               >
                 <Dropdown.Menu>
                   <Dropdown.Item text={t('collection_item.see_details')} as={Link} to={locations.itemDetail(item.id)} />
+                  <Dropdown.Item text={t('collection_context_menu.see_in_world')} onClick={this.handleNavigateToExplorer} />
                   <Dropdown.Item text={t('global.open_in_editor')} onClick={this.handleNavigateToEditor} />
                   <Popup
                     content={t('collection_item.cannot_edit_urn')}

--- a/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.tsx
+++ b/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.tsx
@@ -249,7 +249,7 @@ export default class ThirdPartyCollectionDetailPage extends React.PureComponent<
                     {thirdParty.availableSlots !== undefined ? (
                       <CollectionPublishButton collection={collection} items={selectedItems} slots={thirdParty.availableSlots} />
                     ) : null}
-                    <CollectionContextMenu collection={collection} />
+                    <CollectionContextMenu collection={collection} items={paginatedItems} />
                   </Row>
                 </Column>
               </Row>

--- a/src/modules/collection/utils.ts
+++ b/src/modules/collection/utils.ts
@@ -38,10 +38,21 @@ export function getCollectionEditorURL(collection: Collection, items: Item[]): s
   return locations.itemEditor({ collectionId: collection.id, itemId: items.length > 0 ? items[0].id : undefined })
 }
 
-export function getExplorerURL(collection: Collection) {
+export function getExplorerURL({ collection, item_ids }: { collection?: Collection; item_ids?: string[] }): string {
+  if (!collection && !item_ids) {
+    throw new Error('Either a collection or item ids must be specified to get the explorer url')
+  }
   const EXPLORER_URL = env.get('REACT_APP_EXPLORER_URL', '')
   const BUILDER_SERVER_URL = env.get('REACT_APP_BUILDER_SERVER_URL', '')
-  return `${EXPLORER_URL}?WITH_COLLECTIONS=${collection.id}&BUILDER_SERVER_URL=${BUILDER_SERVER_URL}&NETWORK=ropsten&DEBUG_MODE=true`
+  let URL = `${EXPLORER_URL}?BUILDER_SERVER_URL=${BUILDER_SERVER_URL}&NETWORK=ropsten&DEBUG_MODE=true`
+
+  if (collection) {
+    URL += `&WITH_COLLECTIONS=${collection.id}`
+  } else if (item_ids) {
+    URL += `&WITH_ITEMS=${item_ids.join(',')}`
+  }
+
+  return URL
 }
 
 export function getCollectionBaseURI() {


### PR DESCRIPTION
This PR does the following:
- [x] Adds dropdown item menu to the rows of items in the collection detail & third party collection details so the creators can see a specific item in world.
- [x] Changes the link of the `JumpIn` button in the `TopPanel` of the item editor so it loads for the third party collections, the first 30-40 items that it has loaded for curation. This will at least make curators be capable of reviewing the first batch of items in bulk.
- [x] Changes the `See in world` button in the third party collection detail page so the creators can see the the items that are loaded in world by opening the explorer site with the item ids of the items currently loaded.