### PR TITLE
fix: Extract the models and images content from subfolders to the root level

### DIFF
--- a/src/components/ItemDetailPage/ItemDetailPage.tsx
+++ b/src/components/ItemDetailPage/ItemDetailPage.tsx
@@ -256,7 +256,7 @@ export default class ItemDetailPage extends React.PureComponent<Props, State> {
                   <div className="title-card-container">
                     <div className="title">{t('item_detail_page.representations.title')}</div>
                     <Button className="edit-button" inverted size="small" onClick={this.handleEditRepresentation}>
-                      {t('global.edit')}
+                      {getMissingBodyShapeType(item) ? t('global.add') : t('global.edit')}
                     </Button>
                   </div>
                   <div className="data">

--- a/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
@@ -332,9 +332,9 @@ export default class RightPanel extends React.PureComponent<Props, State> {
       return (
         <div className="metrics">
           <div className="metric circle">{t('model_metrics.sequences', { count: metrics.sequences })}</div>
-          <div className="metric circle">{t('model_metrics.duration', { count: metrics.duration })}</div>
+          <div className="metric circle">{t('model_metrics.duration', { count: metrics.duration.toFixed(2) })}</div>
           <div className="metric circle">{t('model_metrics.frames', { count: metrics.frames })}</div>
-          <div className="metric circle">{t('model_metrics.fps', { count: metrics.fps })}</div>
+          <div className="metric circle">{t('model_metrics.fps', { count: metrics.fps.toFixed(2) })}</div>
         </div>
       )
     } else {

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
@@ -155,13 +155,13 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
   sortContentZipBothBodyShape = (bodyShape: BodyShapeType, contents: Record<string, Blob>): SortedContent => {
     let male: Record<string, Blob> = {},
       female: Record<string, Blob> = {}
-    Object.keys(contents).forEach((key: string) => {
+    for (const key in contents) {
       if (key.startsWith('male/') && (bodyShape === BodyShapeType.BOTH || bodyShape === BodyShapeType.MALE)) {
         male[key] = contents[key]
       } else if (key.startsWith('female/') && (bodyShape === BodyShapeType.BOTH || bodyShape === BodyShapeType.FEMALE)) {
         female[key] = contents[key]
       }
-    })
+    }
     const all = { [THUMBNAIL_PATH]: contents[THUMBNAIL_PATH], ...male, ...female }
     return { male, female, all }
   }

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
@@ -152,13 +152,13 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
     return { male, female, all }
   }
 
-  sortContentZipBothBodyShape = (contents: Record<string, Blob>): SortedContent => {
+  sortContentZipBothBodyShape = (bodyShape: BodyShapeType, contents: Record<string, Blob>): SortedContent => {
     let male: Record<string, Blob> = {},
       female: Record<string, Blob> = {}
     Object.keys(contents).forEach((key: string) => {
-      if (key.startsWith('male/')) {
+      if (key.startsWith('male/') && (bodyShape === BodyShapeType.BOTH || bodyShape === BodyShapeType.MALE)) {
         male[key] = contents[key]
-      } else if (key.startsWith('female/')) {
+      } else if (key.startsWith('female/') && (bodyShape === BodyShapeType.BOTH || bodyShape === BodyShapeType.FEMALE)) {
         female[key] = contents[key]
       }
     })
@@ -341,11 +341,11 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
 
           const sortedContents =
             type === ItemType.WEARABLE && getBodyShapeTypeFromContents(contents) === BodyShapeType.BOTH
-              ? this.sortContentZipBothBodyShape(contents)
+              ? this.sortContentZipBothBodyShape(bodyShape, contents)
               : this.sortContent(bodyShape, contents)
           const representations =
             type === ItemType.WEARABLE && getBodyShapeTypeFromContents(contents) === BodyShapeType.BOTH
-              ? this.buildRepresentationsZipBothBodyshape(sortedContents)
+              ? this.buildRepresentationsZipBothBodyshape(bodyShape, sortedContents)
               : this.buildRepresentations(bodyShape, model, sortedContents)
 
           // Add this item as a representation of an existing item
@@ -529,27 +529,30 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
     return representations
   }
 
-  buildRepresentationsZipBothBodyshape(contents: SortedContent): WearableRepresentation[] {
+  buildRepresentationsZipBothBodyshape(bodyShape: BodyShapeType, contents: SortedContent): WearableRepresentation[] {
     const representations: WearableRepresentation[] = []
 
     // add male representation
-
-    representations.push({
-      bodyShapes: [BodyShape.MALE],
-      mainFile: Object.keys(contents.male).pop()!,
-      contents: Object.keys(contents.male),
-      overrideHides: [],
-      overrideReplaces: []
-    })
+    if (bodyShape === BodyShapeType.MALE || bodyShape === BodyShapeType.BOTH) {
+      representations.push({
+        bodyShapes: [BodyShape.MALE],
+        mainFile: Object.keys(contents.male).pop()!,
+        contents: Object.keys(contents.male),
+        overrideHides: [],
+        overrideReplaces: []
+      })
+    }
 
     // add female representation
-    representations.push({
-      bodyShapes: [BodyShape.FEMALE],
-      mainFile: Object.keys(contents.female).pop()!,
-      contents: Object.keys(contents.female),
-      overrideHides: [],
-      overrideReplaces: []
-    })
+    if (bodyShape === BodyShapeType.FEMALE || bodyShape === BodyShapeType.BOTH) {
+      representations.push({
+        bodyShapes: [BodyShape.FEMALE],
+        mainFile: Object.keys(contents.female).pop()!,
+        contents: Object.keys(contents.female),
+        overrideHides: [],
+        overrideReplaces: []
+      })
+    }
 
     return representations
   }

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
@@ -345,7 +345,7 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
               : this.sortContent(bodyShape, contents)
           const representations =
             type === ItemType.WEARABLE && getBodyShapeTypeFromContents(contents) === BodyShapeType.BOTH
-              ? this.buildRepresentationsZipBothBodyshape(model, sortedContents)
+              ? this.buildRepresentationsZipBothBodyshape(sortedContents)
               : this.buildRepresentations(bodyShape, model, sortedContents)
 
           // Add this item as a representation of an existing item
@@ -529,7 +529,7 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
     return representations
   }
 
-  buildRepresentationsZipBothBodyshape(_model: string, contents: SortedContent): WearableRepresentation[] {
+  buildRepresentationsZipBothBodyshape(contents: SortedContent): WearableRepresentation[] {
     const representations: WearableRepresentation[] = []
 
     // add male representation

--- a/src/components/Modals/CreateSingleItemModal/ImportStep/ImportStep.tsx
+++ b/src/components/Modals/CreateSingleItemModal/ImportStep/ImportStep.tsx
@@ -3,6 +3,7 @@ import uuid from 'uuid'
 import { loadFile, WearableConfig } from '@dcl/builder-client'
 import { ModalNavigation } from 'decentraland-ui'
 import Modal from 'decentraland-dapps/dist/containers/Modal'
+import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { getExtension } from 'lib/file'
 import { EngineType, getIsEmote } from 'lib/getModelData'
 import { cleanAssetName, rawMappingsToObjectURL } from 'modules/asset/utils'
@@ -167,7 +168,11 @@ export default class ImportStep extends React.PureComponent<Props, State> {
             acceptedFileProps.model = getModelFileNameFromSubfolder(model)
             acceptedFileProps.contents = this.cleanContentModelKeys(contents)
           } else {
-            acceptedFileProps.contents = this.cleanContentModelKeys(contents, BodyShapeType.BOTH)
+            if (!isRepresentation) {
+              acceptedFileProps.contents = this.cleanContentModelKeys(contents, BodyShapeType.BOTH)
+            } else {
+              throw new Error(t('create_single_item_modal.error.invalid_model_files_representation'))
+            }
           }
         }
       } else {

--- a/src/components/Modals/CreateSingleItemModal/ImportStep/ImportStep.tsx
+++ b/src/components/Modals/CreateSingleItemModal/ImportStep/ImportStep.tsx
@@ -158,6 +158,10 @@ export default class ImportStep extends React.PureComponent<Props, State> {
             bodyShape: getBodyShapeType(wearable as Item)
           }
         } else {
+          /** If the .zip file doesn't contain an asset.json file,
+           * this method processes the contents by cleaning the empty keys
+           * and extracting the models to the root level if there's just one body shape representation
+           */
           acceptedFileProps.bodyShape = getBodyShapeTypeFromContents(contents) as BodyShapeType
           if (acceptedFileProps.bodyShape !== BodyShapeType.BOTH) {
             acceptedFileProps.model = getModelFileNameFromSubfolder(model)

--- a/src/components/Modals/CreateSingleItemModal/ImportStep/ImportStep.tsx
+++ b/src/components/Modals/CreateSingleItemModal/ImportStep/ImportStep.tsx
@@ -12,7 +12,7 @@ import {
   getBodyShapeType,
   getBodyShapeTypeFromContents,
   getModelPath,
-  getModelFileName,
+  getModelFileNameFromSubfolder,
   isImageCategory,
   isImageFile,
   isModelFile,
@@ -43,7 +43,7 @@ export default class ImportStep extends React.PureComponent<Props, State> {
         if (contents[key].size === 0) {
           return newContents
         } else if (isModelFile(key) && bodyShapeType !== BodyShapeType.BOTH) {
-          const newKeykey = getModelFileName(key)
+          const newKeykey = getModelFileNameFromSubfolder(key)
           newContents[newKeykey] = contents[key]
           return newContents
         } else if (isImageFile(key)) {
@@ -160,7 +160,7 @@ export default class ImportStep extends React.PureComponent<Props, State> {
         } else {
           acceptedFileProps.bodyShape = getBodyShapeTypeFromContents(contents) as BodyShapeType
           if (acceptedFileProps.bodyShape !== BodyShapeType.BOTH) {
-            acceptedFileProps.model = getModelFileName(model)
+            acceptedFileProps.model = getModelFileNameFromSubfolder(model)
             acceptedFileProps.contents = this.cleanContentModelKeys(contents)
           } else {
             acceptedFileProps.contents = this.cleanContentModelKeys(contents, BodyShapeType.BOTH)

--- a/src/modules/item/utils.ts
+++ b/src/modules/item/utils.ts
@@ -61,6 +61,29 @@ export function getBodyShapeType(item: Item): BodyShapeType {
   }
 }
 
+export function getBodyShapeTypeFromContents(contents: Record<string, Blob>) {
+  let hasMale = false,
+    hasFemale = false
+
+  Object.keys(contents).forEach((key: string) => {
+    if (key.startsWith('male/')) {
+      hasMale = true
+    } else if (key.startsWith('female/')) {
+      hasFemale = true
+    }
+  })
+
+  if (hasMale && hasFemale) {
+    return BodyShapeType.BOTH
+  } else if (hasMale) {
+    return BodyShapeType.MALE
+  } else if (hasFemale) {
+    return BodyShapeType.FEMALE
+  } else {
+    return null
+  }
+}
+
 export function getBodyShapes(item: Item): BodyShape[] {
   const bodyShapes = new Set<BodyShape>()
   for (const representation of item.data.representations) {
@@ -85,6 +108,10 @@ export function getMissingBodyShapeType(item: Item) {
 
 export function getModelPath(representations: WearableRepresentation[]) {
   return representations[0].mainFile
+}
+
+export function getModelFileName(modelPath: string) {
+  return modelPath.split('/').pop()!
 }
 
 export function hasBodyShape(item: Item, bodyShape: BodyShape) {

--- a/src/modules/item/utils.ts
+++ b/src/modules/item/utils.ts
@@ -110,7 +110,7 @@ export function getModelPath(representations: WearableRepresentation[]) {
   return representations[0].mainFile
 }
 
-export function getModelFileName(modelPath: string) {
+export function getModelFileNameFromSubfolder(modelPath: string) {
   return modelPath.split('/').pop()!
 }
 

--- a/src/modules/item/utils.ts
+++ b/src/modules/item/utils.ts
@@ -65,13 +65,13 @@ export function getBodyShapeTypeFromContents(contents: Record<string, Blob>) {
   let hasMale = false,
     hasFemale = false
 
-  Object.keys(contents).forEach((key: string) => {
+  for (const key in contents) {
     if (key.startsWith('male/')) {
       hasMale = true
     } else if (key.startsWith('female/')) {
       hasFemale = true
     }
-  })
+  }
 
   if (hasMale && hasFemale) {
     return BodyShapeType.BOTH

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -221,7 +221,8 @@
       "invalid_files": "Files seem to be invalid or broken, please review them and try again.",
       "missing_model_file": "Couldn't find a valid model file.",
       "invalid_content_path": "Invalid path \"{path}\" for property \"{name}\", file not found.",
-      "invalid_enum_value": "Invalid value \"{value}\" for property \"{name}\", possible values: {values}."
+      "invalid_enum_value": "Invalid value \"{value}\" for property \"{name}\", possible values: {values}.",
+      "invalid_model_files_representation": "The file seems to have more than one representation, please review them and try again."
     },
     "emote_notice": "Emotes are available for all body shapes."
   },

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -224,7 +224,8 @@
       "invalid_files": "Los archivos parecen no ser válidos o estar dañados. Por favor revíselos y vuelva a intentarlo.",
       "missing_model_file": "No se pudo encontrar un archivo de modelo válido.",
       "invalid_content_path": "La ruta \"{path}\" es inválida para la propiedad \"{name}\", el archivo no existe.",
-      "invalid_enum_value": "Valor inválido \"{value}\" para la propiedad \"{name}\", valores posibles: {values}."
+      "invalid_enum_value": "Valor inválido \"{value}\" para la propiedad \"{name}\", valores posibles: {values}.",
+      "invalid_model_files_representation": "El archivo parece tener más de una representación. Por favor revíselas y vuelva a intentarlo."
     },
     "emote_notice": "Las animaciones estan disponibles para todos los cuerpos."
   },

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -218,7 +218,8 @@
       "invalid_files": "文件似乎无效或损坏，请检查并重试。",
       "missing_model_file": "找不到有效的模型文件。",
       "invalid_content_path": "属性 \"{name}\" 的无效路径 \"{path}\"，找不到文件。",
-      "invalid_enum_value": "属性 \"{name}\" 的无效值 \"{value}\"，可能的值：{values}。"
+      "invalid_enum_value": "属性 \"{name}\" 的无效值 \"{value}\"，可能的值：{values}。",
+      "invalid_model_files_representation": "该文件似乎有多个表示，请查看它们并重试。"
     },
     "emote_notice": "表情适用于所有体型。"
   },


### PR DESCRIPTION
This PR cleans the model content when uploading a .zip file with male/female representations and processes the file structure to save the proper representation schema in DB.

Closes #2282