### PR TITLE
fix: ENS items don't show

### DIFF
--- a/src/modules/ens/sagas.ts
+++ b/src/modules/ens/sagas.ts
@@ -269,13 +269,15 @@ export function* ensSaga(builderClient: BuilderClient) {
             const resolver = resolverAddress.toString()
 
             if (resolver !== ethers.constants.AddressZero) {
-              const resolverContract = ENSResolver__factory.connect(resolverAddress, signer)
-              content = await resolverContract.contenthash(nodehash)
+              try {
+                const resolverContract = ENSResolver__factory.connect(resolverAddress, signer)
+                content = await resolverContract.contenthash(nodehash)
 
-              const land = landHashes.find(lh => lh.hash === content)
-              if (land) {
-                landId = land.id
-              }
+                const land = landHashes.find(lh => lh.hash === content)
+                if (land) {
+                  landId = land.id
+                }
+              } catch (error) {}
             }
 
             const ens: ENS = {

--- a/src/modules/ens/sagas.ts
+++ b/src/modules/ens/sagas.ts
@@ -277,7 +277,9 @@ export function* ensSaga(builderClient: BuilderClient) {
                 if (land) {
                   landId = land.id
                 }
-              } catch (error) {}
+              } catch (error) {
+                console.error('Failed to load ens resolver', error)
+              }
             }
 
             const ens: ENS = {


### PR DESCRIPTION
This PR catches the errors when an ens resolver address is different from the DCL Resolver to load the names correctly.

Closes #2401