### PR TITLE
Fix: Emotes redirection to the item editor

### DIFF
--- a/src/modules/item/sagas.spec.ts
+++ b/src/modules/item/sagas.spec.ts
@@ -543,7 +543,7 @@ describe('when handling the save item success action', () => {
                 [select(getOpenModals), { CreateSingleItemModal: true }],
                 [select(getIsEmotesFlowEnabled), true]
               ])
-              .put(push(locations.itemEditor({ itemId: item.id })))
+              .put(push(locations.itemEditor({ collectionId: collection.id, itemId: item.id })))
               .dispatch(saveItemSuccess(item, {}))
               .run({ silenceTimeout: true })
           })

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -375,7 +375,7 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
         }
       } else if (location.pathname === locations.collectionDetail(collectionId) && isEmotesFeatureFlagOn && item.type === ItemType.EMOTE) {
         // Redirect to the item editor
-        yield put(push(locations.itemEditor({ itemId: item.id })))
+        yield put(push(locations.itemEditor({ collectionId, itemId: item.id })))
       } else {
         yield put(closeModal('CreateSingleItemModal'))
       }


### PR DESCRIPTION
This PR fixes the emotes redirection to the item editor when creating inside a collection.

Closes #2220