### PR TITLE
fix: Close emotesChannel to avoid unexpected behavior in the browser

### DIFF
--- a/src/modules/editor/sagas.ts
+++ b/src/modules/editor/sagas.ts
@@ -501,23 +501,27 @@ function* handleSetWearablePreviewController() {
   if (controller) {
     const emotesChannel = createWearablePreviewChannel(controller)
 
-    while (true) {
-      try {
-        const event: string = yield take(emotesChannel)
-        switch (event) {
-          case PreviewEmoteEventType.ANIMATION_PLAY:
-            yield put(setEmotePlaying(true))
-            break
-          case PreviewEmoteEventType.ANIMATION_PAUSE:
-            yield put(setEmotePlaying(false))
-            break
-          case PreviewEmoteEventType.ANIMATION_END:
-            yield put(setEmotePlaying(false))
-            break
+    try {
+      while (true) {
+        try {
+          const event: string = yield take(emotesChannel)
+          switch (event) {
+            case PreviewEmoteEventType.ANIMATION_PLAY:
+              yield put(setEmotePlaying(true))
+              break
+            case PreviewEmoteEventType.ANIMATION_PAUSE:
+              yield put(setEmotePlaying(false))
+              break
+            case PreviewEmoteEventType.ANIMATION_END:
+              yield put(setEmotePlaying(false))
+              break
+          }
+        } catch (error) {
+          yield put(setEmotePlaying(false))
         }
-      } catch (error) {
-        yield put(setEmotePlaying(false))
       }
+    } finally {
+      emotesChannel.close()
     }
   }
 }


### PR DESCRIPTION
This PR closes the emotesChannel to avoid unexpected behavior in the browser because the channels were not closing when unmounting the Editor Center component.

Closes #2302