### PR TITLE
fix: create emote from editor

### DIFF
--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -93,7 +93,7 @@ import { updateProgressSaveMultipleItems } from 'modules/ui/createMultipleItems/
 import { isLocked } from 'modules/collection/utils'
 import { locations } from 'routing/locations'
 import { BuilderAPI as LegacyBuilderAPI, FetchCollectionsParams } from 'lib/api/builder'
-import { DEFAULT_PAGE, PaginatedResource, PaginationStats } from 'lib/api/pagination'
+import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE, PaginatedResource, PaginationStats } from 'lib/api/pagination'
 import { getCollection, getCollections } from 'modules/collection/selectors'
 import { getIsEmotesFlowEnabled } from 'modules/features/selectors'
 import { getItemId } from 'modules/location/selectors'
@@ -380,15 +380,25 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
         // When creating a Wearable/Emote in the itemEditor, reload the left panel to show the new item created
         if (location.pathname === locations.itemEditor()) {
           if (collectionId) {
-            const paginationData: ItemPaginationData = yield select(getPaginationData, collectionId)
-            if (paginationData) {
-              yield put(fetchCollectionItemsRequest(collectionId, { page: paginationData.currentPage, limit: paginationData.limit }))
-            }
+            const paginationData: ItemPaginationData | undefined = yield select(getPaginationData, collectionId)
+            yield put(
+              fetchCollectionItemsRequest(
+                collectionId,
+                paginationData
+                  ? { page: paginationData.currentPage, limit: paginationData.limit }
+                  : { page: DEFAULT_PAGE, limit: DEFAULT_PAGE_SIZE }
+              )
+            )
           } else {
-            const paginationData: ItemPaginationData = yield select(getPaginationData, address)
-            if (paginationData) {
-              yield put(fetchItemsRequest(address, { page: paginationData.currentPage, limit: paginationData.limit }))
-            }
+            const paginationData: ItemPaginationData | undefined = yield select(getPaginationData, address)
+            yield put(
+              fetchItemsRequest(
+                address,
+                paginationData
+                  ? { page: paginationData.currentPage, limit: paginationData.limit }
+                  : { page: DEFAULT_PAGE, limit: DEFAULT_PAGE_SIZE }
+              )
+            )
           }
         }
         yield put(closeModal('CreateSingleItemModal'))

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -381,10 +381,14 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
         if (location.pathname === locations.itemEditor()) {
           if (collectionId) {
             const paginationData: ItemPaginationData = yield select(getPaginationData, collectionId)
-            yield put(fetchCollectionItemsRequest(collectionId, { page: paginationData.currentPage, limit: paginationData.limit }))
+            if (paginationData) {
+              yield put(fetchCollectionItemsRequest(collectionId, { page: paginationData.currentPage, limit: paginationData.limit }))
+            }
           } else {
             const paginationData: ItemPaginationData = yield select(getPaginationData, address)
-            yield put(fetchItemsRequest(address, { page: paginationData.currentPage, limit: paginationData.limit }))
+            if (paginationData) {
+              yield put(fetchItemsRequest(address, { page: paginationData.currentPage, limit: paginationData.limit }))
+            }
           }
         }
         yield put(closeModal('CreateSingleItemModal'))


### PR DESCRIPTION
When inside the item editor, but without opening any collection or item, the url is `/item-editor`, and there's no `paginationData`, but there is a `+` button to create an item. If you create an item in this particular page, the success saga at the end fails because `paginationSaga` is undefined. I added a check to make sure it exists.