### PR TITLE
fix: Pre-selected item after emote creation

### DIFF
--- a/src/components/ItemEditorPage/LeftPanel/Items/Items.tsx
+++ b/src/components/ItemEditorPage/LeftPanel/Items/Items.tsx
@@ -42,24 +42,16 @@ export default class Items extends React.PureComponent<Props, State> {
   }
 
   componentDidMount() {
-    const { items, selectedItemId, onSetItems, onSetReviewedItems } = this.props
+    const { items, onSetReviewedItems } = this.props
     onSetReviewedItems(items)
-    const initialActiveItem = items.find(item => item.id === selectedItemId)
-    if (initialActiveItem) {
-      onSetItems([initialActiveItem])
-    }
   }
 
   componentDidUpdate(prevProps: Props) {
-    const { items, selectedCollectionId, initialPage, selectedItemId, onSetItems } = this.props
+    const { items, selectedCollectionId, initialPage } = this.props
     const { currentTab } = this.state
     const prevItemIds = prevProps.items.map(prevItem => prevItem.id)
     if (currentTab === ItemPanelTabs.TO_REVIEW && items.some(item => !prevItemIds.includes(item.id))) {
-      const initialActiveItem = items.find(item => item.id === selectedItemId)
       this.setState({ items })
-      if (initialActiveItem) {
-        onSetItems([initialActiveItem])
-      }
     }
     // initialPage only change when a new created item redirects to the item editor
     else if (currentTab === ItemPanelTabs.TO_REVIEW && initialPage && prevProps.initialPage !== initialPage) {

--- a/src/components/ItemEditorPage/LeftPanel/Items/Items.tsx
+++ b/src/components/ItemEditorPage/LeftPanel/Items/Items.tsx
@@ -42,8 +42,12 @@ export default class Items extends React.PureComponent<Props, State> {
   }
 
   componentDidMount() {
-    const { items, onSetReviewedItems } = this.props
+    const { items, selectedItemId, onSetItems, onSetReviewedItems } = this.props
     onSetReviewedItems(items)
+    const initialActiveItem = items.find(item => item.id === selectedItemId)
+    if (initialActiveItem) {
+      onSetItems([initialActiveItem])
+    }
   }
 
   componentDidUpdate(prevProps: Props) {

--- a/src/components/ItemEditorPage/LeftPanel/LeftPanel.tsx
+++ b/src/components/ItemEditorPage/LeftPanel/LeftPanel.tsx
@@ -6,7 +6,7 @@ import { isThirdParty } from 'lib/urn'
 import { Collection, CollectionType } from 'modules/collection/types'
 import { CurationStatus } from 'modules/curations/types'
 import { getCollectionType } from 'modules/collection/utils'
-import { Item } from 'modules/item/types'
+import { Item, ItemType } from 'modules/item/types'
 import CollectionProvider from 'components/CollectionProvider'
 import Header from './Header'
 import Items from './Items'
@@ -51,7 +51,7 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
-    const { isConnected, address, selectedCollectionId, selectedItemId, orphanItems, totalItems } = this.props
+    const { isConnected, address, selectedCollectionId, selectedItemId, orphanItems, totalItems, visibleItems, onSetItems } = this.props
     const { initialPage, pages } = this.state
     // when a newly created item redirects to the item editor, iterate over the pages until finding it
     if (
@@ -69,6 +69,9 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
           this.setState({ pages: [nextPage], initialPage: nextPage }, this.fetchResource)
         }
       }
+    } else if (prevProps.selectedItemId && selectedItemId && prevProps.selectedItemId !== selectedItemId) {
+      const items = visibleItems.filter((item) => item.type !== ItemType.EMOTE)
+      onSetItems(items)
     } else {
       // fetch only if this was triggered by a connecting event or if th selectedCollection changes
       if (address && isConnected && (isConnected !== prevProps.isConnected || (prevProps.selectedCollectionId && !selectedCollectionId))) {

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -102,6 +102,7 @@ import { fetchEntitiesByPointersRequest } from 'modules/entity/actions'
 import { takeLatestCancellable } from 'modules/common/utils'
 import { waitForTx } from 'modules/transaction/utils'
 import { getMethodData } from 'modules/wallet/utils'
+import { setItems } from 'modules/editor/actions'
 import { getCatalystContentUrl } from 'lib/api/peer'
 import { downloadZip } from 'lib/zip'
 import { calculateFinalSize, reHashOlderContents } from './export'
@@ -366,6 +367,7 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
       if (location.pathname === locations.collections()) {
         if (item.type === ItemType.EMOTE) {
           // Redirect to the item editor
+          yield put(setItems([item]))
           yield put(push(locations.itemEditor({ itemId: item.id })))
         } else {
           // Redirect to the newly created item details
@@ -373,10 +375,12 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
         }
       } else if (location.pathname === locations.collectionDetail(collectionId) && item.type === ItemType.EMOTE) {
         // Redirect to the item editor
+        yield put(setItems([item]))
         yield put(push(locations.itemEditor({ collectionId, itemId: item.id })))
       } else {
         // When creating a Wearable/Emote in the itemEditor, reload the left panel to show the new item created
         if (location.pathname === locations.itemEditor()) {
+          yield put(setItems([item]))
           if (collectionId) {
             const paginationData: ItemPaginationData | undefined = yield select(getPaginationData, collectionId)
             yield put(


### PR DESCRIPTION
This PR fixes the pre-selected emote after its creation, allowing editing it properly.

Closes #2333