### PR TITLE
feat: Show the screenshot thumbnail boundaries on the EditThumbnailStep modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "decentraland-ecs": "file:ecs/decentraland-ecs-6.6.1-20201020183014.commit-bdc29ef-hotfix.tgz",
         "decentraland-experiments": "^1.0.2",
         "decentraland-transactions": "^1.37.0",
-        "decentraland-ui": "^3.53.0",
+        "decentraland-ui": "^3.54.0",
         "ethers": "^5.6.8",
         "file-saver": "^2.0.1",
         "graphql": "^15.8.0",
@@ -10378,9 +10378,9 @@
       "integrity": "sha512-rPhlk5Xt4BcEpZ8v9jh9TqgbHU4DcmrmdLf1nG3WK8OhVHglPKVGd09Ov9aoCE/v0FKBNTtIfoxzR/D2KWA6iA=="
     },
     "node_modules/decentraland-ui": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.53.0.tgz",
-      "integrity": "sha512-Wmq5jGmqyqfgdOIwGxFkTyNsDoGKIbTa7Au2yfY0C60fExvvdo8PGjz+R5S6Iy9V6rPamRlh+uGtetiSPKNceA==",
+      "version": "3.54.0",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.54.0.tgz",
+      "integrity": "sha512-GX0HuZ+MA/HaqrKvrUNq6i6zY9VBj4wpqhHG+e2gOgiz5xUCKORHuEJdFhyc1kA3w7QYK5hKutpNbINMlaQ/Xw==",
       "dependencies": {
         "@dcl/schemas": "^5.17.1",
         "balloon-css": "^0.5.0",
@@ -38051,9 +38051,9 @@
       "integrity": "sha512-rPhlk5Xt4BcEpZ8v9jh9TqgbHU4DcmrmdLf1nG3WK8OhVHglPKVGd09Ov9aoCE/v0FKBNTtIfoxzR/D2KWA6iA=="
     },
     "decentraland-ui": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.53.0.tgz",
-      "integrity": "sha512-Wmq5jGmqyqfgdOIwGxFkTyNsDoGKIbTa7Au2yfY0C60fExvvdo8PGjz+R5S6Iy9V6rPamRlh+uGtetiSPKNceA==",
+      "version": "3.54.0",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.54.0.tgz",
+      "integrity": "sha512-GX0HuZ+MA/HaqrKvrUNq6i6zY9VBj4wpqhHG+e2gOgiz5xUCKORHuEJdFhyc1kA3w7QYK5hKutpNbINMlaQ/Xw==",
       "requires": {
         "@dcl/schemas": "^5.17.1",
         "balloon-css": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "decentraland-ecs": "file:ecs/decentraland-ecs-6.6.1-20201020183014.commit-bdc29ef-hotfix.tgz",
     "decentraland-experiments": "^1.0.2",
     "decentraland-transactions": "^1.37.0",
-    "decentraland-ui": "^3.53.0",
+    "decentraland-ui": "^3.54.0",
     "ethers": "^5.6.8",
     "file-saver": "^2.0.1",
     "graphql": "^15.8.0",

--- a/src/components/Modals/CreateSingleItemModal/EditThumbnailStep/EditThumbnailStep.tsx
+++ b/src/components/Modals/CreateSingleItemModal/EditThumbnailStep/EditThumbnailStep.tsx
@@ -90,6 +90,7 @@ export default class EditThumbnailStep extends React.PureComponent<Props, State>
               disableDefaultWearables
               disableDefaultEmotes
               disableAutoRotate
+              showThumbnailBoundaries
               skin="000000"
               zoom={100}
               wheelZoom={2}


### PR DESCRIPTION
This PR shows a thin box around the emote model to show thumbnail boundaries when taking a screenshot

![Screen Shot 2022-10-17 at 18 34 43](https://user-images.githubusercontent.com/3170051/196294954-05fb0479-bc23-46d1-a1a8-2cd7777401a2.png)

Closes #2335

depends on: https://github.com/decentraland/ui/pull/208