### PR TITLE
fix: make emotes follow the wearable schema to allow deployments

### DIFF
--- a/src/modules/item/export.ts
+++ b/src/modules/item/export.ts
@@ -176,6 +176,15 @@ function buildItemEntityMetadata(collection: Collection, item: Item): StandardCa
     catalystItem.emoteDataV0 = {
       loop: (item.data as EmoteData).category === EmoteCategory.LOOP
     }
+    // add missing properties from wearable schema so catalyst wont reject the deployment
+    catalystItem.data.category = WearableCategory.HAT
+    catalystItem.data.hides = []
+    catalystItem.data.replaces = []
+    catalystItem.data.representations = catalystItem.data.representations.map(representation => ({
+      ...representation,
+      overrideHides: [],
+      overrideReplaces: []
+    }))
   }
 
   return catalystItem


### PR DESCRIPTION
Currently we can't deploy emotes because the metadata doesn't follow the wearable schema (missing hides/replaces/overrides and category is a different enum).

<img width="767" alt="Screen Shot 2022-06-06 at 17 03 17" src="https://user-images.githubusercontent.com/2781777/172246383-979da114-b0de-4f38-aba9-21b5b383a3f8.png">

So I had to hack it to make it pass through. I deployed and minted the pride emotes in ropsten and tested them on play.decentraland.org?NETWORK=ropsten and they worked fine:

 
<img width="1508" alt="Screen Shot 2022-06-06 at 17 44 05" src="https://user-images.githubusercontent.com/2781777/172246687-2afdf536-ea26-4a8a-873e-95ae03fca89a.png">

<img width="816" alt="Screen Shot 2022-06-06 at 17 45 50" src="https://user-images.githubusercontent.com/2781777/172246711-2344c579-b044-444a-a024-d16672158d04.png">

Eventually once the EMOTE entity type is live these emotes will need to be redeployed with the new entity type, and that one is going to have it's own schema so these hacks could be removed.
