### PR TITLE
fix: Computing the emotes metrics when tracks contain different sizes

### DIFF
--- a/src/lib/getModelData.ts
+++ b/src/lib/getModelData.ts
@@ -270,7 +270,6 @@ export async function getItemData({
         const { gltf, renderer } = await loadGltf(URL.createObjectURL(contents[model]))
         document.body.removeChild(renderer.domElement)
         const animation = gltf.animations[0]
-        const duration = animation.duration
         let frames = 0
         for (let i = 0; i < animation.tracks.length; i++) {
           const track = animation.tracks[i]
@@ -279,9 +278,9 @@ export async function getItemData({
 
         info = {
           sequences: gltf.animations.length,
-          duration,
-          frames: frames,
-          fps: frames / duration
+          duration: animation.duration,
+          frames,
+          fps: frames / animation.duration
         }
       }
     } else {

--- a/src/lib/getModelData.ts
+++ b/src/lib/getModelData.ts
@@ -269,8 +269,13 @@ export async function getItemData({
       } else {
         const { gltf, renderer } = await loadGltf(URL.createObjectURL(contents[model]))
         document.body.removeChild(renderer.domElement)
-        const duration = gltf.animations[0].duration
-        const frames = gltf.animations[0].tracks[0].times.length - 1
+        const animation = gltf.animations[0]
+        const duration = animation.duration
+        let frames = 0
+        for (let i = 0; i < animation.tracks.length; i++) {
+          const track = animation.tracks[i]
+          frames = Math.max(frames, track.times.length)
+        }
 
         info = {
           sequences: gltf.animations.length,


### PR DESCRIPTION
This PR fixes the computing of emotes' frames.

Closes #2316