### PR TITLE
fix: Allow push changes when some item couldn't be uploaded to the content server

### DIFF
--- a/src/modules/item/types.ts
+++ b/src/modules/item/types.ts
@@ -18,8 +18,8 @@ export enum ItemType {
 export enum SyncStatus {
   UNPUBLISHED = 'unpublished', // contract not deployed yet
   UNDER_REVIEW = 'under_review', // contract deployed, but not approved yet
-  LOADING = 'loading', // contract deployed and approved, but entitiy not loaded yet from catalyst
   UNSYNCED = 'unsynced', // contract deployed and approved, but contents in catalyst (entity) are different from contents on builder (item)
+  LOADING = 'loading', // contract deployed and approved, but entitiy not loaded yet from catalyst
   SYNCED = 'synced' // contract deployed and approved, and contents in catalyst === contents on builder
 }
 


### PR DESCRIPTION
This PR allows pushing changes to a collection when some item couldn't be uploaded to the content server.