### PR TITLE
feat: remove pagination if not necessary + add padding

### DIFF
--- a/src/components/ItemEditorPage/LeftPanel/Collections/Collections.css
+++ b/src/components/ItemEditorPage/LeftPanel/Collections/Collections.css
@@ -23,4 +23,5 @@
   justify-content: center;
   margin-top: auto;
   margin-bottom: 16px;
+  padding-top: 16px;
 }

--- a/src/components/ItemEditorPage/LeftPanel/Collections/Collections.tsx
+++ b/src/components/ItemEditorPage/LeftPanel/Collections/Collections.tsx
@@ -21,6 +21,8 @@ export default class Collections extends React.PureComponent<Props, State> {
     const { currentPage } = this.state
     if (collections.length === 0) return null
 
+    const totalPages = Math.ceil(totalCollections / LEFT_PANEL_PAGE_SIZE)
+
     return isLoading ? (
       <Loader size="small" active />
     ) : (
@@ -35,14 +37,16 @@ export default class Collections extends React.PureComponent<Props, State> {
               onSetCollection={onSetCollection}
             />
           ))}
-          <Pagination
-            siblingRange={0}
-            firstItem={null}
-            lastItem={null}
-            totalPages={Math.ceil(totalCollections / LEFT_PANEL_PAGE_SIZE)}
-            activePage={currentPage}
-            onPageChange={this.handlePageChange}
-          />
+          {totalPages > 1 ? (
+            <Pagination
+              siblingRange={0}
+              firstItem={null}
+              lastItem={null}
+              totalPages={totalPages}
+              activePage={currentPage}
+              onPageChange={this.handlePageChange}
+            />
+          ) : null}
         </Section>
       </>
     )

--- a/src/components/ItemEditorPage/LeftPanel/Items/Items.css
+++ b/src/components/ItemEditorPage/LeftPanel/Items/Items.css
@@ -52,6 +52,7 @@
   justify-content: center;
   margin-top: auto;
   margin-bottom: 16px;
+  padding-top: 16px;
 }
 
 .Items.dcl.section .ui.header.sub {

--- a/src/components/ItemEditorPage/LeftPanel/Items/Items.tsx
+++ b/src/components/ItemEditorPage/LeftPanel/Items/Items.tsx
@@ -109,16 +109,17 @@ export default class Items extends React.PureComponent<Props, State> {
   renderTabPagination = (total: number) => {
     const { currentTab, currentPages } = this.state
     const currentPage = currentPages[currentTab]
-    return (
+    const totalPages = Math.ceil(total / LEFT_PANEL_PAGE_SIZE)
+    return totalPages > 1 ? (
       <Pagination
         siblingRange={0}
         firstItem={null}
         lastItem={null}
-        totalPages={Math.ceil(total / LEFT_PANEL_PAGE_SIZE)}
+        totalPages={totalPages}
         activePage={currentPage}
         onPageChange={this.handlePageChange}
       />
-    )
+    ) : null
   }
 
   renderPaginationStats = (total: number) => {


### PR DESCRIPTION
This PR adds some padding to the pagination component in the sidebar so it doesn't touch the rows.

Before:
<img width="350" alt="Screen Shot 2022-05-27 at 16 23 34" src="https://user-images.githubusercontent.com/2781777/170781280-537909fd-fa13-4912-95d2-39faf0db4ffc.png">

After:
<img width="353" alt="Screen Shot 2022-05-27 at 16 21 04" src="https://user-images.githubusercontent.com/2781777/170781295-78ca884e-a78b-4e00-8ec0-0d6757f455a1.png">

Also it removes the pagination component if there's only 1 page like here:
<img width="355" alt="Screen Shot 2022-05-27 at 16 23 47" src="https://user-images.githubusercontent.com/2781777/170781351-6e156aba-2ae7-40a8-b307-03273a51dbd7.png">

