### PR TITLE
fix: Avoid the race condition getting the data from the tp items

### DIFF
--- a/src/modules/curations/itemCuration/sagas.spec.ts
+++ b/src/modules/curations/itemCuration/sagas.spec.ts
@@ -129,7 +129,20 @@ describe('when third party items were fetched', () => {
 
   describe('and some of the items were published', () => {
     beforeEach(() => {
-      items = [{ id: 'itemId1', isPublished: false } as Item, { id: 'itemId2', isPublished: true } as Item]
+      items = [
+        {
+          id: 'itemId1',
+          collectionId: thirdPartyCollection.id,
+          urn: 'urn:decentraland:mumbai:collections-thirdparty:thirdparty2:tercer-fiesta-2',
+          isPublished: false
+        } as Item,
+        {
+          id: 'itemId2',
+          collectionId: thirdPartyCollection.id,
+          urn: 'urn:decentraland:mumbai:collections-thirdparty:thirdparty2:tercer-fiesta-2',
+          isPublished: true
+        } as Item
+      ]
     })
 
     it('should put the success action and fetch the item curations for those items', () => {


### PR DESCRIPTION
## Problem

The collection and collection items are fetched at the same time. Once the items request is done, the one for the item curations is trigger. If at that point we collection request is still ongoing, the itemCuration sagas will fail because it tries to get data from the collection before triggering the curations request.


## Solution

We can get the same data from the items (`collectionId` and if the collection is TP or not). Let's do it that way so we don't have to way to both request (collection and item collections) to finish.

Closes #2056