### PR TITLE
fix: Reload left panel when creating a new item

### DIFF
--- a/src/components/ItemEditorPage/CenterPanel/CenterPanel.css
+++ b/src/components/ItemEditorPage/CenterPanel/CenterPanel.css
@@ -163,7 +163,7 @@
   right: 12px;
 }
 
-.CenterPanel .ui.button.zoom-control {
+.CenterPanel .zoom-controls > .ui.button.zoom-control {
   width: 32px;
   height: 32px;
   padding: 0;
@@ -175,11 +175,11 @@
   align-items: center;
 }
 
-.CenterPanel .ui.button.zoom-control i.icon {
+.CenterPanel .zoom-controls > .ui.button.zoom-control i.icon {
   margin: 0 !important;
 }
 
-.CenterPanel .ui.button.zoom-in-control {
+.CenterPanel .zoom-controls > .ui.button.zoom-in-control {
   width: 32px;
   height: 32px;
   padding: 0;

--- a/src/components/ItemEditorPage/CenterPanel/CenterPanel.css
+++ b/src/components/ItemEditorPage/CenterPanel/CenterPanel.css
@@ -124,7 +124,6 @@
 
 .CenterPanel .emote-controls-container {
   position: relative;
-  bottom: 53px;
   margin: 0 16px;
 }
 

--- a/src/components/ItemEditorPage/CenterPanel/CenterPanel.tsx
+++ b/src/components/ItemEditorPage/CenterPanel/CenterPanel.tsx
@@ -273,17 +273,17 @@ export default class CenterPanel extends React.PureComponent<Props, State> {
             </Button>
           </div>
         ) : null}
-        {isRenderingAnEmote ? (
-          <div className="emote-controls-container">
-            <EmoteControls className="emote-controls" wearablePreviewId="wearable-editor" />
-          </div>
-        ) : null}
         {isLoading && (
           <Center>
             <Loader active />
           </Center>
         )}
         <div className="footer">
+          {isRenderingAnEmote ? (
+            <div className="emote-controls-container">
+              <EmoteControls className="emote-controls" wearablePreviewId="wearable-editor" />
+            </div>
+          ) : null}
           <div className="options">
             <div className={`option ${isShowingAvatarAttributes ? 'active' : ''}`} onClick={this.handleToggleShowingAvatarAttributes}>
               <Icon name="user" />

--- a/src/modules/item/sagas.spec.ts
+++ b/src/modules/item/sagas.spec.ts
@@ -571,7 +571,8 @@ describe('when handling the save item success action', () => {
                 [select(getLocation), { pathname: locations.collectionDetail(collection.id) }],
                 [select(getOpenModals), { CreateSingleItemModal: true }],
                 [select(getIsEmotesFlowEnabled), false],
-                [select(getAddress), mockAddress]
+                [select(getAddress), mockAddress],
+                [select(getPaginationData, item.collectionId!), { currentPage: 1, limit: 10 }]
               ])
               .put(closeModal('CreateSingleItemModal'))
               .dispatch(saveItemSuccess(item, {}))
@@ -583,6 +584,11 @@ describe('when handling the save item success action', () => {
   })
 
   describe('and the location is the Item editor page', () => {
+    let paginationData: ItemPaginationData
+    beforeEach(() => {
+      paginationData = { currentPage: 1, limit: 1, total: 1, ids: [item.id], totalPages: 1 }
+    })
+
     describe('and the CreateSingleItemModal is opened', () => {
       describe('and the item type is wearable', () => {
         it('should close the modal CreateSingleItemModal', () => {
@@ -590,8 +596,10 @@ describe('when handling the save item success action', () => {
             .provide([
               [select(getLocation), { pathname: locations.itemEditor() }],
               [select(getOpenModals), { CreateSingleItemModal: true }],
-              [select(getAddress), mockAddress]
+              [select(getAddress), mockAddress],
+              [select(getPaginationData, item.collectionId!), { ...paginationData }]
             ])
+            .put(fetchCollectionItemsRequest(item.collectionId!, { page: paginationData.currentPage, limit: paginationData.limit }))
             .put(closeModal('CreateSingleItemModal'))
             .dispatch(saveItemSuccess(item, {}))
             .run({ silenceTimeout: true })
@@ -604,14 +612,16 @@ describe('when handling the save item success action', () => {
         })
 
         describe('and the FF EmotesFlow is enabled', () => {
-          it('should put a location change to the item editor', () => {
+          it('should close the modal CreateSingleItemModal', () => {
             return expectSaga(itemSaga, builderAPI, builderClient)
               .provide([
                 [select(getLocation), { pathname: locations.itemEditor() }],
                 [select(getOpenModals), { CreateSingleItemModal: true }],
                 [select(getIsEmotesFlowEnabled), true],
-                [select(getAddress), mockAddress]
+                [select(getAddress), mockAddress],
+                [select(getPaginationData, item.collectionId!), { ...paginationData }]
               ])
+              .put(fetchCollectionItemsRequest(item.collectionId!, { page: paginationData.currentPage, limit: paginationData.limit }))
               .put(closeModal('CreateSingleItemModal'))
               .dispatch(saveItemSuccess(item, {}))
               .run({ silenceTimeout: true })
@@ -625,8 +635,10 @@ describe('when handling the save item success action', () => {
                 [select(getLocation), { pathname: locations.itemEditor() }],
                 [select(getOpenModals), { CreateSingleItemModal: true }],
                 [select(getIsEmotesFlowEnabled), false],
-                [select(getAddress), mockAddress]
+                [select(getAddress), mockAddress],
+                [select(getPaginationData, item.collectionId!), { ...paginationData }]
               ])
+              .put(fetchCollectionItemsRequest(item.collectionId!, { page: paginationData.currentPage, limit: paginationData.limit }))
               .put(closeModal('CreateSingleItemModal'))
               .dispatch(saveItemSuccess(item, {}))
               .run({ silenceTimeout: true })
@@ -1562,7 +1574,8 @@ describe('when handling the save item curation success action', () => {
       .provide([
         [select(getLocation), { pathname: locations.collectionDetail('id') }],
         [select(getOpenModals), { CreateSingleItemModal: true }],
-        [select(getAddress), mockAddress]
+        [select(getAddress), mockAddress],
+        [select(getPaginationData, mockAddress), { currentPage: 1, limit: 10 }]
       ])
       .not.put(push(locations.itemDetail(item.id)))
       .dispatch(saveItemSuccess(item, {}))

--- a/src/modules/item/sagas.spec.ts
+++ b/src/modules/item/sagas.spec.ts
@@ -217,6 +217,7 @@ describe('when handling the save item request action', () => {
             [select(getLocation), { pathname: 'notTPdetailPage' }],
             [select(getOpenModals), { EditItemURNModal: true }],
             [select(getItem, item.id), undefined],
+            [select(getAddress), mockAddress],
             [
               call(generateCatalystImage, item, {
                 thumbnail: contents[THUMBNAIL_PATH]
@@ -249,6 +250,7 @@ describe('when handling the save item request action', () => {
             [select(getLocation), { pathname: 'notTPdetailPage' }],
             [select(getOpenModals), { EditItemURNModal: true }],
             [select(getItem, item.id), undefined],
+            [select(getAddress), mockAddress],
             [
               call(generateCatalystImage, item, {
                 thumbnail: contents[THUMBNAIL_PATH]
@@ -276,6 +278,7 @@ describe('when handling the save item request action', () => {
             [select(getLocation), { pathname: 'notTPdetailPage' }],
             [select(getOpenModals), { EditItemURNModal: true }],
             [select(getItem, item.id), undefined],
+            [select(getAddress), mockAddress],
             [call(calculateFinalSize, item, contents, builderAPI), Promise.resolve(1)],
             [call([builderAPI, 'saveItem'], item, contents), Promise.resolve()]
           ])
@@ -305,6 +308,7 @@ describe('when handling the save item request action', () => {
               select(getItem, item.id),
               { ...item, contents: { ...item.contents, [IMAGE_PATH]: item.contents[IMAGE_PATH] }, rarity: ItemRarity.COMMON }
             ],
+            [select(getAddress), mockAddress],
             [
               call(generateCatalystImage, item, {
                 thumbnail: contents[THUMBNAIL_PATH]
@@ -332,6 +336,7 @@ describe('when handling the save item request action', () => {
             [select(getLocation), { pathname: 'notTPdetailPage' }],
             [select(getOpenModals), { EditItemURNModal: true }],
             [select(getItem, item.id), undefined],
+            [select(getAddress), mockAddress],
             [call(calculateFinalSize, item, contents, builderAPI), Promise.resolve(1)],
             [call([builderAPI, 'saveItem'], item, contents), Promise.resolve()]
           ])
@@ -353,6 +358,7 @@ describe('when handling the save item request action', () => {
             [select(getLocation), { pathname: 'notTPdetailPage' }],
             [select(getOpenModals), { EditItemURNModal: true }],
             [select(getItem, item.id), undefined],
+            [select(getAddress), mockAddress],
             [call(calculateFinalSize, item, contents, builderAPI), Promise.resolve(1)],
             [call([builderAPI, 'saveItem'], item, contents), Promise.resolve()]
           ])
@@ -374,6 +380,7 @@ describe('when handling the save item request action', () => {
             [select(getLocation), { pathname: 'notTPdetailPage' }],
             [select(getOpenModals), { EditItemURNModal: true }],
             [select(getItem, item.id), undefined],
+            [select(getAddress), mockAddress],
             [call([builderAPI, 'saveItem'], item, {}), Promise.resolve()]
           ])
           .put(saveItemSuccess(item, {}))
@@ -404,6 +411,7 @@ describe('when handling the save item request action', () => {
             [select(getLocation), { pathname: 'notTPdetailPage' }],
             [select(getOpenModals), { EditItemURNModal: true }],
             [select(getItem, item.id), item],
+            [select(getAddress), mockAddress],
             [call(calculateFinalSize, itemWithNewHashes, newContents, builderAPI), Promise.resolve(1)],
             [call([builderAPI, 'saveItem'], itemWithNewHashes, newContents), Promise.resolve()]
           ])
@@ -437,7 +445,8 @@ describe('when handling the save item success action', () => {
           .provide([
             [select(getLocation), { pathname: locations.thirdPartyCollectionDetail(item.collectionId!) }],
             [select(getOpenModals), { EditItemURNModal: true }],
-            [select(getPaginationData, item.collectionId!), paginationData]
+            [select(getPaginationData, item.collectionId!), paginationData],
+            [select(getAddress), mockAddress]
           ])
           .put(fetchCollectionItemsRequest(item.collectionId!, { page: paginationData.currentPage, limit: paginationData.limit }))
           .dispatch(saveItemSuccess(item, contents))
@@ -455,7 +464,8 @@ describe('when handling the save item success action', () => {
           .provide([
             [select(getLocation), { pathname: locations.thirdPartyCollectionDetail(item.collectionId!) }],
             [select(getOpenModals), { EditItemURNModal: true }],
-            [select(getPaginationData, item.collectionId!), paginationData]
+            [select(getPaginationData, item.collectionId!), paginationData],
+            [select(getAddress), mockAddress]
           ])
           .put(push(locations.thirdPartyCollectionDetail(item.collectionId!, { page: newPageNumber })))
           .dispatch(saveItemSuccess(item, contents))
@@ -471,7 +481,8 @@ describe('when handling the save item success action', () => {
           return expectSaga(itemSaga, builderAPI, builderClient)
             .provide([
               [select(getLocation), { pathname: locations.collections() }],
-              [select(getOpenModals), { CreateSingleItemModal: true }]
+              [select(getOpenModals), { CreateSingleItemModal: true }],
+              [select(getAddress), mockAddress]
             ])
             .put(push(locations.itemDetail(item.id)))
             .dispatch(saveItemSuccess(item, {}))
@@ -490,7 +501,8 @@ describe('when handling the save item success action', () => {
               .provide([
                 [select(getLocation), { pathname: locations.collections() }],
                 [select(getOpenModals), { CreateSingleItemModal: true }],
-                [select(getIsEmotesFlowEnabled), true]
+                [select(getIsEmotesFlowEnabled), true],
+                [select(getAddress), mockAddress]
               ])
               .put(push(locations.itemEditor({ itemId: item.id })))
               .dispatch(saveItemSuccess(item, {}))
@@ -504,7 +516,8 @@ describe('when handling the save item success action', () => {
               .provide([
                 [select(getLocation), { pathname: locations.collections() }],
                 [select(getOpenModals), { CreateSingleItemModal: true }],
-                [select(getIsEmotesFlowEnabled), false]
+                [select(getIsEmotesFlowEnabled), false],
+                [select(getAddress), mockAddress]
               ])
               .put(push(locations.itemDetail(item.id)))
               .dispatch(saveItemSuccess(item, {}))
@@ -522,7 +535,8 @@ describe('when handling the save item success action', () => {
           return expectSaga(itemSaga, builderAPI, builderClient)
             .provide([
               [select(getLocation), { pathname: locations.collectionDetail(collection.id) }],
-              [select(getOpenModals), { CreateSingleItemModal: true }]
+              [select(getOpenModals), { CreateSingleItemModal: true }],
+              [select(getAddress), mockAddress]
             ])
             .put(closeModal('CreateSingleItemModal'))
             .dispatch(saveItemSuccess(item, {}))
@@ -541,7 +555,8 @@ describe('when handling the save item success action', () => {
               .provide([
                 [select(getLocation), { pathname: locations.collectionDetail(collection.id) }],
                 [select(getOpenModals), { CreateSingleItemModal: true }],
-                [select(getIsEmotesFlowEnabled), true]
+                [select(getIsEmotesFlowEnabled), true],
+                [select(getAddress), mockAddress]
               ])
               .put(push(locations.itemEditor({ collectionId: collection.id, itemId: item.id })))
               .dispatch(saveItemSuccess(item, {}))
@@ -555,7 +570,8 @@ describe('when handling the save item success action', () => {
               .provide([
                 [select(getLocation), { pathname: locations.collectionDetail(collection.id) }],
                 [select(getOpenModals), { CreateSingleItemModal: true }],
-                [select(getIsEmotesFlowEnabled), false]
+                [select(getIsEmotesFlowEnabled), false],
+                [select(getAddress), mockAddress]
               ])
               .put(closeModal('CreateSingleItemModal'))
               .dispatch(saveItemSuccess(item, {}))
@@ -573,7 +589,8 @@ describe('when handling the save item success action', () => {
           return expectSaga(itemSaga, builderAPI, builderClient)
             .provide([
               [select(getLocation), { pathname: locations.itemEditor() }],
-              [select(getOpenModals), { CreateSingleItemModal: true }]
+              [select(getOpenModals), { CreateSingleItemModal: true }],
+              [select(getAddress), mockAddress]
             ])
             .put(closeModal('CreateSingleItemModal'))
             .dispatch(saveItemSuccess(item, {}))
@@ -592,7 +609,8 @@ describe('when handling the save item success action', () => {
               .provide([
                 [select(getLocation), { pathname: locations.itemEditor() }],
                 [select(getOpenModals), { CreateSingleItemModal: true }],
-                [select(getIsEmotesFlowEnabled), true]
+                [select(getIsEmotesFlowEnabled), true],
+                [select(getAddress), mockAddress]
               ])
               .put(closeModal('CreateSingleItemModal'))
               .dispatch(saveItemSuccess(item, {}))
@@ -606,7 +624,8 @@ describe('when handling the save item success action', () => {
               .provide([
                 [select(getLocation), { pathname: locations.itemEditor() }],
                 [select(getOpenModals), { CreateSingleItemModal: true }],
-                [select(getIsEmotesFlowEnabled), false]
+                [select(getIsEmotesFlowEnabled), false],
+                [select(getAddress), mockAddress]
               ])
               .put(closeModal('CreateSingleItemModal'))
               .dispatch(saveItemSuccess(item, {}))
@@ -1500,7 +1519,8 @@ describe('when handling the save item curation success action', () => {
       .provide([
         [select(getLocation), { pathname: locations.thirdPartyCollectionDetail(item.collectionId!) }],
         [select(getOpenModals), { EditItemURNModal: true }],
-        [select(getPaginationData, item.collectionId!), {}]
+        [select(getPaginationData, item.collectionId!), {}],
+        [select(getAddress), mockAddress]
       ])
       .put(fetchItemCurationRequest(item.collectionId!, item.id))
       .dispatch(
@@ -1517,7 +1537,8 @@ describe('when handling the save item curation success action', () => {
       .provide([
         [select(getLocation), { pathname: locations.thirdPartyCollectionDetail(item.collectionId!) }],
         [select(getOpenModals), { EditItemURNModal: true }],
-        [select(getPaginationData, item.collectionId!), {}]
+        [select(getPaginationData, item.collectionId!), {}],
+        [select(getAddress), mockAddress]
       ])
       .not.put(fetchItemCurationRequest(item.collectionId!, item.id))
       .dispatch(saveItemSuccess(item, {}))
@@ -1528,7 +1549,8 @@ describe('when handling the save item curation success action', () => {
     return expectSaga(itemSaga, builderAPI, builderClient)
       .provide([
         [select(getLocation), { pathname: locations.collections() }],
-        [select(getOpenModals), { CreateSingleItemModal: true }]
+        [select(getOpenModals), { CreateSingleItemModal: true }],
+        [select(getAddress), mockAddress]
       ])
       .put(push(locations.itemDetail(item.id)))
       .dispatch(saveItemSuccess(item, {}))
@@ -1539,7 +1561,8 @@ describe('when handling the save item curation success action', () => {
     return expectSaga(itemSaga, builderAPI, builderClient)
       .provide([
         [select(getLocation), { pathname: locations.collectionDetail('id') }],
-        [select(getOpenModals), { CreateSingleItemModal: true }]
+        [select(getOpenModals), { CreateSingleItemModal: true }],
+        [select(getAddress), mockAddress]
       ])
       .not.put(push(locations.itemDetail(item.id)))
       .dispatch(saveItemSuccess(item, {}))

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -93,7 +93,7 @@ import { updateProgressSaveMultipleItems } from 'modules/ui/createMultipleItems/
 import { isLocked } from 'modules/collection/utils'
 import { locations } from 'routing/locations'
 import { BuilderAPI as LegacyBuilderAPI, FetchCollectionsParams } from 'lib/api/builder'
-import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE, PaginatedResource, PaginationStats } from 'lib/api/pagination'
+import { DEFAULT_PAGE, PaginatedResource, PaginationStats } from 'lib/api/pagination'
 import { getCollection, getCollections } from 'modules/collection/selectors'
 import { getIsEmotesFlowEnabled } from 'modules/features/selectors'
 import { getItemId } from 'modules/location/selectors'
@@ -377,10 +377,15 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
         // Redirect to the item editor
         yield put(push(locations.itemEditor({ collectionId, itemId: item.id })))
       } else {
-        if (collectionId) {
-          yield put(fetchCollectionItemsRequest(collectionId, { page: DEFAULT_PAGE, limit: DEFAULT_PAGE_SIZE }))
-        } else {
-          yield put(fetchItemsRequest(address, { page: DEFAULT_PAGE, limit: DEFAULT_PAGE_SIZE }))
+        // When creating a Wearable/Emote in the itemEditor, reload the left panel to show the new item created
+        if (location.pathname === locations.itemEditor()) {
+          if (collectionId) {
+            const paginationData: ItemPaginationData = yield select(getPaginationData, collectionId)
+            yield put(fetchCollectionItemsRequest(collectionId, { page: paginationData.currentPage, limit: paginationData.limit }))
+          } else {
+            const paginationData: ItemPaginationData = yield select(getPaginationData, address)
+            yield put(fetchItemsRequest(address, { page: paginationData.currentPage, limit: paginationData.limit }))
+          }
         }
         yield put(closeModal('CreateSingleItemModal'))
       }

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -93,7 +93,7 @@ import { updateProgressSaveMultipleItems } from 'modules/ui/createMultipleItems/
 import { isLocked } from 'modules/collection/utils'
 import { locations } from 'routing/locations'
 import { BuilderAPI as LegacyBuilderAPI, FetchCollectionsParams } from 'lib/api/builder'
-import { DEFAULT_PAGE, PaginatedResource, PaginationStats } from 'lib/api/pagination'
+import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE, PaginatedResource, PaginationStats } from 'lib/api/pagination'
 import { getCollection, getCollections } from 'modules/collection/selectors'
 import { getIsEmotesFlowEnabled } from 'modules/features/selectors'
 import { getItemId } from 'modules/location/selectors'
@@ -355,6 +355,7 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
   }
 
   function* handleSaveItemSuccess(action: SaveItemSuccessAction) {
+    const address: string = yield select(getAddress)
     const openModals: ModalState = yield select(getOpenModals)
     const location: ReturnType<typeof getLocation> = yield select(getLocation)
     const isEmotesFeatureFlagOn: boolean = yield select(getIsEmotesFlowEnabled)
@@ -376,6 +377,11 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
         // Redirect to the item editor
         yield put(push(locations.itemEditor({ collectionId, itemId: item.id })))
       } else {
+        if (collectionId) {
+          yield put(fetchCollectionItemsRequest(collectionId, { page: DEFAULT_PAGE, limit: DEFAULT_PAGE_SIZE }))
+        } else {
+          yield put(fetchItemsRequest(address, { page: DEFAULT_PAGE, limit: DEFAULT_PAGE_SIZE }))
+        }
         yield put(closeModal('CreateSingleItemModal'))
       }
     }


### PR DESCRIPTION
This PR fetches the items when creating a new item on the Item Editor page and keeps visible the emote controls when opening the avatar customization options.

Closes #2299 
Closes #2306 