### PR TITLE
fix: ENS not working when there's no LAND

### DIFF
--- a/src/modules/ens/sagas.ts
+++ b/src/modules/ens/sagas.ts
@@ -230,9 +230,9 @@ export function* ensSaga(builderClient: BuilderClient) {
 
   function* handleFetchENSListRequest(_action: FetchENSListRequestAction) {
     try {
-      let lands: Land[] = yield select(getLands)
+      const lands: Land[] = yield select(getLands)
       const coordsList = lands.map(land => getCenter(getSelection(land))).map(coords => ({ x: coords[0], y: coords[1] }))
-      let coordsWithHashesList: (LandCoords & LandHashes)[] =
+      const coordsWithHashesList: (LandCoords & LandHashes)[] =
         coordsList.length > 0
           ? yield call([builderClient, builderClient.getLandRedirectionHashes], coordsList, getCurrentLocale().locale)
           : []

--- a/src/modules/ens/sagas.ts
+++ b/src/modules/ens/sagas.ts
@@ -230,14 +230,12 @@ export function* ensSaga(builderClient: BuilderClient) {
 
   function* handleFetchENSListRequest(_action: FetchENSListRequestAction) {
     try {
-      const lands: Land[] = yield select(getLands)
+      let lands: Land[] = yield select(getLands)
       const coordsList = lands.map(land => getCenter(getSelection(land))).map(coords => ({ x: coords[0], y: coords[1] }))
-
-      const coordsWithHashesList: (LandCoords & LandHashes)[] = yield call(
-        [builderClient, builderClient.getLandRedirectionHashes],
-        coordsList,
-        getCurrentLocale().locale
-      )
+      let coordsWithHashesList: (LandCoords & LandHashes)[] =
+        coordsList.length > 0
+          ? yield call([builderClient, builderClient.getLandRedirectionHashes], coordsList, getCurrentLocale().locale)
+          : []
 
       const landHashes: { id: string; hash: string }[] = []
 
@@ -293,7 +291,6 @@ export function* ensSaga(builderClient: BuilderClient) {
           })
         )
       )
-
       yield put(fetchENSListSuccess(ensList))
     } catch (error) {
       const ensError: ENSError = { message: error.message }


### PR DESCRIPTION
This PR fixes the issue of the names not showing up when the user has no lands.
The issue was caused due to having an empty array of coordinates being sent to the endpoint, making the endpoint fail thus preventing the rest of the operation to succeed. 