### PR TITLE
fix: Show single emotes in the emote dropdown button

### DIFF
--- a/src/components/CollectionProvider/CollectionProvider.tsx
+++ b/src/components/CollectionProvider/CollectionProvider.tsx
@@ -51,7 +51,7 @@ export default class CollectionProvider extends React.PureComponent<Props> {
       if (!paginatedItems.find(item => item.id === itemSelected)) {
         const totalPages = Math.ceil(items.length / itemsPageSize!)
         const nextPage = Math.min(totalPages, (itemsPage as number[])!.length + 1)
-        if (!(itemsPage as number[]).includes(nextPage)) {
+        if (Array.isArray(itemsPage) && !itemsPage.includes(nextPage)) {
           this.setState({ initialPage: nextPage }, () => onChangePage!(nextPage))
         }
       }

--- a/src/components/CollectionProvider/CollectionProvider.tsx
+++ b/src/components/CollectionProvider/CollectionProvider.tsx
@@ -3,6 +3,10 @@ import equal from 'fast-deep-equal'
 import { DEFAULT_ITEMS_PAGE_SIZE, DEFAULT_ITEMS_PAGE, Props } from './CollectionProvider.types'
 
 export default class CollectionProvider extends React.PureComponent<Props> {
+  state = {
+    initialPage: DEFAULT_ITEMS_PAGE
+  }
+
   fetchCollectionItems(itemsPage: number | number[] = DEFAULT_ITEMS_PAGE) {
     const { id, onFetchCollectionItems, itemsPageSize, fetchOptions } = this.props
     if (id) {
@@ -18,12 +22,39 @@ export default class CollectionProvider extends React.PureComponent<Props> {
     }
   }
 
-  componentDidUpdate(prevProps: Props) {
-    const { id, isConnected, collection, itemsPage, fetchOptions, onFetchCollection } = this.props
+  componentDidUpdate(prevProps: Props, prevState: any) {
+    const {
+      id,
+      isConnected,
+      collection,
+      items,
+      itemsPage,
+      itemsPageSize,
+      itemSelected,
+      fetchOptions,
+      paginatedItems,
+      onFetchCollection,
+      onChangePage
+    } = this.props
     const justFinishedConnecting = !prevProps.isConnected && isConnected
     if (id && justFinishedConnecting) {
       onFetchCollection(id)
       this.fetchCollectionItems(itemsPage)
+    }
+
+    if (
+      collection &&
+      paginatedItems &&
+      itemSelected &&
+      (this.state.initialPage === DEFAULT_ITEMS_PAGE || prevState.initialPage < this.state.initialPage)
+    ) {
+      if (!paginatedItems.find(item => item.id === itemSelected)) {
+        const totalPages = Math.ceil(items.length / itemsPageSize!)
+        const nextPage = Math.min(totalPages, (itemsPage as number[])!.length + 1)
+        if (!(itemsPage as number[]).includes(nextPage)) {
+          this.setState({ initialPage: nextPage }, () => onChangePage!(nextPage))
+        }
+      }
     }
 
     if (id && id !== prevProps.id) {
@@ -58,12 +89,14 @@ export default class CollectionProvider extends React.PureComponent<Props> {
       children,
       onFetchCollectionItems
     } = this.props
+    const { initialPage } = this.state
     return (
       <>
         {children({
           collection,
           items,
           paginatedItems,
+          initialPage,
           paginatedCollections,
           curation,
           itemCurations,

--- a/src/components/CollectionProvider/CollectionProvider.types.ts
+++ b/src/components/CollectionProvider/CollectionProvider.types.ts
@@ -16,6 +16,7 @@ export type Props = {
   paginatedCollections: Collection[]
   items: Item[]
   paginatedItems: Item[]
+  itemSelected?: string | null
   itemsPage?: number | number[]
   itemsPageSize?: number
   fetchOptions?: Pick<FetchCollectionsParams, 'status' | 'synced'>
@@ -29,6 +30,7 @@ export type Props = {
     paginatedItems,
     curation,
     itemCurations,
+    initialPage,
     isLoading,
     onFetchCollectionItemsPages
   }: {
@@ -38,11 +40,13 @@ export type Props = {
     paginatedItems: Item[]
     curation: CollectionCuration | null
     itemCurations: ItemCuration[] | null
+    initialPage: number
     isLoading: boolean
     onFetchCollectionItemsPages: typeof fetchCollectionItemsRequest
   }) => React.ReactNode
   onFetchCollection: typeof fetchCollectionRequest
   onFetchCollectionItems: typeof fetchCollectionItemsRequest
+  onChangePage?: (page: number) => void
 }
 
 export type MapStateProps = Pick<
@@ -51,4 +55,4 @@ export type MapStateProps = Pick<
 >
 export type MapDispatchProps = Pick<Props, 'onFetchCollection' | 'onFetchCollectionItems'>
 export type MapDispatch = Dispatch<FetchCollectionRequestAction | FetchCollectionItemsRequestAction>
-export type OwnProps = Partial<Pick<Props, 'id' | 'itemsPage' | 'itemsPageSize'>>
+export type OwnProps = Partial<Pick<Props, 'id' | 'itemSelected' | 'itemsPage' | 'itemsPageSize' | 'onChangePage'>>

--- a/src/components/ItemEditorPage/CenterPanel/CenterPanel.container.ts
+++ b/src/components/ItemEditorPage/CenterPanel/CenterPanel.container.ts
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 import { PreviewEmote } from '@dcl/schemas'
 import { getOpenModals } from 'decentraland-dapps/dist/modules/modal/selectors'
+import { getAddress } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import { RootState } from 'modules/common/types'
 import { Collection } from 'modules/collection/types'
 import { getCollections } from 'modules/collection/selectors'
@@ -26,6 +27,7 @@ import {
   getWearablePreviewController,
   isPlayingEmote
 } from 'modules/editor/selectors'
+import { fetchCollectionItemsRequest, fetchItemsRequest } from 'modules/item/actions'
 import { getEmotes, getItem } from 'modules/item/selectors'
 import { ItemType } from 'modules/item/types'
 import { getSelectedCollectionId, getSelectedItemId } from 'modules/location/selectors'
@@ -33,6 +35,7 @@ import { MapStateProps, MapDispatchProps, MapDispatch } from './CenterPanel.type
 import CenterPanel from './CenterPanel'
 
 const mapState = (state: RootState): MapStateProps => {
+  const address = getAddress(state)
   let collection: Collection | undefined
   const collectionId = getSelectedCollectionId(state)
   // Emotes created by the user
@@ -58,6 +61,7 @@ const mapState = (state: RootState): MapStateProps => {
   const isImportFilesModalOpen = 'CreateSingleItemModal' in getOpenModals(state)
 
   return {
+    address,
     bodyShape,
     collection,
     selectedItem,
@@ -83,7 +87,9 @@ const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
   onSetBaseWearable: (category, bodyShape, wearable) => dispatch(setBaseWearable(category, bodyShape, wearable)),
   onFetchBaseWearables: () => dispatch(fetchBaseWearablesRequest()),
   onSetWearablePreviewController: controller => dispatch(setWearablePreviewController(controller)),
-  onSetItems: items => dispatch(setItems(items))
+  onSetItems: items => dispatch(setItems(items)),
+  onFetchOrphanItems: (address, params?) => dispatch(fetchItemsRequest(address, params)),
+  onFetchCollectionItems: (id, params?) => dispatch(fetchCollectionItemsRequest(id, params))
 })
 
 export default connect(mapState, mapDispatch)(CenterPanel)

--- a/src/components/ItemEditorPage/CenterPanel/CenterPanel.container.ts
+++ b/src/components/ItemEditorPage/CenterPanel/CenterPanel.container.ts
@@ -35,16 +35,20 @@ import CenterPanel from './CenterPanel'
 const mapState = (state: RootState): MapStateProps => {
   let collection: Collection | undefined
   const collectionId = getSelectedCollectionId(state)
+  // Emotes created by the user
+  let emotes = getEmotes(state)
   if (collectionId) {
     const collections = getCollections(state)
     collection = collections.find(collection => collection.id === collectionId)
+    emotes = emotes.filter(emote => emote.collectionId === collectionId)
+  } else {
+    emotes = emotes.filter(emote => !emote.collectionId)
   }
   const selectedItemId = getSelectedItemId(state) || ''
   const selectedItem = getItem(state, selectedItemId)
   const bodyShape = getBodyShape(state)
   const selectedBaseWearablesByBodyShape = getSelectedBaseWearablesByBodyShape(state)
   const visibleItems = getVisibleItems(state)
-  const emotesFromCollection = getEmotes(state).filter(emote => emote.collectionId === collectionId)
   const emote = getEmote(state)
   const isPLayingIdleEmote = !visibleItems.some(item => item.type === ItemType.EMOTE) && emote === PreviewEmote.IDLE
   /* The library react-dropzone doesn't work as expected when an Iframe is present in the current view.
@@ -64,7 +68,7 @@ const mapState = (state: RootState): MapStateProps => {
     emote,
     visibleItems,
     wearableController: getWearablePreviewController(state),
-    emotesFromCollection,
+    emotes,
     isPlayingEmote: isPLayingIdleEmote ? false : isPlayingEmote(state),
     isImportFilesModalOpen
   }

--- a/src/components/ItemEditorPage/CenterPanel/CenterPanel.css
+++ b/src/components/ItemEditorPage/CenterPanel/CenterPanel.css
@@ -42,6 +42,10 @@
   padding: 0;
 }
 
+.CenterPanel .footer .avatar-animation-dropdown-wrapper.option .ui.buttons {
+  width: 222px;
+}
+
 .CenterPanel .footer .avatar-animation-dropdown-wrapper.option .ui.buttons .ui.button {
   background-color: var(--light-gray);
   font-size: 15px;
@@ -83,6 +87,10 @@
 
 .CenterPanel .footer .ui.dropdown > .menu > .divider {
   margin: 0;
+}
+
+.CenterPanel .footer .ui.dropdown > .menu > .option > .text {
+  text-overflow: ellipsis;
 }
 
 .CenterPanel .footer .avatar-attributes {

--- a/src/components/ItemEditorPage/CenterPanel/CenterPanel.css
+++ b/src/components/ItemEditorPage/CenterPanel/CenterPanel.css
@@ -83,14 +83,16 @@
 
 .CenterPanel .footer .ui.dropdown > .menu {
   padding-top: 0;
+  max-width: 222px;
 }
 
 .CenterPanel .footer .ui.dropdown > .menu > .divider {
   margin: 0;
 }
 
-.CenterPanel .footer .ui.dropdown > .menu > .option > .text {
+.CenterPanel .footer .ui.dropdown > .menu > .item {
   text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .CenterPanel .footer .avatar-attributes {

--- a/src/components/ItemEditorPage/CenterPanel/CenterPanel.tsx
+++ b/src/components/ItemEditorPage/CenterPanel/CenterPanel.tsx
@@ -125,7 +125,8 @@ export default class CenterPanel extends React.PureComponent<Props, State> {
   }
 
   renderEmoteDropdownButton = () => {
-    const { emotes, isPlayingEmote } = this.props
+    const { collection, emotes, isPlayingEmote } = this.props
+    const areEmotesFromCollection = !!collection
     const hasEmotes = emotes.length > 0
 
     if (isPlayingEmote) return null
@@ -135,7 +136,9 @@ export default class CenterPanel extends React.PureComponent<Props, State> {
         <Dropdown.Menu>
           {hasEmotes && (
             <>
-              <Dropdown.Header content={t('item_editor.center_panel.from_collection')} />
+              <Dropdown.Header
+                content={areEmotesFromCollection ? t('item_editor.center_panel.from_collection') : t('item_editor.center_panel.from_items')}
+              />
               <Dropdown.Divider />
               {emotes.map(value => (
                 <Dropdown.Item key={value.id} value={value.id} text={value.name} onClick={this.handleAnimationChange} />

--- a/src/components/ItemEditorPage/CenterPanel/CenterPanel.tsx
+++ b/src/components/ItemEditorPage/CenterPanel/CenterPanel.tsx
@@ -38,12 +38,12 @@ export default class CenterPanel extends React.PureComponent<Props, State> {
   }
 
   handleAnimationChange = (_event: React.SyntheticEvent<HTMLElement, Event>, { value }: DropdownItemProps) => {
-    const { emotesFromCollection, visibleItems, onSetAvatarAnimation, onSetItems } = this.props
-    const emoteFromCollection = emotesFromCollection.find(emote => emote.id === value)
+    const { emotes, visibleItems, onSetAvatarAnimation, onSetItems } = this.props
+    const emote = emotes.find(emote => emote.id === value)
     const newVisibleItems = visibleItems.filter(item => item.type !== ItemType.EMOTE)
 
-    if (emoteFromCollection) {
-      newVisibleItems.push(emoteFromCollection)
+    if (emote) {
+      newVisibleItems.push(emote)
     } else {
       onSetAvatarAnimation(value as PreviewEmote)
     }
@@ -125,8 +125,8 @@ export default class CenterPanel extends React.PureComponent<Props, State> {
   }
 
   renderEmoteDropdownButton = () => {
-    const { emotesFromCollection, isPlayingEmote } = this.props
-    const hasEmotes = emotesFromCollection.length > 0
+    const { emotes, isPlayingEmote } = this.props
+    const hasEmotes = emotes.length > 0
 
     if (isPlayingEmote) return null
 
@@ -137,7 +137,7 @@ export default class CenterPanel extends React.PureComponent<Props, State> {
             <>
               <Dropdown.Header content={t('item_editor.center_panel.from_collection')} />
               <Dropdown.Divider />
-              {emotesFromCollection.map(value => (
+              {emotes.map(value => (
                 <Dropdown.Item key={value.id} value={value.id} text={value.name} onClick={this.handleAnimationChange} />
               ))}
               <Dropdown.Divider />

--- a/src/components/ItemEditorPage/CenterPanel/CenterPanel.tsx
+++ b/src/components/ItemEditorPage/CenterPanel/CenterPanel.tsx
@@ -19,9 +19,28 @@ export default class CenterPanel extends React.PureComponent<Props, State> {
   }
 
   componentDidMount() {
-    const { selectedBaseWearables: bodyShapeBaseWearables, onFetchBaseWearables } = this.props
+    const {
+      address,
+      collection,
+      emotes,
+      selectedBaseWearables: bodyShapeBaseWearables,
+      onFetchBaseWearables,
+      onFetchOrphanItems,
+      onFetchCollectionItems
+    } = this.props
+    const hasEmotesLoaded = emotes.length > 0
+
     if (!bodyShapeBaseWearables) {
       onFetchBaseWearables()
+    }
+
+    // Fetch emotes created by the user to show them in the Play Emote dropdown
+    if (!hasEmotesLoaded) {
+      if (collection) {
+        onFetchCollectionItems(collection.id)
+      } else {
+        onFetchOrphanItems(address!)
+      }
     }
 
     // Setting the editor as loading as soon as it mounts. It will be turned of by the WearablePreview component once it's ready.

--- a/src/components/ItemEditorPage/CenterPanel/CenterPanel.types.ts
+++ b/src/components/ItemEditorPage/CenterPanel/CenterPanel.types.ts
@@ -23,9 +23,16 @@ import {
   SetItemsAction,
   setItems
 } from 'modules/editor/actions'
+import {
+  fetchCollectionItemsRequest,
+  FetchCollectionItemsRequestAction,
+  fetchItemsRequest,
+  FetchItemsRequestAction
+} from 'modules/item/actions'
 import { Item } from 'modules/item/types'
 
 export type Props = {
+  address?: string
   collection: Collection | undefined
   bodyShape: BodyShape
   skinColor: Color4
@@ -46,6 +53,8 @@ export type Props = {
   onSetHairColor: typeof setHairColor
   onSetBaseWearable: typeof setBaseWearable
   onFetchBaseWearables: typeof fetchBaseWearablesRequest
+  onFetchOrphanItems: typeof fetchItemsRequest
+  onFetchCollectionItems: typeof fetchCollectionItemsRequest
   onSetWearablePreviewController: typeof setWearablePreviewController
   onSetItems: typeof setItems
 }
@@ -57,6 +66,7 @@ export type State = {
 
 export type MapStateProps = Pick<
   Props,
+  | 'address'
   | 'bodyShape'
   | 'collection'
   | 'skinColor'
@@ -80,6 +90,8 @@ export type MapDispatchProps = Pick<
   | 'onSetHairColor'
   | 'onSetBaseWearable'
   | 'onFetchBaseWearables'
+  | 'onFetchOrphanItems'
+  | 'onFetchCollectionItems'
   | 'onSetWearablePreviewController'
   | 'onSetItems'
 >
@@ -92,6 +104,8 @@ export type MapDispatch = Dispatch<
   | SetHairColorAction
   | SetBaseWearableAction
   | FetchBaseWearablesRequestAction
+  | FetchItemsRequestAction
+  | FetchCollectionItemsRequestAction
   | SetWearablePreviewControllerAction
   | SetItemsAction
 >

--- a/src/components/ItemEditorPage/CenterPanel/CenterPanel.types.ts
+++ b/src/components/ItemEditorPage/CenterPanel/CenterPanel.types.ts
@@ -36,7 +36,7 @@ export type Props = {
   selectedItem: Item | null
   visibleItems: Item[]
   wearableController?: IPreviewController | null
-  emotesFromCollection: Item[]
+  emotes: Item[]
   isPlayingEmote: boolean
   isImportFilesModalOpen: boolean
   onSetBodyShape: typeof setBodyShape
@@ -67,7 +67,7 @@ export type MapStateProps = Pick<
   | 'selectedBaseWearables'
   | 'selectedItem'
   | 'wearableController'
-  | 'emotesFromCollection'
+  | 'emotes'
   | 'isPlayingEmote'
   | 'isImportFilesModalOpen'
 >

--- a/src/components/ItemEditorPage/LeftPanel/Items/Items.tsx
+++ b/src/components/ItemEditorPage/LeftPanel/Items/Items.tsx
@@ -51,14 +51,18 @@ export default class Items extends React.PureComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    const { items, selectedCollectionId } = this.props
+    const { items, selectedCollectionId, initialPage } = this.props
     const { currentTab } = this.state
     const prevItemIds = prevProps.items.map(prevItem => prevItem.id)
     if (currentTab === ItemPanelTabs.TO_REVIEW && items.some(item => !prevItemIds.includes(item.id))) {
       this.setState({ items })
     }
+    // initialPage only change when a new created item redirects to the item editor
+    else if (currentTab === ItemPanelTabs.TO_REVIEW && initialPage && prevProps.initialPage !== initialPage) {
+      this.setState({ items, currentPages: { ...this.state.currentPages, [currentTab]: initialPage } })
+    }
     // if selectedCollectionId changes, lets clear the items in the state
-    if (selectedCollectionId !== prevProps.selectedCollectionId) {
+    else if (selectedCollectionId !== prevProps.selectedCollectionId) {
       this.setState({ items })
     }
   }

--- a/src/components/ItemEditorPage/LeftPanel/Items/Items.types.ts
+++ b/src/components/ItemEditorPage/LeftPanel/Items/Items.types.ts
@@ -30,6 +30,7 @@ export type Props = {
   hasHeader: boolean
   bodyShape: BodyShape
   wearableController: IPreviewController | null
+  initialPage?: number
   onSetItems: typeof setItems
   onLoadRandomPage: () => void
   onLoadPage: (page: number) => void

--- a/src/components/ItemEditorPage/LeftPanel/LeftPanel.tsx
+++ b/src/components/ItemEditorPage/LeftPanel/LeftPanel.tsx
@@ -63,7 +63,8 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
     ) {
       if (!orphanItems.find(item => item.id === selectedItemId)) {
         const totalPages = Math.ceil(totalItems / LEFT_PANEL_PAGE_SIZE)
-        const nextPage = Math.min(totalPages, pages.length + 1)
+        const page = pages[pages.length - 1]
+        const nextPage = Math.min(totalPages, page + 1)
         if (!pages.includes(nextPage)) {
           this.setState({ pages: [nextPage], initialPage: nextPage }, this.fetchResource)
         }

--- a/src/components/ItemEditorPage/LeftPanel/LeftPanel.tsx
+++ b/src/components/ItemEditorPage/LeftPanel/LeftPanel.tsx
@@ -18,9 +18,21 @@ import './LeftPanel.css'
 const INITIAL_PAGE = 1
 
 export default class LeftPanel extends React.PureComponent<Props, State> {
-  state = {
-    pages: [INITIAL_PAGE],
-    currentTab: ItemEditorTabs.COLLECTIONS
+  state: State = this.getInitialState()
+
+  getInitialState() {
+    const { selectedCollectionId, selectedItemId } = this.props
+    let currentTab = ItemEditorTabs.COLLECTIONS
+
+    if (!selectedCollectionId && selectedItemId) {
+      currentTab = ItemEditorTabs.ORPHAN_ITEMS
+    }
+
+    return {
+      pages: [INITIAL_PAGE],
+      currentTab,
+      initialPage: INITIAL_PAGE
+    }
   }
 
   fetchResource() {
@@ -35,22 +47,35 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
   }
 
   componentDidMount() {
-    const { selectedCollectionId, selectedItemId } = this.props
     this.fetchResource()
-
-    if (!selectedCollectionId && selectedItemId) {
-      this.setState({ currentTab: ItemEditorTabs.ORPHAN_ITEMS })
-    }
   }
 
-  componentDidUpdate(prevProps: Props) {
-    const { isConnected, address, selectedCollectionId } = this.props
-    // fetch only if this was triggered by a connecting event or if th selectedCollection changes
-    if (address && isConnected && (isConnected !== prevProps.isConnected || (prevProps.selectedCollectionId && !selectedCollectionId))) {
-      this.setState({ pages: [INITIAL_PAGE] }, this.fetchResource)
-    }
-    if (prevProps.selectedCollectionId !== selectedCollectionId) {
-      this.setState({ pages: [INITIAL_PAGE] })
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    const { isConnected, address, selectedCollectionId, selectedItemId, orphanItems, totalItems } = this.props
+    const { initialPage, pages } = this.state
+    // when a newly created item redirects to the item editor, iterate over the pages until finding it
+    if (
+      !selectedCollectionId &&
+      address &&
+      selectedItemId &&
+      totalItems &&
+      (initialPage === INITIAL_PAGE || prevState.initialPage < initialPage)
+    ) {
+      if (!orphanItems.find(item => item.id === selectedItemId)) {
+        const totalPages = Math.ceil(totalItems / LEFT_PANEL_PAGE_SIZE)
+        const nextPage = Math.min(totalPages, pages.length + 1)
+        if (!pages.includes(nextPage)) {
+          this.setState({ pages: [nextPage], initialPage: nextPage }, this.fetchResource)
+        }
+      }
+    } else {
+      // fetch only if this was triggered by a connecting event or if th selectedCollection changes
+      if (address && isConnected && (isConnected !== prevProps.isConnected || (prevProps.selectedCollectionId && !selectedCollectionId))) {
+        this.setState({ pages: [INITIAL_PAGE] }, this.fetchResource)
+      }
+      if (prevProps.selectedCollectionId !== selectedCollectionId) {
+        this.setState({ pages: [INITIAL_PAGE] })
+      }
     }
   }
 
@@ -126,14 +151,17 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
         {isConnected ? (
           <CollectionProvider
             id={selectedCollectionId}
+            itemSelected={selectedItemId}
             itemsPage={pages}
             itemsPageSize={LEFT_PANEL_PAGE_SIZE}
             fetchOptions={{ status: isReviewing ? CurationStatus.PENDING : undefined }}
+            onChangePage={page => this.setState({ pages: [page] })}
           >
-            {({ paginatedCollections, collection, paginatedItems: collectionItems, isLoading }) => {
+            {({ paginatedCollections, collection, paginatedItems: collectionItems, initialPage: collectionInitialPage, isLoading }) => {
               const items = this.getItems(collection, collectionItems)
               const isCollectionTab = this.isCollectionTabActive()
               const showLoader = isLoading && ((isCollectionTab && collections.length === 0) || (!isCollectionTab && items.length === 0))
+              const initialPage = selectedCollectionId && collection ? collectionInitialPage : this.state.initialPage
               if (showLoader) {
                 return <Loader size="massive" active />
               }
@@ -198,6 +226,7 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
                       bodyShape={bodyShape}
                       onSetItems={onSetItems}
                       wearableController={wearableController}
+                      initialPage={initialPage}
                       isLoading={isLoading || isLoadingOrphanItems}
                       onLoadRandomPage={() => this.loadRandomPage(items)}
                       onLoadPage={this.loadPage}

--- a/src/components/ItemEditorPage/LeftPanel/LeftPanel.types.ts
+++ b/src/components/ItemEditorPage/LeftPanel/LeftPanel.types.ts
@@ -43,6 +43,7 @@ export type Props = {
 export type State = {
   currentTab: ItemEditorTabs
   pages: number[]
+  initialPage: number
 }
 
 export type MapStateProps = Pick<

--- a/src/components/Modals/AddExistingItemModal/AddExistingItemModal.container.ts
+++ b/src/components/Modals/AddExistingItemModal/AddExistingItemModal.container.ts
@@ -1,17 +1,21 @@
 import { connect } from 'react-redux'
+import { getAddress } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import { RootState } from 'modules/common/types'
-import { SAVE_ITEM_REQUEST, setCollection } from 'modules/item/actions'
+import { fetchItemsRequest, SAVE_ITEM_REQUEST, setCollection } from 'modules/item/actions'
 import { getLoading } from 'modules/item/selectors'
+import { Item } from 'modules/item/types'
 import { MapStateProps, MapDispatchProps, MapDispatch } from './AddExistingItemModal.types'
 import AddExistingItemModal from './AddExistingItemModal'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 
 const mapState = (state: RootState): MapStateProps => ({
+  address: getAddress(state),
   isLoading: isLoadingType(getLoading(state), SAVE_ITEM_REQUEST)
 })
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
-  onSubmit: (item, collectionId) => dispatch(setCollection(item, collectionId))
+  onSubmit: (item: Item, collectionId: string | null) => dispatch(setCollection(item, collectionId)),
+  onFetchItems: (address: string) => dispatch(fetchItemsRequest(address))
 })
 
 export default connect(mapState, mapDispatch)(AddExistingItemModal)

--- a/src/components/Modals/AddExistingItemModal/AddExistingItemModal.tsx
+++ b/src/components/Modals/AddExistingItemModal/AddExistingItemModal.tsx
@@ -9,6 +9,11 @@ import { Props, State, AddExistingItemModalMetadata } from './AddExistingItemMod
 export default class AddExistingItemModal extends React.PureComponent<Props, State> {
   state: State = {}
 
+  componentDidMount() {
+    const { address, onFetchItems } = this.props
+    onFetchItems(address!)
+  }
+
   handleChangeItem = (item: Item) => {
     this.setState({ item })
   }

--- a/src/components/Modals/AddExistingItemModal/AddExistingItemModal.types.ts
+++ b/src/components/Modals/AddExistingItemModal/AddExistingItemModal.types.ts
@@ -1,5 +1,5 @@
 import { ModalProps } from 'decentraland-dapps/dist/providers/ModalProvider/ModalProvider.types'
-import { setCollection, SetCollectionAction } from 'modules/item/actions'
+import { fetchItemsRequest, FetchItemsRequestAction, setCollection, SetCollectionAction } from 'modules/item/actions'
 import { Item } from 'modules/item/types'
 import { Dispatch } from 'redux'
 
@@ -9,14 +9,16 @@ export type State = {
 
 export type Props = ModalProps & {
   metadata: AddExistingItemModalMetadata
+  address: string | undefined
   isLoading: boolean
   onSubmit: typeof setCollection
+  onFetchItems: typeof fetchItemsRequest
 }
 
 export type AddExistingItemModalMetadata = {
   collectionId: string
 }
 
-export type MapStateProps = Pick<Props, 'isLoading'>
-export type MapDispatchProps = Pick<Props, 'onSubmit'>
-export type MapDispatch = Dispatch<SetCollectionAction>
+export type MapStateProps = Pick<Props, 'address' | 'isLoading'>
+export type MapDispatchProps = Pick<Props, 'onSubmit' | 'onFetchItems'>
+export type MapDispatch = Dispatch<SetCollectionAction | FetchItemsRequestAction>

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -8,7 +8,7 @@ import { ContractName, getContract } from 'decentraland-transactions'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { ModalState } from 'decentraland-dapps/dist/modules/modal/reducer'
 import { getOpenModals } from 'decentraland-dapps/dist/modules/modal/selectors'
-import { closeModal } from 'decentraland-dapps/dist/modules/modal/actions'
+import { closeAllModals, closeModal } from 'decentraland-dapps/dist/modules/modal/actions'
 import { sendTransaction } from 'decentraland-dapps/dist/modules/wallet/utils'
 import { getChainIdByNetwork, getNetworkProvider } from 'decentraland-dapps/dist/lib/eth'
 import { BuilderClient, RemoteItem } from '@dcl/builder-client'
@@ -360,10 +360,9 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
     const isEmotesFeatureFlagOn: boolean = yield select(getIsEmotesFlowEnabled)
     const { item } = action.payload
     const collectionId = item.collectionId!
-    if (openModals['EditItemURNModal']) {
-      yield put(closeModal('EditItemURNModal'))
-    } else if (openModals['EditPriceAndBeneficiaryModal']) {
-      yield put(closeModal('EditPriceAndBeneficiaryModal'))
+    const ItemModals = ['EditItemURNModal', 'EditPriceAndBeneficiaryModal', 'AddExistingItemModal']
+    if (ItemModals.some(modal => openModals[modal])) {
+      yield put(closeAllModals())
     } else if (openModals['CreateSingleItemModal']) {
       if (location.pathname === locations.collections()) {
         if (isEmotesFeatureFlagOn && item.type === ItemType.EMOTE) {

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -1407,6 +1407,7 @@
       "play_emote": "Play Emote",
       "stop": "Stop",
       "from_collection": "From Collection",
+      "from_items": "From Items",
       "default": "Default"
     },
     "right_panel": {

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -1422,6 +1422,7 @@
       "play_emote": "Reproducir Animación",
       "stop": "Parar",
       "from_collection": "Desde la Colección",
+      "from_items": "Desde los Items",
       "default": "Predeterminadas"
     },
     "right_panel": {

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -1407,6 +1407,7 @@
       "play_emote": "玩表情",
       "stop": "停止",
       "from_collection": "从收藏",
+      "from_items": "从项目",
       "default": "默认"
     },
     "right_panel": {


### PR DESCRIPTION
This PR allows showing single emotes in the play emotes dropdown button.

Emotes in the Items tab:
![image](https://user-images.githubusercontent.com/3170051/186749342-84ec2511-37f0-493b-9fe1-d20e216493a4.png)

Emotes in the Collection tab:
![image](https://user-images.githubusercontent.com/3170051/186749269-b61c1eee-1354-4203-897e-a29a82f05106.png)

