### PR TITLE
fix: Do not redirect to detail page if creating from collection detail

### DIFF
--- a/src/modules/item/sagas.spec.ts
+++ b/src/modules/item/sagas.spec.ts
@@ -1313,13 +1313,24 @@ describe('when handling the save item success action', () => {
       .run({ silenceTimeout: true })
   })
 
-  it('should put a location change to the item detail if the CreateSingleItemModal was opened', () => {
+  it('should put a location change to the item detail if the CreateSingleItemModal was opened and the location was /collections', () => {
     return expectSaga(itemSaga, builderAPI, builderClient)
       .provide([
         [select(getLocation), { pathname: locations.collections() }],
         [select(getOpenModals), { CreateSingleItemModal: true }]
       ])
       .put(push(locations.itemDetail(item.id)))
+      .dispatch(saveItemSuccess(item, {}))
+      .run({ silenceTimeout: true })
+  })
+
+  it('should not put a location change to the item detail if the CreateSingleItemModal was opened and the location was not /collections', () => {
+    return expectSaga(itemSaga, builderAPI, builderClient)
+      .provide([
+        [select(getLocation), { pathname: locations.collectionDetail('id') }],
+        [select(getOpenModals), { CreateSingleItemModal: true }]
+      ])
+      .not.put(push(locations.itemDetail(item.id)))
       .dispatch(saveItemSuccess(item, {}))
       .run({ silenceTimeout: true })
   })

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -349,16 +349,16 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
 
   function* handleSaveItemSuccess(action: SaveItemSuccessAction) {
     const openModals: ModalState = yield select(getOpenModals)
+    const location: ReturnType<typeof getLocation> = yield select(getLocation)
     if (openModals['EditItemURNModal']) {
       yield put(closeModal('EditItemURNModal'))
-    } else if (openModals['CreateSingleItemModal']) {
+    } else if (openModals['CreateSingleItemModal'] && location.pathname === locations.collections()) {
       // Redirect to the newly created item detail
       const { item } = action.payload
       yield put(push(locations.itemDetail(item.id)))
     }
     const { item } = action.payload
     const collectionId = item.collectionId!
-    const location: ReturnType<typeof getLocation> = yield select(getLocation)
     // Fetch the the collection items again, we don't know where the item is going to be in the pagination data
     if (location.pathname === locations.thirdPartyCollectionDetail(collectionId)) {
       yield call(fetchNewCollectionItemsPaginated, collectionId)


### PR DESCRIPTION
Closes #2052

The behaviour of redirecting to the detail page was planned for the Orphan items creation, that's why we need to specify from where the modal has been opened.