### PR TITLE
fix: show publication errors in modal

### DIFF
--- a/src/components/Modals/PublishCollectionModalWithOracle/PublishCollectionModal.container.ts
+++ b/src/components/Modals/PublishCollectionModalWithOracle/PublishCollectionModal.container.ts
@@ -2,8 +2,13 @@ import { connect } from 'react-redux'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 import { getData as getWallet } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import { RootState } from 'modules/common/types'
-import { getCollection, getLoading as getCollectionLoading, getUnsyncedCollectionError } from 'modules/collection/selectors'
-import { getLoading as getItemLoading, getCollectionItems, getError } from 'modules/item/selectors'
+import {
+  getCollection,
+  getLoading as getCollectionLoading,
+  getUnsyncedCollectionError,
+  getError as getCollectionError
+} from 'modules/collection/selectors'
+import { getLoading as getItemLoading, getCollectionItems, getError as getItemError } from 'modules/item/selectors'
 import { publishCollectionRequest, PUBLISH_COLLECTION_REQUEST } from 'modules/collection/actions'
 import { fetchRaritiesRequest, FETCH_RARITIES_REQUEST, FETCH_ITEMS_REQUEST } from 'modules/item/actions'
 import { getRarities } from 'modules/item/selectors'
@@ -22,7 +27,8 @@ const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
     isPublishLoading: isLoadingType(getCollectionLoading(state), PUBLISH_COLLECTION_REQUEST),
     isFetchingItems: isLoadingType(getItemLoading(state), FETCH_ITEMS_REQUEST),
     isFetchingRarities: isLoadingType(getItemLoading(state), FETCH_RARITIES_REQUEST),
-    error: getError(state)
+    itemError: getItemError(state),
+    collectionError: getCollectionError(state)
   }
 }
 

--- a/src/components/Modals/PublishCollectionModalWithOracle/PublishCollectionModal.tsx
+++ b/src/components/Modals/PublishCollectionModalWithOracle/PublishCollectionModal.tsx
@@ -51,7 +51,7 @@ export default class PublishCollectionModal extends React.PureComponent<Props, S
   }
 
   renderFirstStep = () => {
-    const { items, wallet, onClose, rarities, error, isFetchingItems, isFetchingRarities } = this.props
+    const { items, wallet, onClose, rarities, itemError, isFetchingItems, isFetchingRarities } = this.props
 
     // The UI is designed in a way that considers that all rarities have the same price, so only using the first one
     // as reference for the prices is enough.
@@ -123,13 +123,13 @@ export default class PublishCollectionModal extends React.PureComponent<Props, S
                 </div>
               </div>
               <p className="estimate-notice">{t('publish_collection_modal_with_oracle.estimate_notice')}</p>
-              {error && (
+              {itemError && (
                 <>
                   <p className="rarities-error error">{t('publish_collection_modal_with_oracle.rarities_error')}</p>
-                  <p className="rarities-error-sub error">{error}</p>
+                  <p className="rarities-error-sub error">{itemError}</p>
                 </>
               )}
-              <Button className="proceed" primary fluid onClick={this.handleProceed} disabled={hasInsufficientMANA || !!error}>
+              <Button className="proceed" primary fluid onClick={this.handleProceed} disabled={hasInsufficientMANA || !!itemError}>
                 {t('global.next')}
               </Button>
               {hasInsufficientMANA && (
@@ -190,11 +190,11 @@ export default class PublishCollectionModal extends React.PureComponent<Props, S
   }
 
   renderThirdStep = () => {
-    const { isPublishLoading, unsyncedCollectionError, onClose } = this.props
+    const { isPublishLoading, unsyncedCollectionError, collectionError, onClose } = this.props
     const { email, emailFocus } = this.state
     const hasValidEmail = emailRegex.test(email ?? '')
     const showEmailError = !hasValidEmail && !emailFocus && email !== undefined && email !== ''
-
+    const error = unsyncedCollectionError || collectionError
     return (
       <Form onSubmit={this.handlePublish}>
         <ModalNavigation title={t('publish_collection_modal_with_oracle.title_tos')} onClose={onClose} />
@@ -233,11 +233,11 @@ export default class PublishCollectionModal extends React.PureComponent<Props, S
           />
         </Modal.Content>
         <Modal.Actions className="third-step-footer">
-          <Button primary fluid disabled={!hasValidEmail || isPublishLoading || !!unsyncedCollectionError} loading={isPublishLoading}>
+          <Button primary fluid disabled={!hasValidEmail || isPublishLoading || !!error} loading={isPublishLoading}>
             {t('global.publish')}
           </Button>
           <p>{t('publish_collection_modal_with_oracle.accept_by_publishing')}</p>
-          {unsyncedCollectionError && <p className="error">{t('publish_collection_modal_with_oracle.unsynced_collection')}</p>}
+          {error && <p className="error">{t('publish_collection_modal_with_oracle.unsynced_collection')}</p>}
         </Modal.Actions>
       </Form>
     )

--- a/src/components/Modals/PublishCollectionModalWithOracle/PublishCollectionModal.types.ts
+++ b/src/components/Modals/PublishCollectionModalWithOracle/PublishCollectionModal.types.ts
@@ -16,7 +16,8 @@ export type Props = ModalProps & {
   isFetchingItems: boolean
   isFetchingRarities: boolean
   unsyncedCollectionError: string | null
-  error: string | null
+  collectionError: string | null
+  itemError: string | null
   onPublish: typeof publishCollectionRequest
   onFetchRarities: typeof fetchRaritiesRequest
 }
@@ -41,7 +42,8 @@ export type MapStateProps = Pick<
   | 'isPublishLoading'
   | 'isFetchingItems'
   | 'isFetchingRarities'
-  | 'error'
+  | 'collectionError'
+  | 'itemError'
 >
 export type MapDispatchProps = Pick<Props, 'onPublish' | 'onFetchRarities'>
 export type MapDispatch = Dispatch<PublishCollectionRequestAction | FetchRaritiesRequestAction>


### PR DESCRIPTION
Show errors from the `collection` module in `PublishCollectionModal`. These are errors like when the collection is locked, or when it is already published.