### PR TITLE
fix: Show update operator only if the rental has not finished

### DIFF
--- a/src/components/LandDetailPage/LandDetailPage.tsx
+++ b/src/components/LandDetailPage/LandDetailPage.tsx
@@ -185,7 +185,7 @@ export default class LandDetailPage extends React.PureComponent<Props, State> {
                       </Dropdown>
                     </Row>
                   </Column>
-                ) : land.roles.includes(RoleType.TENANT) ? (
+                ) : land.roles.includes(RoleType.TENANT) && rental && rental.endsAt.getTime() > Date.now() ? (
                   <Dropdown
                     trigger={
                       <Button basic>

--- a/src/components/LandDetailPage/LandDetailPage.tsx
+++ b/src/components/LandDetailPage/LandDetailPage.tsx
@@ -3,7 +3,7 @@ import { Row, Badge, Section, Narrow, Column, Button, Dropdown, Icon, Header, Em
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { LandType, Land, RoleType, Rental } from 'modules/land/types'
 import { Deployment } from 'modules/deployment/types'
-import { coordsToId, hoverStrokeByRole, hoverFillByRole } from 'modules/land/utils'
+import { coordsToId, hoverStrokeByRole, hoverFillByRole, hasRentalPeriodEnded } from 'modules/land/utils'
 import { Atlas } from 'components/Atlas'
 import { locations } from 'routing/locations'
 import LandProviderPage from 'components/LandProviderPage'
@@ -185,7 +185,7 @@ export default class LandDetailPage extends React.PureComponent<Props, State> {
                       </Dropdown>
                     </Row>
                   </Column>
-                ) : land.roles.includes(RoleType.TENANT) && rental && rental.endsAt.getTime() > Date.now() ? (
+                ) : land.roles.includes(RoleType.TENANT) && rental && hasRentalPeriodEnded(rental) ? (
                   <Dropdown
                     trigger={
                       <Button basic>

--- a/src/components/RentalPeriod/RentalPeriod.tsx
+++ b/src/components/RentalPeriod/RentalPeriod.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { formatDistance } from 'date-fns'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import Info from 'components/Info'
+import { hasRentalPeriodEnded } from 'modules/land/utils'
 import { Props } from './RentalPeriod.types'
 import styles from './RentalPeriod.module.css'
 
@@ -11,7 +12,7 @@ export default class RentalPeriod extends React.PureComponent<Props> {
 
     let period: JSX.Element
 
-    if (rental.endsAt.getTime() < Date.now()) {
+    if (hasRentalPeriodEnded(rental)) {
       period = (
         <>
           <span>{t('rental_period.period_over')}</span>&nbsp;

--- a/src/modules/land/utils.spec.ts
+++ b/src/modules/land/utils.spec.ts
@@ -1,0 +1,51 @@
+import { LandType, Rental } from './types'
+import { hasRentalPeriodEnded } from './utils'
+
+describe('when checking if the rental period has ended', () => {
+  let rental: Rental
+
+  beforeEach(() => {
+    rental = {
+      id: 'aRentalId',
+      type: LandType.PARCEL,
+      tokenId: 'aTokenId',
+      lessor: 'anAddress',
+      tenant: 'aTentant',
+      operator: 'anotherAddress',
+      startedAt: new Date(),
+      endsAt: new Date()
+    }
+  })
+
+  describe('and the end date of the rental has passed the current date', () => {
+    beforeEach(() => {
+      rental.endsAt = new Date(Date.now() - 100000000000)
+    })
+
+    it('should return true', () => {
+      expect(hasRentalPeriodEnded(rental)).toBe(true)
+    })
+  })
+
+  describe('and the end date of the rental is the same as current date', () => {
+    beforeEach(() => {
+      const currentDate = Date.now()
+      jest.spyOn(Date, 'now').mockReturnValueOnce(currentDate)
+      rental.endsAt = new Date(currentDate)
+    })
+
+    it('should return false', () => {
+      expect(hasRentalPeriodEnded(rental)).toBe(false)
+    })
+  })
+
+  describe('and the end date of the rental has not passed the current date', () => {
+    beforeEach(() => {
+      rental.endsAt = new Date(Date.now() + 100000000000)
+    })
+
+    it('should return false', () => {
+      expect(hasRentalPeriodEnded(rental)).toBe(false)
+    })
+  })
+})

--- a/src/modules/land/utils.ts
+++ b/src/modules/land/utils.ts
@@ -7,7 +7,7 @@ import { LAND_REGISTRY_ADDRESS, ESTATE_REGISTRY_ADDRESS } from 'modules/common/c
 import { LANDRegistry__factory } from 'contracts/factories/LANDRegistry__factory'
 import { EstateRegistry__factory } from 'contracts/factories/EstateRegistry__factory'
 import { isZero } from 'lib/address'
-import { Land, LandTile, LandType, RoleType } from './types'
+import { Land, LandTile, LandType, Rental, RoleType } from './types'
 
 export const LAND_POOL_ADDRESS = '0xDc13378daFca7Fe2306368A16BCFac38c80BfCAD'
 export const MAX_PARCELS_PER_TX = 20
@@ -178,4 +178,8 @@ export function getExplorerURL(x: string | number, y: string | number) {
 
 export function hasAnyRole(land: Land, roles: RoleType[]): boolean {
   return land.roles.some(role => roles.includes(role))
+}
+
+export function hasRentalPeriodEnded(rental: Rental): boolean {
+  return rental.endsAt.getTime() < Date.now()
 }


### PR DESCRIPTION
This PR removes the dropdown menu for tenant whose rental contract has finished.
Closes #2435