### PR TITLE
fix: Fix the missing prop `bodyshape` when adding an item representation

### DIFF
--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
@@ -342,9 +342,11 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
   }
 
   handleDropAccepted = (acceptedFileProps: AcceptedFileProps) => {
-    this.setState({
-      ...acceptedFileProps
-    })
+    const { bodyShape, ...acceptedProps } = acceptedFileProps
+    this.setState(prevState => ({
+      bodyShape: bodyShape || prevState.bodyShape,
+      ...acceptedProps
+    }))
   }
 
   handleOpenDocs = () => window.open('https://docs.decentraland.org/3d-modeling/3d-models/', '_blank')
@@ -558,12 +560,12 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
 
   renderImportView() {
     const { metadata, onClose } = this.props
-    const { isRepresentation, category } = this.state
+    const { category, isRepresentation } = this.state
     const title = this.renderModalTitle()
 
     return (
       <ImportStep
-        category={category! as WearableCategory}
+        category={category as WearableCategory}
         metadata={metadata}
         title={title}
         wearablePreviewComponent={<div className="importer-thumbnail-container">{this.renderWearablePreview()}</div>}

--- a/src/components/Modals/CreateSingleItemModal/ImportStep/ImportStep.tsx
+++ b/src/components/Modals/CreateSingleItemModal/ImportStep/ImportStep.tsx
@@ -130,6 +130,7 @@ export default class ImportStep extends React.PureComponent<Props, State> {
 
       const handler = extension === '.zip' ? this.handleZippedModelFiles : this.handleModelFile
       const { model, contents, type, assetJson } = await handler(file)
+      const isEmote = type === ItemType.EMOTE
 
       onDropAccepted({
         id: changeItemFile ? item!.id : uuid.v4(),
@@ -138,7 +139,7 @@ export default class ImportStep extends React.PureComponent<Props, State> {
         type,
         model,
         contents,
-        bodyShape: type === ItemType.EMOTE ? BodyShapeType.BOTH : undefined,
+        bodyShape: isEmote ? BodyShapeType.BOTH : undefined,
         category: isRepresentation ? category : undefined,
         ...(await this.getAssetJsonProps(assetJson, contents))
       })

--- a/src/components/Modals/CreateSingleItemModal/ImportStep/ImportStep.types.ts
+++ b/src/components/Modals/CreateSingleItemModal/ImportStep/ImportStep.types.ts
@@ -1,6 +1,6 @@
+import React from 'react'
 import { WearableCategory } from '@dcl/schemas'
 import { Item } from 'modules/item/types'
-import React from 'react'
 import { AcceptedFileProps } from '../CreateSingleItemModal.types'
 
 export type Props = {


### PR DESCRIPTION
This PR fixes the missing prop `bodyShape` when adding an item representation.