### PR TITLE
fix: Update event banner component

### DIFF
--- a/src/components/EventBanner/EventBanner.css
+++ b/src/components/EventBanner/EventBanner.css
@@ -1,9 +1,9 @@
 .EventBanner {
-  width: 100% !important;
-  height: 100px !important;
-  margin: 24px 0 !important;
+  width: 100%;
+  height: 100px;
+  margin: 24px 0;
   padding: 0 32px;
-  display: flex !important;
+  display: flex;
   background-image: url('../../images/mvmf-1064x100.gif');
   border-radius: 10px;
 }

--- a/src/components/EventBanner/EventBanner.tsx
+++ b/src/components/EventBanner/EventBanner.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import { Advertisement, Button } from 'decentraland-ui'
+import { Button } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Props } from './EventBanner.types'
 import './EventBanner.css'
 
 const EventBanner = ({ isMVMFEnabled }: Props) => {
   return isMVMFEnabled ? (
-    <Advertisement className="EventBanner" unit="large leaderboard">
+    <div className="EventBanner">
       <div className="event-banner-text">
         <span className="title">{t('event_banner.small.title')}</span>
         <span className="subtitle">
@@ -30,7 +30,7 @@ const EventBanner = ({ isMVMFEnabled }: Props) => {
           {t('event_banner.small.cta')}
         </Button>
       </div>
-    </Advertisement>
+    </div>
   ) : null
 }
 


### PR DESCRIPTION
This PR updates the component banner from the advertiser component to a plane div to avoid being blocked by ad blockers. 

Banner:
![image](https://user-images.githubusercontent.com/3170051/195615162-2f5570dd-4cff-4442-81a8-62e01ae80b84.png)
