### PR TITLE
feat: Filter collections to only show allowed ones when moving a single item to a collection

### DIFF
--- a/src/components/CollectionDropdown/CollectionDropdown.tsx
+++ b/src/components/CollectionDropdown/CollectionDropdown.tsx
@@ -6,9 +6,9 @@ import './CollectionDropdown.css'
 
 export default class CollectionDropdown extends React.PureComponent<Props> {
   componentDidMount() {
-    const { address, isCollectionPublished, onFetchCollections } = this.props
+    const { address, onFetchCollections, fetchCollectionParams } = this.props
     if (address) {
-      onFetchCollections(address, {isPublished: isCollectionPublished})
+      onFetchCollections(address, fetchCollectionParams)
     }
   }
 

--- a/src/components/CollectionDropdown/CollectionDropdown.tsx
+++ b/src/components/CollectionDropdown/CollectionDropdown.tsx
@@ -6,9 +6,9 @@ import './CollectionDropdown.css'
 
 export default class CollectionDropdown extends React.PureComponent<Props> {
   componentDidMount() {
-    const { address, onFetchCollections } = this.props
+    const { address, isCollectionPublished, onFetchCollections } = this.props
     if (address) {
-      onFetchCollections(address)
+      onFetchCollections(address, {isPublished: isCollectionPublished})
     }
   }
 

--- a/src/components/CollectionDropdown/CollectionDropdown.types.ts
+++ b/src/components/CollectionDropdown/CollectionDropdown.types.ts
@@ -1,4 +1,5 @@
 import { Dispatch } from 'redux'
+import { FetchCollectionsParams } from 'lib/api/builder'
 import { fetchCollectionsRequest, FetchCollectionsRequestAction } from 'modules/collection/actions'
 import { Collection } from 'modules/collection/types'
 
@@ -8,7 +9,7 @@ export type Props = {
   value?: Collection
   placeholder?: string
   filter?: (collection: Collection) => boolean
-  isCollectionPublished?: boolean
+  fetchCollectionParams?: FetchCollectionsParams
   onChange: (collection: Collection) => void
   isDisabled?: boolean
   onFetchCollections: typeof fetchCollectionsRequest

--- a/src/components/CollectionDropdown/CollectionDropdown.types.ts
+++ b/src/components/CollectionDropdown/CollectionDropdown.types.ts
@@ -8,6 +8,7 @@ export type Props = {
   value?: Collection
   placeholder?: string
   filter?: (collection: Collection) => boolean
+  isCollectionPublished?: boolean
   onChange: (collection: Collection) => void
   isDisabled?: boolean
   onFetchCollections: typeof fetchCollectionsRequest

--- a/src/components/Modals/MoveItemToCollectionModal/MoveItemToCollectionModal.tsx
+++ b/src/components/Modals/MoveItemToCollectionModal/MoveItemToCollectionModal.tsx
@@ -30,7 +30,7 @@ export default class MoveItemToCollectionModal extends React.PureComponent<Props
             value={collection}
             onChange={this.handleChangeCollection}
             filter={collection => !isTPCollection(collection) && !collection.isPublished}
-            isCollectionPublished={false}
+            fetchCollectionParams={{ isPublished: false }}
           />
         </ModalContent>
         <ModalActions>

--- a/src/components/Modals/MoveItemToCollectionModal/MoveItemToCollectionModal.tsx
+++ b/src/components/Modals/MoveItemToCollectionModal/MoveItemToCollectionModal.tsx
@@ -30,6 +30,7 @@ export default class MoveItemToCollectionModal extends React.PureComponent<Props
             value={collection}
             onChange={this.handleChangeCollection}
             filter={collection => !isTPCollection(collection) && !collection.isPublished}
+            isCollectionPublished={false}
           />
         </ModalContent>
         <ModalActions>

--- a/src/components/Modals/MoveItemToCollectionModal/MoveItemToCollectionModal.tsx
+++ b/src/components/Modals/MoveItemToCollectionModal/MoveItemToCollectionModal.tsx
@@ -29,7 +29,7 @@ export default class MoveItemToCollectionModal extends React.PureComponent<Props
           <CollectionDropdown
             value={collection}
             onChange={this.handleChangeCollection}
-            filter={collection => !isTPCollection(collection)}
+            filter={collection => !isTPCollection(collection) && !collection.isPublished}
           />
         </ModalContent>
         <ModalActions>

--- a/src/lib/api/builder.ts
+++ b/src/lib/api/builder.ts
@@ -331,7 +331,7 @@ function toRemoteItem(item: Item): Omit<RemoteItem, 'created_at' | 'updated_at'>
     contents: item.contents,
     content_hash: item.blockchainContentHash,
     local_content_hash: item.currentContentHash,
-    catalyst_content_hash: item.catalystContentHash,
+    catalyst_content_hash: item.catalystContentHash
   }
 
   return remoteItem
@@ -682,9 +682,8 @@ export class BuilderAPI extends BaseAPI {
   }
 
   async fetchCollections(address?: string, params?: FetchCollectionsParams) {
-    const remoteCollections = address
-      ? await this.request('get', `/${address}/collections`, toRemoteCollectionQueryParameters(params))
-      : await this.request('get', '/collections', toRemoteCollectionQueryParameters(params))
+    const url = address ? `/${address}/collections` : '/collections'
+    const remoteCollections = await this.request('get', url, toRemoteCollectionQueryParameters(params))
 
     const { limit, page } = params || {}
     if (page && limit && remoteCollections.results) {

--- a/src/lib/api/builder.ts
+++ b/src/lib/api/builder.ts
@@ -683,7 +683,7 @@ export class BuilderAPI extends BaseAPI {
 
   async fetchCollections(address?: string, params?: FetchCollectionsParams) {
     const remoteCollections = address
-      ? await this.request('get', `/${address}/collections`, params)
+      ? await this.request('get', `/${address}/collections`, toRemoteCollectionQueryParameters(params))
       : await this.request('get', '/collections', toRemoteCollectionQueryParameters(params))
 
     const { limit, page } = params || {}


### PR DESCRIPTION
This PR allows filtering the available collections to show when moving an item to a collection.

Closes: #2143