### PR TITLE
ci: fix prebuild

### DIFF
--- a/now.json
+++ b/now.json
@@ -5,6 +5,7 @@
     "env": {
       "NODE_PATH": "src",
       "NODE_ENV": "development",
+      "GEN_STATIC_LOCAL": "true",
       "PUBLIC_URL": "/",
       "REACT_APP_CHAIN_ID": "3",
       "REACT_APP_LOCAL_STORAGE_KEY": "builder",

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -1,6 +1,8 @@
 const fs = require('fs')
 const dotenv = require('dotenv')
 
+dotenv.config()
+
 let ENV_CONTENT = {}
 
 if (fs.existsSync('.env')) {
@@ -38,15 +40,24 @@ fs.writeFileSync('./package.json', JSON.stringify(packageJson, null, 2))
 fs.writeFileSync('./public/package.json', JSON.stringify(publicPackageJson, null, 2))
 
 function getPublicUrls() {
-  if (!process.env.GEN_STATIC_LOCAL) {
-    if (process.env.CI && !process.env.VERCEL_URL) {
-      // master/main branch, also releases
-      return {
-        PUBLIC_URL: `https://cdn.decentraland.org/${packageJson.name}/${packageJson.version}`
-      }
+  const isStatic = !!process.env.GEN_STATIC_LOCAL
+  const isCI = !!process.env.CI
+  const isVercel = isCI && !!process.env.VERCEL_URL
+  const isCDN = !isStatic && isCI && !isVercel
+  console.log('is static', isStatic)
+  console.log('is CI', isCI)
+  console.log('is Vercel', isVercel)
+  console.log('is CDN', isCDN)
+  if (isCDN) {
+    // master/main branch, also releases
+    const cdnUrl = `https://cdn.decentraland.org/${packageJson.name}/${packageJson.version}`
+    console.log(`Using CDN as public url: "${cdnUrl}"`)
+    return {
+      PUBLIC_URL: cdnUrl
     }
   }
   // localhost
+  console.log(`Using empty pubic url`)
   return {
     PUBLIC_URL: ``
   }

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -42,7 +42,7 @@ fs.writeFileSync('./public/package.json', JSON.stringify(publicPackageJson, null
 function getPublicUrls() {
   const isStatic = !!process.env.GEN_STATIC_LOCAL
   const isCI = !!process.env.CI
-  const isVercel = isCI && !!process.env.VERCEL_URL
+  const isVercel = isCI && !!process.env.VERCEL
   const isCDN = !isStatic && isCI && !isVercel
   console.log('is static', isStatic)
   console.log('is CI', isCI)


### PR DESCRIPTION
The fix is basically calling the `dotenv.config()` that puts the stuff from the `.env` file into the `process.env` object. The rest is for debugging.