### PR TITLE
fix: Fetch the items list again when moving a single item to a collection successfully

### DIFF
--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -451,6 +451,8 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
     yield put(saveItemRequest(newItem, {}))
     yield take(SAVE_ITEM_SUCCESS)
     yield put(closeModal('AddExistingItemModal'))
+    const address: string = yield select(getAddress)
+    yield put(fetchItemsRequest(address))
   }
 
   function* handleSetItemsTokenIdRequest(action: SetItemsTokenIdRequestAction) {

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -443,6 +443,7 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
   function* handleSetCollection(action: SetCollectionAction) {
     const { item, collectionId } = action.payload
     const newItem = { ...item }
+    const address: string = yield select(getAddress)
     if (collectionId === null) {
       delete newItem.collectionId
     } else {
@@ -450,8 +451,6 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
     }
     yield put(saveItemRequest(newItem, {}))
     yield take(SAVE_ITEM_SUCCESS)
-    yield put(closeModal('AddExistingItemModal'))
-    const address: string = yield select(getAddress)
     yield put(fetchItemsRequest(address))
   }
 


### PR DESCRIPTION
This PR allows fetching the items list again when moving an orphan item to an unpublished collection successfully.

Closes: #2152