### PR TITLE
fix: Fix retrieving batched item curations

### DIFF
--- a/src/modules/curations/itemCuration/sagas.ts
+++ b/src/modules/curations/itemCuration/sagas.ts
@@ -51,7 +51,7 @@ export function* itemCurationSaga(builder: BuilderAPI) {
       let itemCurations: ItemCuration[] = []
       if (items && items.length > 0) {
         const queue = new PQueue({ concurrency: REQUESTS_BATCH_SIZE })
-        const promisesOfCurationsToFetch: (() => Promise<ItemCuration[]>)[] = chunk(items!, MAX_ITEM_CURATIONS).map(chunkOfItems => () =>
+        const promisesOfCurationsToFetch: (() => Promise<ItemCuration[]>)[] = chunk(items, MAX_ITEM_CURATIONS).map(chunkOfItems => () =>
           builder.fetchItemCurations(
             collectionId,
             chunkOfItems.map(item => item.id)


### PR DESCRIPTION
After selecting all the items of a collection to publish or push changes, all the curations were requested at the same time using `/collections/collectionId/itemCurations` endpoint, failing the request due to reaching the maximum length of the URL.