### PR TITLE
feat: Update old emote data to the new ADR74 schema

### DIFF
--- a/src/components/CollectionImage/CollectionImage.tsx
+++ b/src/components/CollectionImage/CollectionImage.tsx
@@ -32,7 +32,7 @@ export default class CollectionImage extends React.PureComponent<Props> {
     const needsToFetchMoreImages =
       (itemCount >= MAX_IMAGES_TO_SHOW && items.length < MAX_IMAGES_TO_SHOW) || (itemCount < MAX_IMAGES_TO_SHOW && items.length < itemCount)
     if (needsToFetchMoreImages) {
-      onFetchCollectionItems(collectionId, { page: 1, limit: MAX_IMAGES_TO_SHOW }) // fetch just the first page and 4 items to show the images
+      onFetchCollectionItems(collectionId, { page: 1, limit: itemCount }) // fetch all the collection items to show the images and get the entity data
     }
   }
 

--- a/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import equal from 'fast-deep-equal'
 import { Loader, Dropdown, Button } from 'decentraland-ui'
-import { EmoteDataADR74, Network, WearableCategory } from '@dcl/schemas'
+import { EmoteCategory, EmoteDataADR74, Network, WearableCategory } from '@dcl/schemas'
 import { NetworkButton } from 'decentraland-dapps/dist/containers'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
@@ -123,15 +123,23 @@ export default class RightPanel extends React.PureComponent<Props, State> {
     this.setState({ rarity, isDirty: this.isDirty({ rarity }) })
   }
 
-  handleChangeCategory = (category: WearableCategory) => {
-    let data: WearableData = {
-      ...(this.state.data as WearableData)!,
-      category
-    }
-    // when changing the category to SKIN we hide everything else
-    if (category === WearableCategory.SKIN) {
-      data = this.setReplaces(data, [])
-      data = this.setHides(data, [])
+  handleChangeCategory = (category: WearableCategory | EmoteCategory) => {
+    let data
+    if (this.state.data && isEmoteData(this.state.data)) {
+      data = {
+        ...this.state.data,
+        category
+      } as EmoteDataADR74
+    } else {
+      data = {
+        ...this.state.data,
+        category
+      } as WearableData
+      // when changing the category to SKIN we hide everything else
+      if (category === WearableCategory.SKIN) {
+        data = this.setReplaces(data, [])
+        data = this.setHides(data, [])
+      }
     }
     this.setState({ data, isDirty: this.isDirty({ data }) })
   }
@@ -466,16 +474,16 @@ export default class RightPanel extends React.PureComponent<Props, State> {
                           maxLength={ITEM_DESCRIPTION_MAX_LENGTH}
                           onChange={this.handleChangeDescription}
                         />
-                        {item.type === ItemType.WEARABLE && (
-                          <Select<WearableCategory>
-                            itemId={item.id}
-                            label={t('global.category')}
-                            value={(data as WearableData)!.category}
-                            options={this.asCategorySelect(item.type, wearableCategories as WearableCategory[])}
-                            disabled={!canEditItemMetadata}
-                            onChange={this.handleChangeCategory}
-                          />
-                        )}
+
+                        <Select<WearableCategory | EmoteCategory>
+                          itemId={item.id}
+                          label={t('global.category')}
+                          value={data!.category}
+                          options={this.asCategorySelect(item.type, wearableCategories as WearableCategory[])}
+                          disabled={!canEditItemMetadata}
+                          onChange={this.handleChangeCategory}
+                        />
+
                         {!(item.urn && isThirdParty(item.urn)) && (
                           <Select<ItemRarity>
                             itemId={item.id}
@@ -531,6 +539,7 @@ export default class RightPanel extends React.PureComponent<Props, State> {
                           label={t('create_single_item_modal.play_mode_label')}
                           value={(data as EmoteDataADR74)!.loop ? EmotePlayMode.LOOP : EmotePlayMode.SIMPLE}
                           options={this.asPlayModeSelect(playModes)}
+                          disabled={!canEditItemMetadata}
                           onChange={this.handlePlayModeChange}
                         />
                       ) : null}

--- a/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
@@ -125,7 +125,7 @@ export default class RightPanel extends React.PureComponent<Props, State> {
 
   handleChangeCategory = (category: WearableCategory | EmoteCategory) => {
     let data
-    if (this.state.data && isEmoteData(this.state.data)) {
+    if (isEmoteData(this.state.data!)) {
       data = {
         ...this.state.data,
         category

--- a/src/modules/item/utils.ts
+++ b/src/modules/item/utils.ts
@@ -468,7 +468,7 @@ export function isWearableSynced(item: Item, entity: Entity) {
   return true
 }
 
-export function isEmoteSynced(item: Item, entity: Entity, isEmotesFeatureFlagOn: boolean) {
+export function isEmoteSynced(item: Item | Item<ItemType.EMOTE>, entity: Entity, isEmotesFeatureFlagOn: boolean) {
   if (item.type !== ItemType.EMOTE) {
     throw new Error('Item must be EMOTE')
   }
@@ -482,19 +482,26 @@ export function isEmoteSynced(item: Item, entity: Entity, isEmotesFeatureFlagOn:
   // check if metadata is synced
   const catalystItem = entity.metadata
   const catalystItemMetadataData = isADR74 ? entity.metadata.emoteDataADR74 : entity.metadata.data
+  const data = item.data as EmoteDataADR74
 
   const hasMetadataChanged =
     item.name !== catalystItem.name ||
     item.description !== catalystItem.description ||
-    (item.data.category as string) !== catalystItemMetadataData.category ||
-    item.data.tags.toString() !== catalystItemMetadataData.tags.toString()
+    data.category !== catalystItemMetadataData.category ||
+    data.loop !== catalystItemMetadataData.loop ||
+    data.tags.toString() !== catalystItemMetadataData.tags.toString()
 
   if (hasMetadataChanged) {
     return false
   }
 
   // check if representations are synced
-  if (!areEqualRepresentations(item.data.representations, catalystItemMetadataData.representations as WearableRepresentation[])) {
+  if (
+    !areEqualRepresentations(
+      data.representations as WearableRepresentation[],
+      catalystItemMetadataData.representations as WearableRepresentation[]
+    )
+  ) {
     return false
   }
 


### PR DESCRIPTION
This PR verifies if the updated items' data by the migration: https://github.com/decentraland/builder-server/pull/591, are synced and matching with the new emote ADR74 data schema in the catalyst.