### PR TITLE
chore: remove support for legacy emotes

### DIFF
--- a/src/components/CollectionDetailPage/CollectionContextMenu/CollectionContextMenu.container.ts
+++ b/src/components/CollectionDetailPage/CollectionContextMenu/CollectionContextMenu.container.ts
@@ -7,7 +7,6 @@ import { deleteCollectionRequest } from 'modules/collection/actions'
 import { getName } from 'modules/profile/selectors'
 import { openModal } from 'modules/modal/actions'
 import { createCollectionForumPostRequest, CREATE_COLLECTION_FORUM_POST_REQUEST } from 'modules/forum/actions'
-import { getIsEmotesFlowEnabled } from 'modules/features/selectors'
 import { getLoading } from 'modules/collection/selectors'
 import { getCollectionItems } from 'modules/item/selectors'
 import { MapDispatchProps, MapDispatch, MapStateProps, OwnProps } from './CollectionContextMenu.types'
@@ -17,8 +16,7 @@ const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => ({
   wallet: getWallet(state)!,
   items: getCollectionItems(state, ownProps.collection.id),
   name: getName(state) || '',
-  isForumPostLoading: isLoadingType(getLoading(state), CREATE_COLLECTION_FORUM_POST_REQUEST),
-  isEmotesFeatureFlagOn: getIsEmotesFlowEnabled(state)
+  isForumPostLoading: isLoadingType(getLoading(state), CREATE_COLLECTION_FORUM_POST_REQUEST)
 })
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({

--- a/src/components/CollectionDetailPage/CollectionContextMenu/CollectionContextMenu.tsx
+++ b/src/components/CollectionDetailPage/CollectionContextMenu/CollectionContextMenu.tsx
@@ -5,7 +5,6 @@ import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { buildCollectionForumPost } from 'modules/forum/utils'
 import { RoleType } from 'modules/collection/types'
 import { getExplorerURL, isOwner as isCollectionOwner, isLocked } from 'modules/collection/utils'
-import { ItemType } from 'modules/item/types'
 import ConfirmDelete from 'components/ConfirmDelete'
 import { Props } from './CollectionContextMenu.types'
 import styles from './CollectionContextMenu.module.css'
@@ -19,10 +18,9 @@ export default class CollectionContextMenu extends React.PureComponent<Props> {
   }
 
   handleNavigateToExplorer = () => {
-    const { collection, items, isEmotesFeatureFlagOn } = this.props
+    const { collection } = this.props
     const explorerLink = getExplorerURL({
-      collection,
-      hasNewEmotes: isEmotesFeatureFlagOn && items.some(item => item.type === ItemType.EMOTE)
+      collection
     })
     this.navigateTo(explorerLink, '_blank')
   }

--- a/src/components/CollectionDetailPage/CollectionContextMenu/CollectionContextMenu.types.ts
+++ b/src/components/CollectionDetailPage/CollectionContextMenu/CollectionContextMenu.types.ts
@@ -13,7 +13,6 @@ export type Props = {
   items: Item[]
   name: string
   isForumPostLoading: boolean
-  isEmotesFeatureFlagOn: boolean
   onOpenModal: typeof openModal
   onPostToForum: typeof createCollectionForumPostRequest
   onDelete: typeof deleteCollectionRequest
@@ -21,7 +20,7 @@ export type Props = {
 }
 
 export type OwnProps = Pick<Props, 'collection'>
-export type MapStateProps = Pick<Props, 'wallet' | 'items' | 'name' | 'isForumPostLoading' | 'isEmotesFeatureFlagOn'>
+export type MapStateProps = Pick<Props, 'wallet' | 'items' | 'name' | 'isForumPostLoading'>
 export type MapDispatchProps = Pick<Props, 'onNavigate' | 'onOpenModal' | 'onPostToForum' | 'onDelete'>
 export type MapDispatch = Dispatch<
   CallHistoryMethodAction | OpenModalAction | CreateCollectionForumPostRequestAction | DeleteCollectionRequestAction

--- a/src/components/CollectionDetailPage/CollectionItem/CollectionItem.container.ts
+++ b/src/components/CollectionDetailPage/CollectionItem/CollectionItem.container.ts
@@ -5,20 +5,18 @@ import { RootState } from 'modules/common/types'
 import { openModal } from 'modules/modal/actions'
 import { setCollection } from 'modules/item/actions'
 import { setItems } from 'modules/editor/actions'
-import { getIsEmotesFlowEnabled } from 'modules/features/selectors'
 import { MapStateProps, MapDispatch, MapDispatchProps } from './CollectionItem.types'
 import CollectionItem from './CollectionItem'
 
 const mapState = (state: RootState): MapStateProps => ({
-  ethAddress: getAddress(state),
-  isEmotesFeatureFlagOn: getIsEmotesFlowEnabled(state)
+  ethAddress: getAddress(state)
 })
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
   onNavigate: path => dispatch(push(path)),
   onOpenModal: (name, metadata) => dispatch(openModal(name, metadata)),
   onRemoveFromCollection: item => dispatch(setCollection(item, null)),
-  onSetItems: items => dispatch(setItems(items)),
+  onSetItems: items => dispatch(setItems(items))
 })
 
 export default connect(mapState, mapDispatch)(CollectionItem)

--- a/src/components/CollectionDetailPage/CollectionItem/CollectionItem.tsx
+++ b/src/components/CollectionDetailPage/CollectionItem/CollectionItem.tsx
@@ -24,11 +24,8 @@ export default class CollectionItem extends React.PureComponent<Props> {
   }
 
   handleNavigateToExplorer = () => {
-    const { item, isEmotesFeatureFlagOn } = this.props
-    const newWindow = window.open(
-      getExplorerURL({ item_ids: [item.id], hasNewEmotes: isEmotesFeatureFlagOn && item.type === ItemType.EMOTE }),
-      '_blank'
-    )
+    const { item } = this.props
+    const newWindow = window.open(getExplorerURL({ item_ids: [item.id] }), '_blank')
     if (newWindow) {
       newWindow.focus()
     }

--- a/src/components/CollectionDetailPage/CollectionItem/CollectionItem.types.ts
+++ b/src/components/CollectionDetailPage/CollectionItem/CollectionItem.types.ts
@@ -10,13 +10,12 @@ export type Props = {
   ethAddress?: string
   collection: Collection
   item: Item
-  isEmotesFeatureFlagOn: boolean
   onNavigate: (path: string) => void
   onOpenModal: typeof openModal
   onRemoveFromCollection: typeof setCollection
   onSetItems: typeof setItems
 }
 
-export type MapStateProps = Pick<Props, 'ethAddress' | 'isEmotesFeatureFlagOn'>
+export type MapStateProps = Pick<Props, 'ethAddress'>
 export type MapDispatchProps = Pick<Props, 'onNavigate' | 'onOpenModal' | 'onRemoveFromCollection' | 'onSetItems'>
 export type MapDispatch = Dispatch<CallHistoryMethodAction | OpenModalAction | SetCollectionAction | SetItemsAction>

--- a/src/components/CollectionDetailPage/CollectionPublishButton/CollectionPublishButton.container.ts
+++ b/src/components/CollectionDetailPage/CollectionPublishButton/CollectionPublishButton.container.ts
@@ -4,7 +4,6 @@ import { getData as getWallet } from 'decentraland-dapps/dist/modules/wallet/sel
 import { RootState } from 'modules/common/types'
 import { fetchCollectionCurationRequest } from 'modules/curations/collectionCuration/actions'
 import { getStatusByCollectionId } from 'modules/collection/selectors'
-import { getIsNewEmotesPublishEnabled } from 'modules/features/selectors'
 import { getHasPendingCollectionCuration } from 'modules/curations/collectionCuration/selectors'
 import { getCollectionItems } from 'modules/item/selectors'
 import { openModal } from 'modules/modal/actions'
@@ -20,8 +19,7 @@ const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
     items: getCollectionItems(state, collectionId),
     authorizations: getAuthorizations(state),
     status: statusByCollectionId[collectionId],
-    hasPendingCuration: getHasPendingCollectionCuration(state, collectionId),
-    isNewEmotesPublishFlagOn: getIsNewEmotesPublishEnabled(state)
+    hasPendingCuration: getHasPendingCollectionCuration(state, collectionId)
   }
 }
 

--- a/src/components/CollectionDetailPage/CollectionPublishButton/CollectionPublishButton.tsx
+++ b/src/components/CollectionDetailPage/CollectionPublishButton/CollectionPublishButton.tsx
@@ -9,24 +9,13 @@ import { ContractName } from 'decentraland-transactions'
 import { AuthorizationModal } from 'components/AuthorizationModal'
 import { MAX_ITEMS } from 'modules/collection/constants'
 import { isComplete } from 'modules/item/utils'
-import { ItemType, SyncStatus } from 'modules/item/types'
+import { SyncStatus } from 'modules/item/types'
 import { buildManaAuthorization } from 'lib/mana'
 import { Props } from './CollectionPublishButton.types'
 import UnderReview from './UnderReview'
 
 const CollectionPublishButton = (props: Props) => {
-  const {
-    wallet,
-    collection,
-    items,
-    authorizations,
-    status,
-    hasPendingCuration,
-    onPublish,
-    onPush,
-    onInit,
-    isNewEmotesPublishFlagOn
-  } = props
+  const { wallet, collection, items, authorizations, status, hasPendingCuration, onPublish, onPush, onInit } = props
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false)
 
   useEffect(() => {
@@ -36,15 +25,11 @@ const CollectionPublishButton = (props: Props) => {
   }, [collection, onInit])
 
   const hasExceededMaxItemsLimit = items.length > MAX_ITEMS
-  const isTryingToPublishEmotesButCant = useMemo(() => items.some(item => item.type === ItemType.EMOTE) && !isNewEmotesPublishFlagOn, [
-    isNewEmotesPublishFlagOn,
-    items
-  ])
 
-  const isPublishDisabled = useMemo(
-    () => isTryingToPublishEmotesButCant || items.length === 0 || !items.every(isComplete) || hasExceededMaxItemsLimit,
-    [isTryingToPublishEmotesButCant, items, hasExceededMaxItemsLimit]
-  )
+  const isPublishDisabled = useMemo(() => items.length === 0 || !items.every(isComplete) || hasExceededMaxItemsLimit, [
+    items,
+    hasExceededMaxItemsLimit
+  ])
 
   const getAuthorization = (): Authorization => {
     return buildManaAuthorization(wallet.address, wallet.networks.MATIC.chainId, ContractName.CollectionManager)
@@ -96,8 +81,6 @@ const CollectionPublishButton = (props: Props) => {
         reason = t('collection_detail_page.publish_reason_max_items', { maxItems: MAX_ITEMS })
       } else if (items.length === 0) {
         reason = t('collection_detail_page.publish_reason_no_items')
-      } else if (isTryingToPublishEmotesButCant) {
-        reason = t('collection_detail_page.cant_publish_new_emotes')
       } else {
         reason = t('collection_detail_page.publish_reason_items_not_complete')
       }

--- a/src/components/CollectionDetailPage/CollectionPublishButton/CollectionPublishButton.types.ts
+++ b/src/components/CollectionDetailPage/CollectionPublishButton/CollectionPublishButton.types.ts
@@ -13,16 +13,12 @@ export type Props = {
   authorizations: Authorization[]
   status: SyncStatus
   hasPendingCuration: boolean
-  isNewEmotesPublishFlagOn: boolean
   onPublish: () => void
   onPush: () => void
   onInit: () => void
 }
 
 export type OwnProps = Pick<Props, 'collection'>
-export type MapStateProps = Pick<
-  Props,
-  'wallet' | 'items' | 'authorizations' | 'status' | 'hasPendingCuration' | 'isNewEmotesPublishFlagOn'
->
+export type MapStateProps = Pick<Props, 'wallet' | 'items' | 'authorizations' | 'status' | 'hasPendingCuration'>
 export type MapDispatchProps = Pick<Props, 'onPublish' | 'onPush' | 'onInit'>
 export type MapDispatch = Dispatch<OpenModalAction | FetchCollectionCurationRequestAction>

--- a/src/components/ItemDetailPage/ItemDetailPage.container.ts
+++ b/src/components/ItemDetailPage/ItemDetailPage.container.ts
@@ -7,7 +7,6 @@ import { getItemId } from 'modules/location/selectors'
 import { getCollection } from 'modules/collection/selectors'
 import { getItem, getLoading, hasViewAndEditRights } from 'modules/item/selectors'
 import { openModal } from 'modules/modal/actions'
-import { getIsEmotesFlowEnabled } from 'modules/features/selectors'
 import { FETCH_ITEMS_REQUEST, DELETE_ITEM_REQUEST, deleteItemRequest, saveItemRequest, SAVE_ITEM_REQUEST } from 'modules/item/actions'
 import { MapStateProps, MapDispatchProps, MapDispatch } from './ItemDetailPage.types'
 import ItemDetailPage from './ItemDetailPage'
@@ -27,8 +26,7 @@ const mapState = (state: RootState): MapStateProps => {
       isLoadingType(getLoading(state), FETCH_ITEMS_REQUEST) ||
       isLoadingType(getLoading(state), DELETE_ITEM_REQUEST) ||
       isLoadingType(getLoading(state), SAVE_ITEM_REQUEST),
-    hasAccess: item !== null && hasViewAndEditRights(state, wallet.address, collection, item),
-    isEmotesFeatureFlagOn: getIsEmotesFlowEnabled(state)
+    hasAccess: item !== null && hasViewAndEditRights(state, wallet.address, collection, item)
   }
 }
 

--- a/src/components/ItemDetailPage/ItemDetailPage.tsx
+++ b/src/components/ItemDetailPage/ItemDetailPage.tsx
@@ -64,9 +64,9 @@ export default class ItemDetailPage extends React.PureComponent<Props, State> {
   }
 
   handleOpenThumbnailDialog = () => {
-    const { item, onOpenModal, isEmotesFeatureFlagOn } = this.props
+    const { item, onOpenModal } = this.props
 
-    if (isEmotesFeatureFlagOn && item?.type === ItemType.EMOTE) {
+    if (item?.type === ItemType.EMOTE) {
       onOpenModal('EditThumbnailModal', { onSaveThumbnail: this.handleEmoteThumbnailChange, item })
     } else if (this.thumbnailInput.current) {
       this.thumbnailInput.current.click()

--- a/src/components/ItemDetailPage/ItemDetailPage.types.ts
+++ b/src/components/ItemDetailPage/ItemDetailPage.types.ts
@@ -21,10 +21,9 @@ export type Props = {
   onOpenModal: typeof openModal
   onDelete: typeof deleteItemRequest
   onSaveItem: typeof saveItemRequest
-  isEmotesFeatureFlagOn: boolean
   hasAccess: boolean
 }
 
-export type MapStateProps = Pick<Props, 'wallet' | 'itemId' | 'item' | 'collection' | 'isLoading' | 'hasAccess' | 'isEmotesFeatureFlagOn'>
+export type MapStateProps = Pick<Props, 'wallet' | 'itemId' | 'item' | 'collection' | 'isLoading' | 'hasAccess'>
 export type MapDispatchProps = Pick<Props, 'onSaveItem' | 'onNavigate' | 'onDelete' | 'onOpenModal'>
 export type MapDispatch = Dispatch<SaveItemRequestAction | CallHistoryMethodAction | DeleteItemRequestAction | OpenModalAction>

--- a/src/components/ItemEditorPage/RightPanel/RightPanel.container.ts
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.container.ts
@@ -8,7 +8,7 @@ import { isOwner } from 'modules/item/utils'
 import { getSelectedItemId } from 'modules/location/selectors'
 import { getCollection, hasViewAndEditRights } from 'modules/collection/selectors'
 import { isWalletCommitteeMember } from 'modules/committee/selectors'
-import { getIsEmotePlayModeEnabled, getIsEmotesFlowEnabled } from 'modules/features/selectors'
+import { getIsEmotePlayModeEnabled } from 'modules/features/selectors'
 import { MapStateProps, MapDispatchProps, MapDispatch } from './RightPanel.types'
 import RightPanel from './RightPanel'
 
@@ -31,7 +31,6 @@ const mapState = (state: RootState): MapStateProps => {
     isConnected: isConnected(state),
     isDownloading: isDownloading(state),
     isCommitteeMember: isWalletCommitteeMember(state),
-    isEmotesFeatureFlagOn: getIsEmotesFlowEnabled(state),
     isEmotePlayModeFeatureFlagOn: getIsEmotePlayModeEnabled(state)
   }
 }

--- a/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
@@ -234,9 +234,9 @@ export default class RightPanel extends React.PureComponent<Props, State> {
   }
 
   handleOpenThumbnailDialog = () => {
-    const { selectedItem, isEmotesFeatureFlagOn, onOpenModal } = this.props
+    const { selectedItem, onOpenModal } = this.props
 
-    if (isEmotesFeatureFlagOn && selectedItem?.type === ItemType.EMOTE) {
+    if (selectedItem?.type === ItemType.EMOTE) {
       onOpenModal('EditThumbnailModal', { onSaveThumbnail: this.handleEmoteThumbnailChange, item: selectedItem })
     } else if (this.thumbnailInput.current) {
       this.thumbnailInput.current.click()

--- a/src/components/ItemEditorPage/RightPanel/RightPanel.types.ts
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.types.ts
@@ -24,7 +24,6 @@ export type Props = {
   isConnected: boolean
   isDownloading: boolean
   isCommitteeMember: boolean
-  isEmotesFeatureFlagOn: boolean
   isEmotePlayModeFeatureFlagOn: boolean
   onSaveItem: typeof saveItemRequest
   onDeleteItem: typeof deleteItemRequest
@@ -54,7 +53,6 @@ export type MapStateProps = Pick<
   | 'isConnected'
   | 'isDownloading'
   | 'isCommitteeMember'
-  | 'isEmotesFeatureFlagOn'
   | 'isEmotePlayModeFeatureFlagOn'
   | 'canEditSelectedItem'
 >

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.container.ts
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.container.ts
@@ -3,7 +3,7 @@ import { getAddress } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 import { RootState } from 'modules/common/types'
 import { saveItemRequest, SAVE_ITEM_REQUEST } from 'modules/item/actions'
-import { getIsEmotePlayModeEnabled, getIsEmotesFlowEnabled, getIsNewEmotesPublishEnabled } from 'modules/features/selectors'
+import { getIsEmotePlayModeEnabled } from 'modules/features/selectors'
 import { getLoading, getError } from 'modules/item/selectors'
 import { getCollection } from 'modules/collection/selectors'
 import { Collection } from 'modules/collection/types'
@@ -18,9 +18,7 @@ const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
     address: getAddress(state),
     error: getError(state),
     isLoading: isLoadingType(getLoading(state), SAVE_ITEM_REQUEST),
-    isEmotesFeatureFlagOn: getIsEmotesFlowEnabled(state),
-    isEmotePlayModeFeatureFlagOn: getIsEmotePlayModeEnabled(state),
-    isNewEmotesPublishEnabled: getIsNewEmotesPublishEnabled(state)
+    isEmotePlayModeFeatureFlagOn: getIsEmotePlayModeEnabled(state)
   }
 }
 

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
@@ -167,7 +167,7 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
   }
 
   createItem = async (sortedContents: SortedContent, representations: WearableRepresentation[]) => {
-    const { address, collection, isEmotesFeatureFlagOn, onSave } = this.props
+    const { address, collection, onSave } = this.props
     const { id, name, description, type, metrics, collectionId, category, playMode, rarity } = this.state as StateData
 
     const belongsToAThirdPartyCollection = collection?.urn && isThirdParty(collection?.urn)
@@ -227,7 +227,7 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
     }
 
     // The Emote will be saved on the set price step
-    if (isEmotesFeatureFlagOn && type === ItemType.EMOTE) {
+    if (type === ItemType.EMOTE) {
       this.setState({
         item: { ...(item as Item) },
         itemSortedContents: sortedContents.all,
@@ -366,7 +366,6 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
   }
 
   getMetricsAndScreenshot = async () => {
-    const { isEmotesFeatureFlagOn } = this.props
     const { type, previewController, model, contents, category } = this.state
     if (type && model && contents) {
       const data = await getItemData({
@@ -374,8 +373,7 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
         type,
         model,
         contents,
-        category,
-        isEmotesFeatureFlagOn
+        category
       })
       this.setState({ metrics: data.info, thumbnail: data.image, isLoading: false }, () => {
         this.setState({ view: CreateItemView.DETAILS })
@@ -422,9 +420,8 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
   }
 
   handleOpenThumbnailDialog = () => {
-    const { isEmotesFeatureFlagOn } = this.props
     const { type } = this.state
-    if (isEmotesFeatureFlagOn && type === ItemType.EMOTE) {
+    if (type === ItemType.EMOTE) {
       this.setState({ fromView: CreateItemView.DETAILS, view: CreateItemView.THUMBNAIL })
     } else if (this.thumbnailInput.current) {
       this.thumbnailInput.current.click()
@@ -651,7 +648,7 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
   }
 
   renderFields() {
-    const { collection, isNewEmotesPublishEnabled } = this.props
+    const { collection } = this.props
     const { name, category, rarity, contents, item, type } = this.state
 
     const belongsToAThirdPartyCollection = collection?.urn && isThirdParty(collection.urn)
@@ -659,7 +656,7 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
     const categories: string[] = type === ItemType.WEARABLE ? getWearableCategories(contents) : getEmoteCategories()
 
     const raritiesLink =
-      isNewEmotesPublishEnabled && type === ItemType.EMOTE
+      type === ItemType.EMOTE
         ? 'https://docs.decentraland.org/emotes/emotes/#rarity'
         : 'https://docs.decentraland.org/decentraland/wearables-editor-user-guide/#rarity'
 
@@ -866,7 +863,7 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
   }
 
   renderDetailsView() {
-    const { onClose, metadata, error, isLoading, isEmotesFeatureFlagOn } = this.props
+    const { onClose, metadata, error, isLoading } = this.props
     const { thumbnail, isRepresentation, rarity, error: stateError, type } = this.state
 
     const isDisabled = this.isDisabled()
@@ -900,7 +897,7 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
                 <Button primary disabled={isDisabled} loading={isLoading}>
                   {(metadata && metadata.changeItemFile) || isRepresentation
                     ? t('global.save')
-                    : isEmotesFeatureFlagOn && type === ItemType.EMOTE
+                    : type === ItemType.EMOTE
                     ? t('global.next')
                     : t('global.create')}
                 </Button>

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.types.ts
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.types.ts
@@ -19,9 +19,7 @@ export type Props = ModalProps & {
   error: string | null
   isLoading: boolean
   collection: Collection | null
-  isEmotesFeatureFlagOn: boolean
   isEmotePlayModeFeatureFlagOn: boolean
-  isNewEmotesPublishEnabled: boolean
   onSave: typeof saveItemRequest
 }
 
@@ -74,9 +72,6 @@ export type AcceptedFileProps = Pick<
   'id' | 'name' | 'description' | 'rarity' | 'file' | 'model' | 'metrics' | 'contents' | 'type' | 'bodyShape' | 'category' | 'thumbnail'
 >
 export type OwnProps = Pick<Props, 'metadata' | 'name' | 'onClose'>
-export type MapStateProps = Pick<
-  Props,
-  'address' | 'error' | 'isLoading' | 'collection' | 'isEmotesFeatureFlagOn' | 'isEmotePlayModeFeatureFlagOn' | 'isNewEmotesPublishEnabled'
->
+export type MapStateProps = Pick<Props, 'address' | 'error' | 'isLoading' | 'collection' | 'isEmotePlayModeFeatureFlagOn'>
 export type MapDispatchProps = Pick<Props, 'onSave'>
 export type MapDispatch = Dispatch<SaveItemRequestAction>

--- a/src/lib/getModelData.ts
+++ b/src/lib/getModelData.ts
@@ -230,15 +230,13 @@ export async function getItemData({
   model,
   wearablePreviewController,
   contents,
-  category,
-  isEmotesFeatureFlagOn
+  category
 }: {
   type: ItemType
   model: string
   wearablePreviewController?: IPreviewController
   contents: Record<string, Blob>
   category?: string
-  isEmotesFeatureFlagOn?: boolean
 }) {
   let info: Metrics
   let image
@@ -257,31 +255,20 @@ export async function getItemData({
       throw Error('WearablePreview controller needed')
     }
     if (type === ItemType.EMOTE) {
-      if (!isEmotesFeatureFlagOn) {
-        info = {
-          triangles: 0,
-          materials: 0,
-          textures: 0,
-          meshes: 0,
-          bodies: 0,
-          entities: 1
-        }
-      } else {
-        const { gltf, renderer } = await loadGltf(URL.createObjectURL(contents[model]))
-        document.body.removeChild(renderer.domElement)
-        const animation = gltf.animations[0]
-        let frames = 0
-        for (let i = 0; i < animation.tracks.length; i++) {
-          const track = animation.tracks[i]
-          frames = Math.max(frames, track.times.length)
-        }
+      const { gltf, renderer } = await loadGltf(URL.createObjectURL(contents[model]))
+      document.body.removeChild(renderer.domElement)
+      const animation = gltf.animations[0]
+      let frames = 0
+      for (let i = 0; i < animation.tracks.length; i++) {
+        const track = animation.tracks[i]
+        frames = Math.max(frames, track.times.length)
+      }
 
-        info = {
-          sequences: gltf.animations.length,
-          duration: animation.duration,
-          frames,
-          fps: frames / animation.duration
-        }
+      info = {
+        sequences: gltf.animations.length,
+        duration: animation.duration,
+        frames,
+        fps: frames / animation.duration
       }
     } else {
       info = await wearablePreviewController.scene.getMetrics()

--- a/src/modules/collection/sagas.spec.ts
+++ b/src/modules/collection/sagas.spec.ts
@@ -261,8 +261,8 @@ describe('when executing the approval flow', () => {
                 [item.id]: entity
               }
             ],
-            [call(buildStandardWearableContentHash, collection, item, EntityHashingType.V0, false), 'QmOldDifferentHash'],
-            [call(buildStandardWearableContentHash, collection, item, EntityHashingType.V1, false), newBlockchainHash],
+            [call(buildStandardWearableContentHash, collection, item, EntityHashingType.V0), 'QmOldDifferentHash'],
+            [call(buildStandardWearableContentHash, collection, item, EntityHashingType.V1), newBlockchainHash],
             [delay(1000), void 0],
             [select(getItemsById), { [updatedItem.id]: updatedItem }],
             [select(getCurationsByCollectionId), { [collection.id]: curation }]
@@ -323,8 +323,8 @@ describe('when executing the approval flow', () => {
                 [item.id]: entity
               }
             ],
-            [call(buildStandardWearableContentHash, collection, item, EntityHashingType.V0, false), 'QmOldContentHash'],
-            [call(buildStandardWearableContentHash, collection, item, EntityHashingType.V1, false), 'aNewHash'],
+            [call(buildStandardWearableContentHash, collection, item, EntityHashingType.V0), 'QmOldContentHash'],
+            [call(buildStandardWearableContentHash, collection, item, EntityHashingType.V1), 'aNewHash'],
             [select(getCurationsByCollectionId), { [collection.id]: curation }]
           ])
           .dispatch(initiateApprovalFlow(collection))
@@ -365,8 +365,8 @@ describe('when executing the approval flow', () => {
                 [item.id]: entity
               }
             ],
-            [call(buildStandardWearableContentHash, collection, item, EntityHashingType.V0, false), 'QmOldContentHash'],
-            [call(buildStandardWearableContentHash, collection, item, EntityHashingType.V1, false), 'aNewHash'],
+            [call(buildStandardWearableContentHash, collection, item, EntityHashingType.V0), 'QmOldContentHash'],
+            [call(buildStandardWearableContentHash, collection, item, EntityHashingType.V1), 'aNewHash'],
             [select(getCurationsByCollectionId), { [collection.id]: curation }]
           ])
           .dispatch(initiateApprovalFlow(collection))
@@ -420,7 +420,7 @@ describe('when executing the approval flow', () => {
           [delay(1000), void 0],
           [select(getItemsById), { [syncedItem.id]: syncedItem, [updatedItem.id]: updatedItem }],
           [select(getEntityByItemId), { [syncedItem.id]: syncedEntity, [updatedItem.id]: unsyncedEntity }],
-          [call(buildItemEntity, mockCatalyst, mockBuilder, collection, unsyncedItem, undefined, undefined, false), deployData]
+          [call(buildItemEntity, mockCatalyst, mockBuilder, collection, unsyncedItem, undefined, undefined), deployData]
         ])
         .dispatch(initiateApprovalFlow(collection))
         .put(
@@ -505,7 +505,7 @@ describe('when executing the approval flow', () => {
           [delay(1000), void 0],
           [select(getItemsById), { [syncedItem.id]: syncedItem, [unsyncedItem.id]: updatedItem }],
           [select(getEntityByItemId), { [syncedItem.id]: syncedEntity, [updatedItem.id]: unsyncedEntity }],
-          [call(buildItemEntity, mockCatalyst, mockBuilder, collection, unsyncedItem, undefined, undefined, false), deployData],
+          [call(buildItemEntity, mockCatalyst, mockBuilder, collection, unsyncedItem, undefined, undefined), deployData],
           [select(getCurationsByCollectionId), { [collection.id]: curation }]
         ])
         .dispatch(initiateApprovalFlow(collection))
@@ -668,7 +668,7 @@ describe('when executing the approval flow', () => {
           [delay(1000), void 0],
           [select(getItemsById), { [syncedItem.id]: syncedItem, [updatedItem.id]: updatedItem }],
           [select(getEntityByItemId), { [syncedItem.id]: syncedEntity, [updatedItem.id]: unsyncedEntity }],
-          [call(buildItemEntity, mockCatalyst, mockBuilder, collection, unsyncedItem, undefined, undefined, false), deployData]
+          [call(buildItemEntity, mockCatalyst, mockBuilder, collection, unsyncedItem, undefined, undefined), deployData]
         ])
         .dispatch(initiateApprovalFlow(collection))
         .put(
@@ -747,7 +747,7 @@ describe('when executing the approval flow', () => {
           [delay(1000), void 0],
           [select(getItemsById), { [syncedItem.id]: syncedItem, [updatedItem.id]: updatedItem }],
           [select(getEntityByItemId), { [syncedItem.id]: syncedEntity, [updatedItem.id]: unsyncedEntity }],
-          [call(buildItemEntity, mockCatalyst, mockBuilder, collection, unsyncedItem, undefined, undefined, false), deployData]
+          [call(buildItemEntity, mockCatalyst, mockBuilder, collection, unsyncedItem, undefined, undefined), deployData]
         ])
         .dispatch(initiateApprovalFlow(collection))
         .put(
@@ -835,7 +835,7 @@ describe('when executing the approval flow', () => {
           [delay(1000), void 0],
           [select(getItemsById), { [syncedItem.id]: syncedItem, [unsyncedItem.id]: updatedItem }],
           [select(getEntityByItemId), { [syncedItem.id]: syncedEntity, [updatedItem.id]: unsyncedEntity }],
-          [call(buildItemEntity, mockCatalyst, mockBuilder, collection, unsyncedItem, undefined, undefined, false), deployData],
+          [call(buildItemEntity, mockCatalyst, mockBuilder, collection, unsyncedItem, undefined, undefined), deployData],
           [select(getCurationsByCollectionId), { [collection.id]: curation }]
         ])
         .dispatch(initiateApprovalFlow(collection))

--- a/src/modules/collection/utils.ts
+++ b/src/modules/collection/utils.ts
@@ -39,26 +39,13 @@ export function getCollectionEditorURL(collection: Collection, items: Item[]): s
   return locations.itemEditor({ collectionId: collection.id, itemId: items.length > 0 ? items[0].id : undefined })
 }
 
-export function getExplorerURL({
-  collection,
-  item_ids,
-  hasNewEmotes = false
-}: {
-  collection?: Collection
-  item_ids?: string[]
-  hasNewEmotes?: boolean
-}): string {
+export function getExplorerURL({ collection, item_ids }: { collection?: Collection; item_ids?: string[] }): string {
   if (!collection && !item_ids) {
     throw new Error('Either a collection or item ids must be specified to get the explorer url')
   }
   const EXPLORER_URL = config.get('EXPLORER_URL', '')
   const BUILDER_SERVER_URL = config.get('BUILDER_SERVER_URL', '')
   let URL = `${EXPLORER_URL}?BUILDER_SERVER_URL=${BUILDER_SERVER_URL}&NETWORK=goerli&DEBUG_MODE=true`
-
-  // TODO: @emotes remove this when kernel and explorer are released. This is temporary so creators and preview the new emotes
-  if (hasNewEmotes) {
-    URL += `&renderer-branch=feat/new-nft-emotes-flow&kernel-branch=feat/fetch-emotes`
-  }
 
   if (collection) {
     URL += `&WITH_COLLECTIONS=${collection.id}`

--- a/src/modules/editor/utils.ts
+++ b/src/modules/editor/utils.ts
@@ -302,8 +302,7 @@ export function toWearable(item: Item): WearableDefinition {
         ...representation,
         contents: representation.contents.map(path => ({ key: path, url: getContentsStorageUrl(item.contents[path]) }))
       }))
-    },
-    emoteDataV0: undefined
+    }
   }
 }
 

--- a/src/modules/features/selectors.ts
+++ b/src/modules/features/selectors.ts
@@ -14,14 +14,6 @@ export const getIsMaintenanceEnabled = (state: RootState) => {
   }
 }
 
-export const getIsEmotesFlowEnabled = (state: RootState) => {
-  try {
-    return getIsFeatureEnabled(state, ApplicationName.BUILDER, FeatureName.NEW_EMOTE_FLOW)
-  } catch (e) {
-    return false
-  }
-}
-
 export const getIsRentalsEnabled = (state: RootState) => {
   try {
     return getIsFeatureEnabled(state, ApplicationName.BUILDER, FeatureName.RENTALS)
@@ -33,14 +25,6 @@ export const getIsRentalsEnabled = (state: RootState) => {
 export const getIsEmotePlayModeEnabled = (state: RootState) => {
   try {
     return getIsFeatureEnabled(state, ApplicationName.BUILDER, FeatureName.EMOTE_PLAY_MODE)
-  } catch (e) {
-    return false
-  }
-}
-
-export const getIsNewEmotesPublishEnabled = (state: RootState) => {
-  try {
-    return getIsFeatureEnabled(state, ApplicationName.BUILDER, FeatureName.PUBLISH_NEW_EMOTES)
   } catch (e) {
     return false
   }

--- a/src/modules/item/sagas.spec.ts
+++ b/src/modules/item/sagas.spec.ts
@@ -20,7 +20,6 @@ import { MAX_ITEMS } from 'modules/collection/constants'
 import { getMethodData } from 'modules/wallet/utils'
 import { mockedItem, mockedItemContents, mockedLocalItem, mockedRemoteItem } from 'specs/item'
 import { getCollections, getCollection } from 'modules/collection/selectors'
-import { getIsEmotesFlowEnabled } from 'modules/features/selectors'
 import { updateProgressSaveMultipleItems } from 'modules/ui/createMultipleItems/action'
 import { fetchItemCurationRequest } from 'modules/curations/itemCuration/actions'
 import { downloadZip } from 'lib/zip'
@@ -495,34 +494,16 @@ describe('when handling the save item success action', () => {
           item = { ...item, type: ItemType.EMOTE }
         })
 
-        describe('and the FF EmotesFlow is enabled', () => {
-          it('should put a location change to the item editor', () => {
-            return expectSaga(itemSaga, builderAPI, builderClient)
-              .provide([
-                [select(getLocation), { pathname: locations.collections() }],
-                [select(getOpenModals), { CreateSingleItemModal: true }],
-                [select(getIsEmotesFlowEnabled), true],
-                [select(getAddress), mockAddress]
-              ])
-              .put(push(locations.itemEditor({ itemId: item.id })))
-              .dispatch(saveItemSuccess(item, {}))
-              .run({ silenceTimeout: true })
-          })
-        })
-
-        describe('and the FF EmotesFlow is disabled', () => {
-          it('should put a location change to the item detail', () => {
-            return expectSaga(itemSaga, builderAPI, builderClient)
-              .provide([
-                [select(getLocation), { pathname: locations.collections() }],
-                [select(getOpenModals), { CreateSingleItemModal: true }],
-                [select(getIsEmotesFlowEnabled), false],
-                [select(getAddress), mockAddress]
-              ])
-              .put(push(locations.itemDetail(item.id)))
-              .dispatch(saveItemSuccess(item, {}))
-              .run({ silenceTimeout: true })
-          })
+        it('should put a location change to the item editor', () => {
+          return expectSaga(itemSaga, builderAPI, builderClient)
+            .provide([
+              [select(getLocation), { pathname: locations.collections() }],
+              [select(getOpenModals), { CreateSingleItemModal: true }],
+              [select(getAddress), mockAddress]
+            ])
+            .put(push(locations.itemEditor({ itemId: item.id })))
+            .dispatch(saveItemSuccess(item, {}))
+            .run({ silenceTimeout: true })
         })
       })
     })
@@ -549,35 +530,16 @@ describe('when handling the save item success action', () => {
           item = { ...item, type: ItemType.EMOTE }
         })
 
-        describe('and the FF EmotesFlow is enabled', () => {
-          it('should put a location change to the item editor', () => {
-            return expectSaga(itemSaga, builderAPI, builderClient)
-              .provide([
-                [select(getLocation), { pathname: locations.collectionDetail(collection.id) }],
-                [select(getOpenModals), { CreateSingleItemModal: true }],
-                [select(getIsEmotesFlowEnabled), true],
-                [select(getAddress), mockAddress]
-              ])
-              .put(push(locations.itemEditor({ collectionId: collection.id, itemId: item.id })))
-              .dispatch(saveItemSuccess(item, {}))
-              .run({ silenceTimeout: true })
-          })
-        })
-
-        describe('and the FF EmotesFlow is disabled', () => {
-          it('should close the modal CreateSingleItemModal', () => {
-            return expectSaga(itemSaga, builderAPI, builderClient)
-              .provide([
-                [select(getLocation), { pathname: locations.collectionDetail(collection.id) }],
-                [select(getOpenModals), { CreateSingleItemModal: true }],
-                [select(getIsEmotesFlowEnabled), false],
-                [select(getAddress), mockAddress],
-                [select(getPaginationData, item.collectionId!), { currentPage: 1, limit: 10 }]
-              ])
-              .put(closeModal('CreateSingleItemModal'))
-              .dispatch(saveItemSuccess(item, {}))
-              .run({ silenceTimeout: true })
-          })
+        it('should put a location change to the item editor', () => {
+          return expectSaga(itemSaga, builderAPI, builderClient)
+            .provide([
+              [select(getLocation), { pathname: locations.collectionDetail(collection.id) }],
+              [select(getOpenModals), { CreateSingleItemModal: true }],
+              [select(getAddress), mockAddress]
+            ])
+            .put(push(locations.itemEditor({ collectionId: collection.id, itemId: item.id })))
+            .dispatch(saveItemSuccess(item, {}))
+            .run({ silenceTimeout: true })
         })
       })
     })
@@ -617,7 +579,6 @@ describe('when handling the save item success action', () => {
               .provide([
                 [select(getLocation), { pathname: locations.itemEditor() }],
                 [select(getOpenModals), { CreateSingleItemModal: true }],
-                [select(getIsEmotesFlowEnabled), true],
                 [select(getAddress), mockAddress],
                 [select(getPaginationData, item.collectionId!), { ...paginationData }]
               ])
@@ -634,7 +595,6 @@ describe('when handling the save item success action', () => {
               .provide([
                 [select(getLocation), { pathname: locations.itemEditor() }],
                 [select(getOpenModals), { CreateSingleItemModal: true }],
-                [select(getIsEmotesFlowEnabled), false],
                 [select(getAddress), mockAddress],
                 [select(getPaginationData, item.collectionId!), { ...paginationData }]
               ])

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -95,7 +95,6 @@ import { locations } from 'routing/locations'
 import { BuilderAPI as LegacyBuilderAPI, FetchCollectionsParams } from 'lib/api/builder'
 import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE, PaginatedResource, PaginationStats } from 'lib/api/pagination'
 import { getCollection, getCollections } from 'modules/collection/selectors'
-import { getIsEmotesFlowEnabled } from 'modules/features/selectors'
 import { getItemId } from 'modules/location/selectors'
 import { Collection } from 'modules/collection/types'
 import { MAX_ITEMS } from 'modules/collection/constants'
@@ -358,7 +357,6 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
     const address: string = yield select(getAddress)
     const openModals: ModalState = yield select(getOpenModals)
     const location: ReturnType<typeof getLocation> = yield select(getLocation)
-    const isEmotesFeatureFlagOn: boolean = yield select(getIsEmotesFlowEnabled)
     const { item } = action.payload
     const collectionId = item.collectionId!
     const ItemModals = ['EditItemURNModal', 'EditPriceAndBeneficiaryModal', 'AddExistingItemModal']
@@ -366,14 +364,14 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
       yield put(closeAllModals())
     } else if (openModals['CreateSingleItemModal']) {
       if (location.pathname === locations.collections()) {
-        if (isEmotesFeatureFlagOn && item.type === ItemType.EMOTE) {
+        if (item.type === ItemType.EMOTE) {
           // Redirect to the item editor
           yield put(push(locations.itemEditor({ itemId: item.id })))
         } else {
           // Redirect to the newly created item details
           yield put(push(locations.itemDetail(item.id)))
         }
-      } else if (location.pathname === locations.collectionDetail(collectionId) && isEmotesFeatureFlagOn && item.type === ItemType.EMOTE) {
+      } else if (location.pathname === locations.collectionDetail(collectionId) && item.type === ItemType.EMOTE) {
         // Redirect to the item editor
         yield put(push(locations.itemEditor({ collectionId, itemId: item.id })))
       } else {

--- a/src/modules/item/selectors.ts
+++ b/src/modules/item/selectors.ts
@@ -10,7 +10,6 @@ import { EntityState } from 'modules/entity/reducer'
 import { CollectionCuration } from 'modules/curations/collectionCuration/types'
 import { getCurationsByCollectionId } from 'modules/curations/collectionCuration/selectors'
 import { ItemCuration } from 'modules/curations/itemCuration/types'
-import { getIsEmotesFlowEnabled } from 'modules/features/selectors'
 import { getItemCurationsByItemId } from 'modules/curations/itemCuration/selectors'
 import { CurationStatus } from 'modules/curations/types'
 import { getItemThirdParty } from 'modules/thirdParty/selectors'
@@ -130,12 +129,7 @@ const getStatusForTP = (item: Item, itemCuration: ItemCuration | null): SyncStat
   return SyncStatus.UNPUBLISHED
 }
 
-const getStatusForStandard = (
-  item: Item,
-  collectionCuration: CollectionCuration | null,
-  entity: Entity,
-  isEmotesFeatureFlagOn: boolean
-): SyncStatus => {
+const getStatusForStandard = (item: Item, collectionCuration: CollectionCuration | null, entity: Entity): SyncStatus => {
   let status: SyncStatus
   if (!item.isPublished) {
     status = SyncStatus.UNPUBLISHED
@@ -144,7 +138,7 @@ const getStatusForStandard = (
   } else {
     if (!entity) {
       status = SyncStatus.LOADING
-    } else if (areSynced(item, entity, isEmotesFeatureFlagOn)) {
+    } else if (areSynced(item, entity)) {
       status = SyncStatus.SYNCED
     } else {
       status = SyncStatus.UNSYNCED
@@ -159,25 +153,18 @@ export const getStatusByItemId = createSelector<
   EntityState['data'],
   Record<string, CollectionCuration>,
   Record<string, ItemCuration>,
-  boolean,
   Record<string, SyncStatus>
 >(
   state => getItems(state),
   state => getEntityByItemId(state),
   state => getCurationsByCollectionId(state),
   getItemCurationsByItemId,
-  state => getIsEmotesFlowEnabled(state),
-  (items, entitiesByItemId, curationsByCollectionId, itemCurationByItemId, isEmotesFeatureFlagOn) => {
+  (items, entitiesByItemId, curationsByCollectionId, itemCurationByItemId) => {
     const statusByItemId: Record<string, SyncStatus> = {}
     for (const item of items) {
       statusByItemId[item.id] = isThirdParty(item.urn)
         ? getStatusForTP(item, itemCurationByItemId[item.id])
-        : getStatusForStandard(
-            item,
-            item.collectionId ? curationsByCollectionId[item.collectionId] : null,
-            entitiesByItemId[item.id],
-            isEmotesFeatureFlagOn
-          )
+        : getStatusForStandard(item, item.collectionId ? curationsByCollectionId[item.collectionId] : null, entitiesByItemId[item.id])
     }
     return statusByItemId
   }

--- a/src/modules/item/utils.ts
+++ b/src/modules/item/utils.ts
@@ -495,14 +495,14 @@ export function isWearableSynced(item: Item, entity: Entity) {
   return true
 }
 
-export function isEmoteSynced(item: Item | Item<ItemType.EMOTE>, entity: Entity, isEmotesFeatureFlagOn: boolean) {
+export function isEmoteSynced(item: Item | Item<ItemType.EMOTE>, entity: Entity) {
   if (item.type !== ItemType.EMOTE) {
     throw new Error('Item must be EMOTE')
   }
 
   // check if metadata has the new schema from ADR 74
   const isADR74 = 'emoteDataADR74' in entity.metadata
-  if (!isADR74 && isEmotesFeatureFlagOn) {
+  if (!isADR74) {
     return false
   }
 
@@ -544,8 +544,8 @@ export function isEmoteSynced(item: Item | Item<ItemType.EMOTE>, entity: Entity,
   return true
 }
 
-export function areSynced(item: Item, entity: Entity, isEmotesFeatureFlagOn: boolean) {
-  return item.type === ItemType.WEARABLE ? isWearableSynced(item, entity) : isEmoteSynced(item, entity, isEmotesFeatureFlagOn)
+export function areSynced(item: Item, entity: Entity) {
+  return item.type === ItemType.WEARABLE ? isWearableSynced(item, entity) : isEmoteSynced(item, entity)
 }
 
 export function isAllowedToPushChanges(item: Item, status: SyncStatus, itemCuration: ItemCuration | undefined) {

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -1162,7 +1162,6 @@
     "locked": "Locked",
     "publish_reason_max_items": "A collection can be published with a max amount of {maxItems} items.",
     "publish_reason_no_items": "You need to add at least one item to publish your collection.",
-    "cant_publish_new_emotes": "Emotes can not be published yet",
     "publish_reason_items_not_complete": "All items must be complete to publish your collection, check if all the properties are set.",
     "emotes": "Emotes",
     "wearables": "Wearables",

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -1173,7 +1173,6 @@
     "locked": "Bloqueada",
     "publish_reason_max_items": "Las colecciones pueden publicarse con un máximo de  {maxItems} items.",
     "publish_reason_no_items": "Debes agregar al menos un item para publicar tu colección.",
-    "cant_publish_new_emotes": "Emotes no pueden ser publicados todavia",
     "publish_reason_items_not_complete": "Todos los items deben estar completos para publicar tu colección, comprueba que todas sus propiedades estén establecidas.",
     "emotes": "Animaciones",
     "wearables": "Vestimentas",

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -1155,7 +1155,6 @@
     "locked": "锁定",
     "publish_reason_max_items": "可以发布包含最多 {maxItems} 个项目的集合。",
     "publish_reason_no_items": "您需要添加至少一项才能发布您的收藏。",
-    "cant_publish_new_emotes": "表情还不能发布",
     "publish_reason_items_not_complete": "所有项目必须完整才能发布您的收藏，检查是否设置了所有属性。",
     "emotes": "表情",
     "wearables": "可穿戴设备",


### PR DESCRIPTION
This PR:
- Removes support for legacy emotes
- Removes feature flags (both `isEmotesFeatureFlagOn` and `isNewEmotesPublishFlagOn`).
- Removes the special renderer branch used in "See in world"