### PR TITLE
feat: Add support to filter collections by items tag

### DIFF
--- a/src/components/CurationPage/CurationPage.container.ts
+++ b/src/components/CurationPage/CurationPage.container.ts
@@ -2,7 +2,7 @@ import { connect } from 'react-redux'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 import { getData as getWallet, isConnecting } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import { RootState } from 'modules/common/types'
-import { getIsMvmfEnabled } from 'modules/features/selectors'
+import { getIsMVMFEnabled } from 'modules/features/selectors'
 import { getPaginatedCollections, getLoading as getLoadingCollection, getPaginationData } from 'modules/collection/selectors'
 import { getCurationsByCollectionId, getLoading as getLoadingCuration } from 'modules/curations/collectionCuration/selectors'
 import { getLoading as getLoadingCommittee, getCommitteeMembers, isWalletCommitteeMember } from 'modules/committee/selectors'
@@ -29,7 +29,7 @@ const mapState = (state: RootState): MapStateProps => {
     isLoadingCollectionsData:
       isLoadingType(getLoadingCollection(state), FETCH_COLLECTIONS_REQUEST) ||
       isLoadingType(getLoadingCuration(state), FETCH_COLLECTION_CURATION_REQUEST),
-    isMvmfEnabled: getIsMvmfEnabled(state)
+    isMVMFEnabled: getIsMVMFEnabled(state)
   }
 }
 

--- a/src/components/CurationPage/CurationPage.container.ts
+++ b/src/components/CurationPage/CurationPage.container.ts
@@ -2,6 +2,7 @@ import { connect } from 'react-redux'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 import { getData as getWallet, isConnecting } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import { RootState } from 'modules/common/types'
+import { getIsMvmfEnabled } from 'modules/features/selectors'
 import { getPaginatedCollections, getLoading as getLoadingCollection, getPaginationData } from 'modules/collection/selectors'
 import { getCurationsByCollectionId, getLoading as getLoadingCuration } from 'modules/curations/collectionCuration/selectors'
 import { getLoading as getLoadingCommittee, getCommitteeMembers, isWalletCommitteeMember } from 'modules/committee/selectors'
@@ -27,7 +28,8 @@ const mapState = (state: RootState): MapStateProps => {
     isLoadingCommittee: isLoadingType(getLoadingCommittee(state), FETCH_COMMITTEE_MEMBERS_REQUEST),
     isLoadingCollectionsData:
       isLoadingType(getLoadingCollection(state), FETCH_COLLECTIONS_REQUEST) ||
-      isLoadingType(getLoadingCuration(state), FETCH_COLLECTION_CURATION_REQUEST)
+      isLoadingType(getLoadingCuration(state), FETCH_COLLECTION_CURATION_REQUEST),
+    isMvmfEnabled: getIsMvmfEnabled(state)
   }
 }
 

--- a/src/components/CurationPage/CurationPage.css
+++ b/src/components/CurationPage/CurationPage.css
@@ -25,3 +25,7 @@
 .ui.dropdown.selected {
   color: var(--primary);
 }
+
+.CurationPage .filters .filterByMvmfTag {
+  margin-right: 16px;
+}

--- a/src/components/CurationPage/CurationPage.tsx
+++ b/src/components/CurationPage/CurationPage.tsx
@@ -190,7 +190,7 @@ export default class CurationPage extends React.PureComponent<Props, State> {
   }
 
   renderPage() {
-    const { isLoadingCollectionsData, isLoadingCommittee, collections, curationsByCollectionId, paginationData, isMvmfEnabled } = this.props
+    const { isLoadingCollectionsData, isLoadingCommittee, collections, curationsByCollectionId, paginationData, isMVMFEnabled } = this.props
     const { page, searchText } = this.state
     const totalCurations = paginationData?.total
     const totalPages = paginationData?.totalPages
@@ -215,7 +215,7 @@ export default class CurationPage extends React.PureComponent<Props, State> {
               </Column>
               <Column align="right">
                 <Row>
-                  {isMvmfEnabled ? this.renderMvmfFilterToggle() : null}
+                  {isMVMFEnabled ? this.renderMvmfFilterToggle() : null}
                   {this.renderAssigneeFilterDropdown()}
                   {this.renderStatusFilterDropdown()}
                   {this.renderSortDropdown()}

--- a/src/components/CurationPage/CurationPage.tsx
+++ b/src/components/CurationPage/CurationPage.tsx
@@ -28,7 +28,7 @@ import './CurationPage.css'
 
 const PAGE_SIZE = 12
 const ALL_ASSIGNEES_KEY = 'all'
-const MVMF_TAG = 'mvmf22'
+const MVMF_TAG = 'MVMF22'
 
 export default class CurationPage extends React.PureComponent<Props, State> {
   state: State = {

--- a/src/components/CurationPage/CurationPage.tsx
+++ b/src/components/CurationPage/CurationPage.tsx
@@ -11,7 +11,9 @@ import {
   Table,
   DropdownProps,
   PaginationProps,
-  Loader
+  Loader,
+  Radio,
+  CheckboxProps
 } from 'decentraland-ui'
 import { T, t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { FetchCollectionsParams } from 'lib/api/builder'
@@ -26,11 +28,13 @@ import './CurationPage.css'
 
 const PAGE_SIZE = 12
 const ALL_ASSIGNEES_KEY = 'all'
+const MVMF_TAG = 'mvmf22'
 
 export default class CurationPage extends React.PureComponent<Props, State> {
   state: State = {
     sortBy: CurationSortOptions.MOST_RELEVANT,
-    filterBy: CurationExtraStatuses.ALL_STATUS,
+    filterByStatus: CurationExtraStatuses.ALL_STATUS,
+    filterByTags: [],
     assignee: ALL_ASSIGNEES_KEY,
     searchText: '',
     page: 1
@@ -53,14 +57,15 @@ export default class CurationPage extends React.PureComponent<Props, State> {
   }
 
   getFetchParams = (overrides?: FetchCollectionsParams) => {
-    const { assignee, filterBy, page, searchText, sortBy } = this.state
+    const { assignee, filterByStatus, page, searchText, sortBy, filterByTags } = this.state
     return {
       page,
       limit: PAGE_SIZE,
       assignee: assignee !== ALL_ASSIGNEES_KEY ? assignee : undefined,
-      status: filterBy !== CurationExtraStatuses.ALL_STATUS ? filterBy : undefined,
+      status: filterByStatus !== CurationExtraStatuses.ALL_STATUS ? filterByStatus : undefined,
       q: searchText ? searchText : undefined,
       sort: sortBy,
+      tag: filterByTags.length > 0 ? filterByTags : undefined,
       isPublished: true,
       ...overrides
     }
@@ -80,7 +85,7 @@ export default class CurationPage extends React.PureComponent<Props, State> {
   }
 
   handleStatusChange = (_event: React.SyntheticEvent<HTMLElement, Event>, { value }: DropdownProps) => {
-    this.updateParam({ filterBy: `${value}` as Filters, page: 1 })
+    this.updateParam({ filterByStatus: `${value}` as Filters, page: 1 })
   }
 
   handleAssigneeChange = (_event: React.SyntheticEvent<HTMLElement, Event>, { value }: DropdownProps) => {
@@ -96,6 +101,15 @@ export default class CurationPage extends React.PureComponent<Props, State> {
 
   handlePageChange = (_event: React.MouseEvent<HTMLAnchorElement, MouseEvent>, props: PaginationProps) => {
     this.updateParam({ page: +props.activePage! })
+  }
+
+  handleOnMvmfToggleChange = (_event: React.FormEvent<HTMLInputElement>, checkboxProps: CheckboxProps) => {
+    const { checked } = checkboxProps
+    if (checked) {
+      this.updateParam({ filterByTags: [...this.state.filterByTags, MVMF_TAG] })
+    } else {
+      this.updateParam({ filterByTags: [...this.state.filterByTags.filter(tag => tag !== MVMF_TAG)] })
+    }
   }
 
   renderSortDropdown = () => {
@@ -116,11 +130,11 @@ export default class CurationPage extends React.PureComponent<Props, State> {
   }
 
   renderStatusFilterDropdown = () => {
-    const { filterBy } = this.state
+    const { filterByStatus } = this.state
     return (
       <Dropdown
         direction="left"
-        value={filterBy}
+        value={filterByStatus}
         options={[
           { value: CurationFilterOptions.ALL_STATUS, text: t('curation_page.filter.all_status') },
           { value: CurationFilterOptions.UNDER_REVIEW, text: t('curation_page.filter.under_review') },
@@ -162,8 +176,21 @@ export default class CurationPage extends React.PureComponent<Props, State> {
     )
   }
 
+  renderMvmfFilterToggle = () => {
+    const { filterByTags } = this.state
+    return (
+      <Radio
+        toggle
+        className="filterByMvmfTag"
+        checked={filterByTags.includes(MVMF_TAG)}
+        onChange={this.handleOnMvmfToggleChange}
+        label={t('curation_page.filter.mvmf_collections').toUpperCase()}
+      />
+    )
+  }
+
   renderPage() {
-    const { isLoadingCollectionsData, isLoadingCommittee, collections, curationsByCollectionId, paginationData } = this.props
+    const { isLoadingCollectionsData, isLoadingCommittee, collections, curationsByCollectionId, paginationData, isMvmfEnabled } = this.props
     const { page, searchText } = this.state
     const totalCurations = paginationData?.total
     const totalPages = paginationData?.totalPages
@@ -188,6 +215,7 @@ export default class CurationPage extends React.PureComponent<Props, State> {
               </Column>
               <Column align="right">
                 <Row>
+                  {isMvmfEnabled ? this.renderMvmfFilterToggle() : null}
                   {this.renderAssigneeFilterDropdown()}
                   {this.renderStatusFilterDropdown()}
                   {this.renderSortDropdown()}

--- a/src/components/CurationPage/CurationPage.types.ts
+++ b/src/components/CurationPage/CurationPage.types.ts
@@ -25,7 +25,7 @@ export type Props = {
   isConnecting: boolean
   isLoadingCollectionsData: boolean
   isLoadingCommittee: boolean
-  isMvmfEnabled: boolean
+  isMVMFEnabled: boolean
   onNavigate: (path: string) => void
   onFetchCollections: (params?: FetchCollectionsParams) => ReturnType<Dispatch<FetchCollectionsRequestAction>>
 }
@@ -50,7 +50,7 @@ export type MapStateProps = Pick<
   | 'isConnecting'
   | 'isLoadingCollectionsData'
   | 'isLoadingCommittee'
-  | 'isMvmfEnabled'
+  | 'isMVMFEnabled'
 >
 
 export type MapDispatchProps = Pick<Props, 'onFetchCollections'>

--- a/src/components/CurationPage/CurationPage.types.ts
+++ b/src/components/CurationPage/CurationPage.types.ts
@@ -25,6 +25,7 @@ export type Props = {
   isConnecting: boolean
   isLoadingCollectionsData: boolean
   isLoadingCommittee: boolean
+  isMvmfEnabled: boolean
   onNavigate: (path: string) => void
   onFetchCollections: (params?: FetchCollectionsParams) => ReturnType<Dispatch<FetchCollectionsRequestAction>>
 }
@@ -32,7 +33,8 @@ export type Props = {
 export type State = {
   page: number
   sortBy: CurationSortOptions
-  filterBy: Filters
+  filterByStatus: Filters
+  filterByTags: string[]
   assignee: string
   searchText: string
 }
@@ -48,6 +50,7 @@ export type MapStateProps = Pick<
   | 'isConnecting'
   | 'isLoadingCollectionsData'
   | 'isLoadingCommittee'
+  | 'isMvmfEnabled'
 >
 
 export type MapDispatchProps = Pick<Props, 'onFetchCollections'>

--- a/src/components/ItemEditorPage/RightPanel/RightPanel.container.ts
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.container.ts
@@ -8,7 +8,7 @@ import { isOwner } from 'modules/item/utils'
 import { getSelectedItemId } from 'modules/location/selectors'
 import { getCollection, hasViewAndEditRights } from 'modules/collection/selectors'
 import { isWalletCommitteeMember } from 'modules/committee/selectors'
-import { getIsEmotePlayModeEnabled } from 'modules/features/selectors'
+import { getIsEmotePlayModeEnabled, getIsMvmfEnabled } from 'modules/features/selectors'
 import { MapStateProps, MapDispatchProps, MapDispatch } from './RightPanel.types'
 import RightPanel from './RightPanel'
 
@@ -31,7 +31,8 @@ const mapState = (state: RootState): MapStateProps => {
     isConnected: isConnected(state),
     isDownloading: isDownloading(state),
     isCommitteeMember: isWalletCommitteeMember(state),
-    isEmotePlayModeFeatureFlagOn: getIsEmotePlayModeEnabled(state)
+    isEmotePlayModeFeatureFlagOn: getIsEmotePlayModeEnabled(state),
+    isMvmfEnabled: getIsMvmfEnabled(state)
   }
 }
 

--- a/src/components/ItemEditorPage/RightPanel/RightPanel.container.ts
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.container.ts
@@ -8,7 +8,7 @@ import { isOwner } from 'modules/item/utils'
 import { getSelectedItemId } from 'modules/location/selectors'
 import { getCollection, hasViewAndEditRights } from 'modules/collection/selectors'
 import { isWalletCommitteeMember } from 'modules/committee/selectors'
-import { getIsEmotePlayModeEnabled, getIsMvmfEnabled } from 'modules/features/selectors'
+import { getIsEmotePlayModeEnabled, getIsMVMFEnabled } from 'modules/features/selectors'
 import { MapStateProps, MapDispatchProps, MapDispatch } from './RightPanel.types'
 import RightPanel from './RightPanel'
 
@@ -32,7 +32,7 @@ const mapState = (state: RootState): MapStateProps => {
     isDownloading: isDownloading(state),
     isCommitteeMember: isWalletCommitteeMember(state),
     isEmotePlayModeFeatureFlagOn: getIsEmotePlayModeEnabled(state),
-    isMvmfEnabled: getIsMvmfEnabled(state)
+    isMVMFEnabled: getIsMVMFEnabled(state)
   }
 }
 

--- a/src/components/ItemEditorPage/RightPanel/RightPanel.css
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.css
@@ -157,3 +157,18 @@
   top: auto;
   left: auto;
 }
+
+.RightPanel .event-tag {
+  color: var(--secondary-text);
+}
+
+.RightPanel .event-tag span {
+  color: var(--text-on-primary);
+  font-weight: 600;
+}
+
+.RightPanel .event-tag a {
+  color: var(--text-on-primary);
+  font-weight: 600;
+  text-decoration: underline;
+}

--- a/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
@@ -350,7 +350,7 @@ export default class RightPanel extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { selectedItemId, address, isConnected, isDownloading, error, isMvmfEnabled } = this.props
+    const { selectedItemId, address, isConnected, isDownloading, error, isMVMFEnabled } = this.props
     const { name, description, thumbnail, rarity, data, isDirty, hasItem } = this.state
     const rarities = getRarities()
     const playModes = getEmotePlayModes()
@@ -545,7 +545,7 @@ export default class RightPanel extends React.PureComponent<Props, State> {
                     {item ? (
                       <>
                         <Tags itemId={item.id} value={data!.tags} onChange={this.handleChangeTags} isDisabled={!canEditItemMetadata} />
-                        {isMvmfEnabled ? (
+                        {isMVMFEnabled && canEditItemMetadata ? (
                           <p className="event-tag">
                             {t('item_editor.right_panel.event_tag', {
                               event_tag: <span>MVMF22</span>,

--- a/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
@@ -547,7 +547,7 @@ export default class RightPanel extends React.PureComponent<Props, State> {
                     {item ? (
                       <>
                         <Tags itemId={item.id} value={data!.tags} onChange={this.handleChangeTags} isDisabled={!canEditItemMetadata} />
-                        {isMVMFEnabled && canEditItemMetadata ? (
+                        {isMVMFEnabled && canEditItemMetadata && (
                           <p className="event-tag">
                             {t('item_editor.right_panel.event_tag', {
                               event_tag: <span>{MVMF_TAG}</span>,
@@ -555,7 +555,7 @@ export default class RightPanel extends React.PureComponent<Props, State> {
                               learn_more: <a href="#">{t('global.learn_more')}</a>
                             })}
                           </p>
-                        ) : null}
+                        )}
                       </>
                     ) : null}
                   </Collapsable>

--- a/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
@@ -43,6 +43,8 @@ import Tags from './Tags'
 import { Props, State } from './RightPanel.types'
 import './RightPanel.css'
 
+const MVMF_TAG = 'MVMF22'
+
 export default class RightPanel extends React.PureComponent<Props, State> {
   analytics = getAnalytics()
   state: State = this.getInitialState()
@@ -548,8 +550,8 @@ export default class RightPanel extends React.PureComponent<Props, State> {
                         {isMVMFEnabled && canEditItemMetadata ? (
                           <p className="event-tag">
                             {t('item_editor.right_panel.event_tag', {
-                              event_tag: <span>MVMF22</span>,
-                              event_name: <span>Metaverse Festival</span>,
+                              event_tag: <span>{MVMF_TAG}</span>,
+                              event_name: <span>{t('item_editor.right_panel.mvmf')}</span>,
                               learn_more: <a href="#">{t('global.learn_more')}</a>
                             })}
                           </p>

--- a/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
@@ -350,7 +350,7 @@ export default class RightPanel extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { selectedItemId, address, isConnected, isDownloading, error } = this.props
+    const { selectedItemId, address, isConnected, isDownloading, error, isMvmfEnabled } = this.props
     const { name, description, thumbnail, rarity, data, isDirty, hasItem } = this.state
     const rarities = getRarities()
     const playModes = getEmotePlayModes()
@@ -543,7 +543,18 @@ export default class RightPanel extends React.PureComponent<Props, State> {
                   )}
                   <Collapsable label={t('item_editor.right_panel.tags')}>
                     {item ? (
-                      <Tags itemId={item.id} value={data!.tags} onChange={this.handleChangeTags} isDisabled={!canEditItemMetadata} />
+                      <>
+                        <Tags itemId={item.id} value={data!.tags} onChange={this.handleChangeTags} isDisabled={!canEditItemMetadata} />
+                        {isMvmfEnabled ? (
+                          <p className="event-tag">
+                            {t('item_editor.right_panel.event_tag', {
+                              event_tag: <span>MVMF22</span>,
+                              event_name: <span>Metaverse Festival</span>,
+                              learn_more: <a href="#">{t('global.learn_more')}</a>
+                            })}
+                          </p>
+                        ) : null}
+                      </>
                     ) : null}
                   </Collapsable>
                   {isDirty ? (

--- a/src/components/ItemEditorPage/RightPanel/RightPanel.types.ts
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.types.ts
@@ -25,6 +25,7 @@ export type Props = {
   isDownloading: boolean
   isCommitteeMember: boolean
   isEmotePlayModeFeatureFlagOn: boolean
+  isMvmfEnabled: boolean
   onSaveItem: typeof saveItemRequest
   onDeleteItem: typeof deleteItemRequest
   onOpenModal: typeof openModal
@@ -55,6 +56,7 @@ export type MapStateProps = Pick<
   | 'isCommitteeMember'
   | 'isEmotePlayModeFeatureFlagOn'
   | 'canEditSelectedItem'
+  | 'isMvmfEnabled'
 >
 export type MapDispatchProps = Pick<Props, 'onSaveItem' | 'onDeleteItem' | 'onOpenModal' | 'onSetCollection' | 'onDownload'>
 export type MapDispatch = Dispatch<

--- a/src/components/ItemEditorPage/RightPanel/RightPanel.types.ts
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.types.ts
@@ -25,7 +25,7 @@ export type Props = {
   isDownloading: boolean
   isCommitteeMember: boolean
   isEmotePlayModeFeatureFlagOn: boolean
-  isMvmfEnabled: boolean
+  isMVMFEnabled: boolean
   onSaveItem: typeof saveItemRequest
   onDeleteItem: typeof deleteItemRequest
   onOpenModal: typeof openModal
@@ -56,7 +56,7 @@ export type MapStateProps = Pick<
   | 'isCommitteeMember'
   | 'isEmotePlayModeFeatureFlagOn'
   | 'canEditSelectedItem'
-  | 'isMvmfEnabled'
+  | 'isMVMFEnabled'
 >
 export type MapDispatchProps = Pick<Props, 'onSaveItem' | 'onDeleteItem' | 'onOpenModal' | 'onSetCollection' | 'onDownload'>
 export type MapDispatch = Dispatch<

--- a/src/lib/api/builder.ts
+++ b/src/lib/api/builder.ts
@@ -38,6 +38,7 @@ export type FetchCollectionsParams = {
   sort?: CurationSortOptions
   q?: string
   isPublished?: boolean
+  tag?: string[]
   page?: number
   limit?: number
 }
@@ -440,11 +441,47 @@ function fromRemoteItemCuration(remoteCuration: RemoteItemCuration): ItemCuratio
 }
 
 const toRemoteCollectionQueryParameters = (params?: FetchCollectionsParams) => {
-  const { isPublished, ...rest } = params || {}
-  return {
-    is_published: isPublished,
-    ...rest
+  const queryParams = new URLSearchParams()
+
+  if (params?.isPublished) {
+    queryParams.append('is_published', `${params.isPublished}`)
   }
+
+  if (params?.assignee) {
+    queryParams.append('assignee', params.assignee)
+  }
+
+  if (params?.status) {
+    queryParams.append('status', params.status)
+  }
+
+  if (params?.synced) {
+    queryParams.append('synced', `${params.synced}`)
+  }
+
+  if (params?.sort) {
+    queryParams.append('sort', params.sort)
+  }
+
+  if (params?.q) {
+    queryParams.append('q', params.q)
+  }
+
+  if (params?.page) {
+    queryParams.append('page', `${params.page}`)
+  }
+
+  if (params?.limit) {
+    queryParams.append('limit', `${params.limit}`)
+  }
+
+  if (params?.tag && params.tag.length > 0) {
+    for (const tag of params.tag) {
+      queryParams.append('tag', tag)
+    }
+  }
+
+  return queryParams
 }
 
 export type PoolDeploymentAdditionalFields = {

--- a/src/modules/collection/sagas.spec.ts
+++ b/src/modules/collection/sagas.spec.ts
@@ -1823,4 +1823,24 @@ describe('when handling the fetch of collections', () => {
         .run({ silenceTimeout: true })
     })
   })
+
+  describe('and tag filter is sent', () => {
+    let mockedFetchParameters: FetchCollectionsParams
+    beforeEach(() => {
+      collection = getCollectionMock()
+      mockedFetchParameters = {
+        tag: ['TAG']
+      }
+    })
+    it('should put the success action with the collections filtered by item tag', () => {
+      return expectSaga(collectionSaga, mockBuilder, mockBuilderClient, mockCatalyst)
+        .provide([
+          [select(getWalletItems), []],
+          [call([mockBuilder, 'fetchCollections'], undefined, mockedFetchParameters), [collection]]
+        ])
+        .put(fetchCollectionsSuccess([collection], undefined))
+        .dispatch(fetchCollectionsRequest(undefined, mockedFetchParameters))
+        .run({ silenceTimeout: true })
+    })
+  })
 })

--- a/src/modules/features/selectors.ts
+++ b/src/modules/features/selectors.ts
@@ -29,3 +29,11 @@ export const getIsEmotePlayModeEnabled = (state: RootState) => {
     return false
   }
 }
+
+export const getIsMvmfEnabled = (state: RootState) => {
+  try {
+    return getIsFeatureEnabled(state, ApplicationName.BUILDER, FeatureName.MVMF)
+  } catch (e) {
+    return false
+  }
+}

--- a/src/modules/features/selectors.ts
+++ b/src/modules/features/selectors.ts
@@ -30,7 +30,7 @@ export const getIsEmotePlayModeEnabled = (state: RootState) => {
   }
 }
 
-export const getIsMvmfEnabled = (state: RootState) => {
+export const getIsMVMFEnabled = (state: RootState) => {
   try {
     return getIsFeatureEnabled(state, ApplicationName.BUILDER, FeatureName.MVMF)
   } catch (e) {

--- a/src/modules/features/types.ts
+++ b/src/modules/features/types.ts
@@ -3,5 +3,6 @@ export enum FeatureName {
   NEW_EMOTE_FLOW = 'new-emote-flow',
   PUBLISH_NEW_EMOTES = 'publish-new-emotes',
   RENTALS = 'rentals',
-  EMOTE_PLAY_MODE = 'emote-play-mode'
+  EMOTE_PLAY_MODE = 'emote-play-mode',
+  MVMF = 'mvmf-2022'
 }

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -1420,6 +1420,7 @@
       "animation": "Animation",
       "tags": "Tags",
       "event_tag": "Use the {event_tag} tag if you want to include this item in the {event_name}. {learn_more}",
+      "mvmf": "Metaverse Festival",
       "select_placeholder": "Select an option",
       "request_for_changes": "Request for changes",
       "request_for_changes_explanation": "If you want to make changes to {name} please ask a committee member for authorization in the forum"

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -1030,7 +1030,8 @@
       "approved": "Approved",
       "rejected": "Rejected",
       "under_review": "Under Review",
-      "to_review": "To Review"
+      "to_review": "To Review",
+      "mvmf_collections": "Metaverse Festival Collections"
     },
     "search_placeholder": "Search between {count} {count, plural, one {result} other {results}} by name or owner address...",
     "collections": "{count} {count, plural, one {collection} other {collections}}",
@@ -1418,6 +1419,7 @@
       "hides_info": "When a user equips your item, any other items in the category you select will stay equipped, but they won't be rendered. Users will only see their other items reappear after removing your item.",
       "animation": "Animation",
       "tags": "Tags",
+      "event_tag": "Use the {event_tag} tag if you want to include this item in the {event_name}. {learn_more}",
       "select_placeholder": "Select an option",
       "request_for_changes": "Request for changes",
       "request_for_changes_explanation": "If you want to make changes to {name} please ask a committee member for authorization in the forum"

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -1435,6 +1435,7 @@
       "animation": "Animación",
       "tags": "Etiquetas",
       "event_tag": "Usa la etiqueta {event_tag} si quieres incluir este item en el {event_name}. {learn_more}",
+      "mvmf": "Metaverse Festival",
       "select_placeholder": "Selecciona una opción",
       "request_for_changes": "Solicitud de cambios",
       "request_for_changes_explanation": "Si desea realizar cambios en {name}, solicite autorización a un miembro del comité en el foro"

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -1043,7 +1043,8 @@
       "approved": "Aprobado",
       "rejected": "Rechazado",
       "under_review": "Bajo revisión",
-      "to_review": "A revisar"
+      "to_review": "A revisar",
+      "mvmf_collections": "Colecciones del Metaverse Festival"
     },
     "search_placeholder": "Busca entre {count} {count, plural, one {resultado} other {resultados} por nombre o por la dirección del dueño...",
     "collections": "{count} {count, plural, one {colecccion} other {coleccciones}}",
@@ -1433,6 +1434,7 @@
       "hides_info": "Cuando un usuario equipa tu item, cualquier otro item de la categoría que selecciones permanecerá equipado, pero no se renderizará. Los usuarios solo verán reaparecer sus otros elementos después de eliminar su elemento.",
       "animation": "Animación",
       "tags": "Etiquetas",
+      "event_tag": "Usa la etiqueta {event_tag} si quieres incluir este item en el {event_name}. {learn_more}",
       "select_placeholder": "Selecciona una opción",
       "request_for_changes": "Solicitud de cambios",
       "request_for_changes_explanation": "Si desea realizar cambios en {name}, solicite autorización a un miembro del comité en el foro"

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -1024,7 +1024,8 @@
       "approved": "已批准",
       "rejected": "拒绝了",
       "under_review": "审查中",
-      "to_review": "回顾"
+      "to_review": "回顾",
+      "mvmf_collections": "元界节日合集"
     },
     "search_placeholder": "按名称或所有者地址在 {count} 个结果之间搜索...",
     "collections": "{count} {count, plural, one {个合集} other {个收藏}}",
@@ -1418,6 +1419,7 @@
       "hides_info": "当用户装备您的物品时，您选择的类别中的所有其他物品将保持装备状态，但不会被渲染。 用户仅会在删除您的商品后看到他们的其他商品。 ",
       "animation": "动画",
       "tags": "标签",
+      "event_tag": "如果您想将此项目包含在 {event_tag} 中，请使用 {event_name} 标签。{learn_more}",
       "select_placeholder": "选择一个选项",
       "request_for_changes": "要求变更",
       "request_for_changes_explanation": "如果您想更改{name}，请在论坛中请求委员会成员的授权"

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -1420,6 +1420,7 @@
       "animation": "动画",
       "tags": "标签",
       "event_tag": "如果您想将此项目包含在 {event_tag} 中，请使用 {event_name} 标签。{learn_more}",
+      "mvmf": "元节",
       "select_placeholder": "选择一个选项",
       "request_for_changes": "要求变更",
       "request_for_changes_explanation": "如果您想更改{name}，请在论坛中请求委员会成员的授权"


### PR DESCRIPTION
This PR adds support to filter collections by item tag in the curations page and a message for upcoming events below the tags container in the Item Editor Right Panel.

- Curation page toggle filter:
![image](https://user-images.githubusercontent.com/3170051/194414145-92aade64-09b7-4073-8bc0-036b495e3418.png)
![image](https://user-images.githubusercontent.com/3170051/194414170-54e4d344-4b80-474e-880c-9651b354292b.png)


- Item Editor - Right Panel message:
![image](https://user-images.githubusercontent.com/3170051/194413988-04ffd189-127b-4481-a2a4-2f65a453b281.png)


Closes #2343
Closes #2342