### PR TITLE
fix: Enable the move button only when selecting a collection

### DIFF
--- a/src/components/Modals/MoveItemToCollectionModal/MoveItemToCollectionModal.tsx
+++ b/src/components/Modals/MoveItemToCollectionModal/MoveItemToCollectionModal.tsx
@@ -33,7 +33,7 @@ export default class MoveItemToCollectionModal extends React.PureComponent<Props
           />
         </ModalContent>
         <ModalActions>
-          <Button primary onClick={() => collection && onSubmit(item, collection.id)} loading={isLoading} disabled={!item}>
+          <Button primary onClick={() => collection && onSubmit(item, collection.id)} loading={isLoading} disabled={!item || !collection}>
             {t('move_item_to_collection_modal.confirm')}
           </Button>
         </ModalActions>


### PR DESCRIPTION
This PR disables the move button when the user has not selected a collection and enables it when a collection is selected.

Closes: #2153