### PR TITLE
fix: Use Emotes FF to build entity to deploy

### DIFF
--- a/src/modules/collection/sagas.spec.ts
+++ b/src/modules/collection/sagas.spec.ts
@@ -420,7 +420,7 @@ describe('when executing the approval flow', () => {
           [delay(1000), void 0],
           [select(getItemsById), { [syncedItem.id]: syncedItem, [updatedItem.id]: updatedItem }],
           [select(getEntityByItemId), { [syncedItem.id]: syncedEntity, [updatedItem.id]: unsyncedEntity }],
-          [call(buildItemEntity, mockCatalyst, mockBuilder, collection, unsyncedItem), deployData]
+          [call(buildItemEntity, mockCatalyst, mockBuilder, collection, unsyncedItem, undefined, undefined, false), deployData]
         ])
         .dispatch(initiateApprovalFlow(collection))
         .put(
@@ -505,7 +505,7 @@ describe('when executing the approval flow', () => {
           [delay(1000), void 0],
           [select(getItemsById), { [syncedItem.id]: syncedItem, [unsyncedItem.id]: updatedItem }],
           [select(getEntityByItemId), { [syncedItem.id]: syncedEntity, [updatedItem.id]: unsyncedEntity }],
-          [call(buildItemEntity, mockCatalyst, mockBuilder, collection, unsyncedItem), deployData],
+          [call(buildItemEntity, mockCatalyst, mockBuilder, collection, unsyncedItem, undefined, undefined, false), deployData],
           [select(getCurationsByCollectionId), { [collection.id]: curation }]
         ])
         .dispatch(initiateApprovalFlow(collection))
@@ -668,7 +668,7 @@ describe('when executing the approval flow', () => {
           [delay(1000), void 0],
           [select(getItemsById), { [syncedItem.id]: syncedItem, [updatedItem.id]: updatedItem }],
           [select(getEntityByItemId), { [syncedItem.id]: syncedEntity, [updatedItem.id]: unsyncedEntity }],
-          [call(buildItemEntity, mockCatalyst, mockBuilder, collection, unsyncedItem), deployData]
+          [call(buildItemEntity, mockCatalyst, mockBuilder, collection, unsyncedItem, undefined, undefined, false), deployData]
         ])
         .dispatch(initiateApprovalFlow(collection))
         .put(
@@ -747,7 +747,7 @@ describe('when executing the approval flow', () => {
           [delay(1000), void 0],
           [select(getItemsById), { [syncedItem.id]: syncedItem, [updatedItem.id]: updatedItem }],
           [select(getEntityByItemId), { [syncedItem.id]: syncedEntity, [updatedItem.id]: unsyncedEntity }],
-          [call(buildItemEntity, mockCatalyst, mockBuilder, collection, unsyncedItem), deployData]
+          [call(buildItemEntity, mockCatalyst, mockBuilder, collection, unsyncedItem, undefined, undefined, false), deployData]
         ])
         .dispatch(initiateApprovalFlow(collection))
         .put(
@@ -835,7 +835,7 @@ describe('when executing the approval flow', () => {
           [delay(1000), void 0],
           [select(getItemsById), { [syncedItem.id]: syncedItem, [unsyncedItem.id]: updatedItem }],
           [select(getEntityByItemId), { [syncedItem.id]: syncedEntity, [updatedItem.id]: unsyncedEntity }],
-          [call(buildItemEntity, mockCatalyst, mockBuilder, collection, unsyncedItem), deployData],
+          [call(buildItemEntity, mockCatalyst, mockBuilder, collection, unsyncedItem, undefined, undefined, false), deployData],
           [select(getCurationsByCollectionId), { [collection.id]: curation }]
         ])
         .dispatch(initiateApprovalFlow(collection))

--- a/src/modules/collection/sagas.ts
+++ b/src/modules/collection/sagas.ts
@@ -623,7 +623,17 @@ export function* collectionSaga(legacyBuilderClient: BuilderAPI, client: Builder
     for (const item of itemsOfCollection) {
       const deployedEntity = entitiesByItemId[item.id]
       if (!deployedEntity || !areSynced(item, deployedEntity, emotesFeatureFlag)) {
-        const entity: DeploymentPreparationData = yield call(buildItemEntity, catalyst, legacyBuilderClient, collection, item)
+        //TODO: @Emotes remove emotesFeatureFlag once launched
+        const entity: DeploymentPreparationData = yield call(
+          buildItemEntity,
+          catalyst,
+          legacyBuilderClient,
+          collection,
+          item,
+          undefined,
+          undefined,
+          emotesFeatureFlag
+        )
         itemsToDeploy.push(item)
         entitiesToDeploy.push(entity)
       }

--- a/src/modules/item/export.ts
+++ b/src/modules/item/export.ts
@@ -242,7 +242,7 @@ export async function buildItemEntity(
     metadata = buildWearableEntityMetadata(collection, item as Item)
   }
   return client.buildEntity({
-    type: isEmote && emotesFeatureFlag ? EntityType.EMOTE : EntityType.WEARABLE,
+    type: isEmote ? EntityType.EMOTE : EntityType.WEARABLE,
     pointers: [metadata.id],
     metadata,
     files,

--- a/src/modules/item/export.ts
+++ b/src/modules/item/export.ts
@@ -226,21 +226,23 @@ export async function buildItemEntity(
   collection: Collection,
   item: Item | Item<ItemType.EMOTE>,
   tree?: MerkleDistributorInfo,
-  itemHash?: string
+  itemHash?: string,
+  emotesFeatureFlag = false
 ): Promise<DeploymentPreparationData> {
   const blobs = await buildItemEntityBlobs(item, legacyBuilderClient)
   const files = await makeContentFiles(blobs)
   let metadata
-  const isEmote = isEmoteItemType(item)
+  const isEmote = emotesFeatureFlag && isEmoteItemType(item) //TODO: @Emotes remove this FF once launched
   if (isEmote) {
     metadata = buildEmoteEntityMetadata(collection, item)
   } else if (tree && itemHash) {
-    metadata = buildTPItemEntityMetadata(item, itemHash, tree)
+    metadata = buildTPItemEntityMetadata(item as Item, itemHash, tree)
   } else {
-    metadata = buildWearableEntityMetadata(collection, item)
+    // Emotes will be deployed as Wearables ultil they are released
+    metadata = buildWearableEntityMetadata(collection, item as Item)
   }
   return client.buildEntity({
-    type: isEmote ? EntityType.EMOTE : EntityType.WEARABLE,
+    type: isEmote && emotesFeatureFlag ? EntityType.EMOTE : EntityType.WEARABLE,
     pointers: [metadata.id],
     metadata,
     files,


### PR DESCRIPTION
Until the new emotes code is released, we need to keep deploying them as pre-ADR74 emotes, meaning as wearables.