### PR TITLE
fix: use as alias

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dcl/content-hash-tree": "^1.1.3",
         "@dcl/crypto": "^3.0.1",
         "@dcl/hashing": "^1.1.0",
-        "@dcl/schemas": "^4.11.0",
+        "@dcl/schemas": "^4.14.0",
         "@dcl/ui-env": "^1.2.0",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^11.0.0",
@@ -2371,9 +2371,9 @@
       "integrity": "sha512-Z0zpNr2HAxn2cLWUadWGlzaG48Z+N3hg2bI20UH+OT8NJtvCJnAwVBshAG83iAn4BTC+CsUsk4A394jrlv2ZIQ=="
     },
     "node_modules/@dcl/schemas": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-4.13.0.tgz",
-      "integrity": "sha512-Pb2PZ+4JmqosmcF2q0hojBEW2KNUcxQ7a0mpfANnIHALygjgUZmNrN03a3RzXB5U0SztJAvto1AVEnptg1lKLg==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-4.14.0.tgz",
+      "integrity": "sha512-poocumKlQ8XwoUWNzpyfHNARMsxvOzM3lbrU82KnyXbsgcv/8STj41ZHkCaFafCpAVWSb+IJGPe8tQaTxy0Ygw==",
       "dependencies": {
         "ajv": "^7.1.0",
         "ajv-errors": "^2.0.1",
@@ -33493,9 +33493,9 @@
       "integrity": "sha512-Z0zpNr2HAxn2cLWUadWGlzaG48Z+N3hg2bI20UH+OT8NJtvCJnAwVBshAG83iAn4BTC+CsUsk4A394jrlv2ZIQ=="
     },
     "@dcl/schemas": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-4.13.0.tgz",
-      "integrity": "sha512-Pb2PZ+4JmqosmcF2q0hojBEW2KNUcxQ7a0mpfANnIHALygjgUZmNrN03a3RzXB5U0SztJAvto1AVEnptg1lKLg==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-4.14.0.tgz",
+      "integrity": "sha512-poocumKlQ8XwoUWNzpyfHNARMsxvOzM3lbrU82KnyXbsgcv/8STj41ZHkCaFafCpAVWSb+IJGPe8tQaTxy0Ygw==",
       "requires": {
         "ajv": "^7.1.0",
         "ajv-errors": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@dcl/content-hash-tree": "^1.1.3",
     "@dcl/crypto": "^3.0.1",
     "@dcl/hashing": "^1.1.0",
-    "@dcl/schemas": "^4.11.0",
+    "@dcl/schemas": "^4.14.0",
     "@dcl/ui-env": "^1.2.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^11.0.0",


### PR DESCRIPTION
There was very niche dependency problem causing EntityType to be `undefined` **inside** decentraland-dapps. Because the (not major 😠 ) version of @dcl/schemas removes EntityType I had to force-install 4.14.0 for it to work.

That said, I'm now hitting this error:

`"Failed to fetch https://peer.decentraland.zone/content/contents/QmV6f9iNyPGTFsFrWuv5AnQkjWcHkt8WXNZnjXSAGtofdy. Got status 404. Response was ''"`

in dev. Pls reviewer could you check with your names? as I'm not sure if this is a me thing