### PR TITLE
chore: Bump decentraland-ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "decentraland-ecs": "file:ecs/decentraland-ecs-6.6.1-20201020183014.commit-bdc29ef-hotfix.tgz",
         "decentraland-experiments": "^1.0.2",
         "decentraland-transactions": "^1.37.0",
-        "decentraland-ui": "^3.54.0",
+        "decentraland-ui": "^3.54.1",
         "ethers": "^5.6.8",
         "file-saver": "^2.0.1",
         "graphql": "^15.8.0",
@@ -2348,9 +2348,9 @@
       "integrity": "sha512-Z0zpNr2HAxn2cLWUadWGlzaG48Z+N3hg2bI20UH+OT8NJtvCJnAwVBshAG83iAn4BTC+CsUsk4A394jrlv2ZIQ=="
     },
     "node_modules/@dcl/schemas": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.17.1.tgz",
-      "integrity": "sha512-4UgDwSOQOfu+n2iHz/0qOwRqBH+/6aC7O/2LYCr0/sbT54RDiAc0sks3iJyFI9qR7+mFaxT1GCCCQaeRJWMvMg==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.27.0.tgz",
+      "integrity": "sha512-8nnbaSTyIY0sIBsrAwjQJV44K1yX6TUO3SkhDId3hkLpF3Wr67w0lnfrCi0tW685/ZTRAdgOE3huCqXAgllmTg==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -10378,11 +10378,11 @@
       "integrity": "sha512-rPhlk5Xt4BcEpZ8v9jh9TqgbHU4DcmrmdLf1nG3WK8OhVHglPKVGd09Ov9aoCE/v0FKBNTtIfoxzR/D2KWA6iA=="
     },
     "node_modules/decentraland-ui": {
-      "version": "3.54.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.54.0.tgz",
-      "integrity": "sha512-GX0HuZ+MA/HaqrKvrUNq6i6zY9VBj4wpqhHG+e2gOgiz5xUCKORHuEJdFhyc1kA3w7QYK5hKutpNbINMlaQ/Xw==",
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.54.1.tgz",
+      "integrity": "sha512-eiYo4HJ9rsuuVV4AQS6280qUWsFxUG99ze4K7UbEAp4gqBq2gmv1vxAGw0lPwZ2yILiDC6gYYteeimzvGQ7ltQ==",
       "dependencies": {
-        "@dcl/schemas": "^5.17.1",
+        "@dcl/schemas": "^5.27.0",
         "balloon-css": "^0.5.0",
         "deep-equal": "^2.0.5",
         "ethereum-blockies": "^0.1.1",
@@ -31752,9 +31752,9 @@
       "integrity": "sha512-Z0zpNr2HAxn2cLWUadWGlzaG48Z+N3hg2bI20UH+OT8NJtvCJnAwVBshAG83iAn4BTC+CsUsk4A394jrlv2ZIQ=="
     },
     "@dcl/schemas": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.17.1.tgz",
-      "integrity": "sha512-4UgDwSOQOfu+n2iHz/0qOwRqBH+/6aC7O/2LYCr0/sbT54RDiAc0sks3iJyFI9qR7+mFaxT1GCCCQaeRJWMvMg==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.27.0.tgz",
+      "integrity": "sha512-8nnbaSTyIY0sIBsrAwjQJV44K1yX6TUO3SkhDId3hkLpF3Wr67w0lnfrCi0tW685/ZTRAdgOE3huCqXAgllmTg==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -38051,11 +38051,11 @@
       "integrity": "sha512-rPhlk5Xt4BcEpZ8v9jh9TqgbHU4DcmrmdLf1nG3WK8OhVHglPKVGd09Ov9aoCE/v0FKBNTtIfoxzR/D2KWA6iA=="
     },
     "decentraland-ui": {
-      "version": "3.54.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.54.0.tgz",
-      "integrity": "sha512-GX0HuZ+MA/HaqrKvrUNq6i6zY9VBj4wpqhHG+e2gOgiz5xUCKORHuEJdFhyc1kA3w7QYK5hKutpNbINMlaQ/Xw==",
+      "version": "3.54.1",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.54.1.tgz",
+      "integrity": "sha512-eiYo4HJ9rsuuVV4AQS6280qUWsFxUG99ze4K7UbEAp4gqBq2gmv1vxAGw0lPwZ2yILiDC6gYYteeimzvGQ7ltQ==",
       "requires": {
-        "@dcl/schemas": "^5.17.1",
+        "@dcl/schemas": "^5.27.0",
         "balloon-css": "^0.5.0",
         "deep-equal": "^2.0.5",
         "ethereum-blockies": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "decentraland-ecs": "file:ecs/decentraland-ecs-6.6.1-20201020183014.commit-bdc29ef-hotfix.tgz",
     "decentraland-experiments": "^1.0.2",
     "decentraland-transactions": "^1.37.0",
-    "decentraland-ui": "^3.54.0",
+    "decentraland-ui": "^3.54.1",
     "ethers": "^5.6.8",
     "file-saver": "^2.0.1",
     "graphql": "^15.8.0",


### PR DESCRIPTION
This PR upgrades the `decentraland-ui` version to `3.54.1`, which fixes the animation progress indicator that sometimes doesn't reach the end of the timeline.

Closes #2247