### PR TITLE
Fix: Edit item Price and Beneficiary should not change the item metadata

### DIFF
--- a/src/modules/item/sagas.spec.ts
+++ b/src/modules/item/sagas.spec.ts
@@ -1322,7 +1322,7 @@ describe('when handling the delete item success action', () => {
   })
 })
 
-describe('when handling the save item success action', () => {
+describe('when handling the save item curation success action', () => {
   let item: Item
   beforeEach(() => {
     item = { ...mockedItem }

--- a/src/modules/item/sagas.spec.ts
+++ b/src/modules/item/sagas.spec.ts
@@ -474,7 +474,7 @@ describe('when handling the setPriceAndBeneficiaryRequest action', () => {
       mockEthers.mockReturnValue(contractInstanceMock)
     })
 
-    afterAll(() => {
+    afterEach(() => {
       mockEthers.mockRestore()
     })
 

--- a/src/modules/item/sagas.spec.ts
+++ b/src/modules/item/sagas.spec.ts
@@ -466,19 +466,19 @@ describe('when handling the setPriceAndBeneficiaryRequest action', () => {
       mockEthers = jest.spyOn(ethers, 'Contract')
 
       contractInstanceMock = {
-        items: jest.fn().mockImplementation(() => ({
+        items: jest.fn().mockReturnValue(() => ({
           metadata: 'metadata'
         }))
       }
 
-      mockEthers.mockImplementation(() => contractInstanceMock)
+      mockEthers.mockReturnValue(contractInstanceMock)
     })
 
     afterAll(() => {
       mockEthers.mockRestore()
     })
 
-    it.only('should put a setPriceAndBeneficiarySuccess action', () => {
+    it('should put a setPriceAndBeneficiarySuccess action', () => {
       const collection = {
         id: 'aCollection'
       } as Collection

--- a/src/modules/item/sagas.spec.ts
+++ b/src/modules/item/sagas.spec.ts
@@ -460,7 +460,7 @@ describe('when handling the save item success action', () => {
 describe('when handling the setPriceAndBeneficiaryRequest action', () => {
   describe('and the item is published', () => {
     let mockEthers: jest.SpyInstance
-    let contractInstanceMock: { items: (tokenId: string) => {} }
+    let contractInstanceMock: { items: () => {} }
 
     beforeEach(() => {
       mockEthers = jest.spyOn(ethers, 'Contract')
@@ -478,7 +478,7 @@ describe('when handling the setPriceAndBeneficiaryRequest action', () => {
       mockEthers.mockRestore()
     })
 
-    it('should put a setPriceAndBeneficiarySuccess action', () => {
+    it('should put a setPriceAndBeneficiarySuccess action', async () => {
       const collection = {
         id: 'aCollection'
       } as Collection
@@ -510,15 +510,11 @@ describe('when handling the setPriceAndBeneficiaryRequest action', () => {
       const price = '1000'
       const beneficiary = '0xpepe'
 
-      expectSaga(itemSaga, builderAPI, builderClient)
+      await expectSaga(itemSaga, builderAPI, builderClient)
         .provide([
           [select(getItems), [item]],
           [select(getCollections), [collection]],
           [call(getChainIdByNetwork, Network.MATIC), ChainId.MATIC_MAINNET],
-          [
-            matchers.call.fn(contractInstanceMock.items as ethers.ContractFunction),
-            Promise.resolve(contractInstanceMock.items(item.tokenId!))
-          ],
           [matchers.call.fn(sendTransaction), Promise.resolve('0xhash')]
         ])
         .put(setPriceAndBeneficiarySuccess({ ...item, price, beneficiary }, ChainId.MATIC_MAINNET, '0xhash'))

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -102,7 +102,7 @@ import { MAX_ITEMS } from 'modules/collection/constants'
 import { fetchEntitiesByPointersRequest } from 'modules/entity/actions'
 import { takeLatestCancellable } from 'modules/common/utils'
 import { waitForTx } from 'modules/transaction/utils'
-import { getMethodData, getProperty } from 'modules/wallet/utils'
+import { getMethodData } from 'modules/wallet/utils'
 import { getCatalystContentUrl } from 'lib/api/peer'
 import { downloadZip } from 'lib/zip'
 import { calculateFinalSize, reHashOlderContents } from './export'
@@ -397,7 +397,7 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
       // Get the item metadata from the blockchain to avoid modifications when updating the price or the beneficiary.
       const provider: Awaited<ReturnType<typeof getNetworkProvider>> = yield call(getNetworkProvider, chainId)
       const implementation = new Contract(contract.address, contract.abi, new providers.Web3Provider(provider))
-      const { metadata } = yield call(getProperty, implementation.items(item.tokenId))
+      const { metadata } = yield call(implementation.items, item.tokenId)
       const txHash: string = yield call(sendTransaction, contract, collection =>
         collection.editItemsData([newItem.tokenId!], [newItem.price!], [newItem.beneficiary!], [metadata])
       )

--- a/src/modules/wallet/utils.ts
+++ b/src/modules/wallet/utils.ts
@@ -30,3 +30,7 @@ export async function getMethodData(populatedTransactionPromise: Promise<ethers.
   const populatedTransaction = await populatedTransactionPromise
   return populatedTransaction.data!
 }
+
+export async function getProperty(propertyPromise: Promise<ethers.ContractFunction>) {
+  return await propertyPromise
+}

--- a/src/modules/wallet/utils.ts
+++ b/src/modules/wallet/utils.ts
@@ -30,7 +30,3 @@ export async function getMethodData(populatedTransactionPromise: Promise<ethers.
   const populatedTransaction = await populatedTransactionPromise
   return populatedTransaction.data!
 }
-
-export async function getProperty(propertyPromise: Promise<ethers.ContractFunction>) {
-  return await propertyPromise
-}


### PR DESCRIPTION
This PR avoids updating the item metadata when setting a new item price/beneficiary. Instead, it gets the item metadata from the blockchain and uses it when sending the txn.

Closes: #1694