### PR TITLE
feat: Update single items management

### DIFF
--- a/src/components/CollectionDetailPage/CollectionItem/CollectionItem.container.ts
+++ b/src/components/CollectionDetailPage/CollectionItem/CollectionItem.container.ts
@@ -3,7 +3,7 @@ import { push } from 'connected-react-router'
 import { getAddress } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import { RootState } from 'modules/common/types'
 import { openModal } from 'modules/modal/actions'
-import { setCollection } from 'modules/item/actions'
+import { deleteItemRequest } from 'modules/item/actions'
 import { setItems } from 'modules/editor/actions'
 import { MapStateProps, MapDispatch, MapDispatchProps } from './CollectionItem.types'
 import CollectionItem from './CollectionItem'
@@ -15,7 +15,7 @@ const mapState = (state: RootState): MapStateProps => ({
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
   onNavigate: path => dispatch(push(path)),
   onOpenModal: (name, metadata) => dispatch(openModal(name, metadata)),
-  onRemoveFromCollection: item => dispatch(setCollection(item, null)),
+  onRemoveItem: item => dispatch(deleteItemRequest(item)),
   onSetItems: items => dispatch(setItems(items))
 })
 

--- a/src/components/CollectionDetailPage/CollectionItem/CollectionItem.container.ts
+++ b/src/components/CollectionDetailPage/CollectionItem/CollectionItem.container.ts
@@ -15,7 +15,7 @@ const mapState = (state: RootState): MapStateProps => ({
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
   onNavigate: path => dispatch(push(path)),
   onOpenModal: (name, metadata) => dispatch(openModal(name, metadata)),
-  onRemoveItem: item => dispatch(deleteItemRequest(item)),
+  onDeleteItem: item => dispatch(deleteItemRequest(item)),
   onSetItems: items => dispatch(setItems(items))
 })
 

--- a/src/components/CollectionDetailPage/CollectionItem/CollectionItem.tsx
+++ b/src/components/CollectionDetailPage/CollectionItem/CollectionItem.tsx
@@ -43,9 +43,9 @@ export default class CollectionItem extends React.PureComponent<Props> {
     onNavigate(locations.itemEditor({ itemId: item.id, collectionId: item.collectionId }))
   }
 
-  handleRemoveItem = () => {
-    const { item, onRemoveItem } = this.props
-    onRemoveItem(item)
+  handleDeleteItem = () => {
+    const { item, onDeleteItem } = this.props
+    onDeleteItem(item)
   }
 
   renderPrice() {
@@ -149,14 +149,17 @@ export default class CollectionItem extends React.PureComponent<Props> {
                     {item.price ? (
                       <Dropdown.Item text={t('collection_item.edit_price')} onClick={this.handleEditPriceAndBeneficiary} />
                     ) : null}
-                    {!item.isPublished ? (
-                      <ConfirmDelete
-                        name={item.name}
-                        onDelete={this.handleRemoveItem}
-                        trigger={<Dropdown.Item text={t('collection_item.remove_item')} />}
-                      />
-                    ) : null}
                     <ResetItemButton itemId={item.id} />
+                    {!item.isPublished ? (
+                      <>
+                        <Dropdown.Divider />
+                        <ConfirmDelete
+                          name={item.name}
+                          onDelete={this.handleDeleteItem}
+                          trigger={<Dropdown.Item text={t('collection_item.delete_item')} />}
+                        />
+                      </>
+                    ) : null}
                   </>
                 ) : null}
               </Dropdown.Menu>

--- a/src/components/CollectionDetailPage/CollectionItem/CollectionItem.tsx
+++ b/src/components/CollectionDetailPage/CollectionItem/CollectionItem.tsx
@@ -13,6 +13,7 @@ import { isEmoteData, ItemType, WearableData } from 'modules/item/types'
 import ItemBadge from 'components/ItemBadge'
 import RarityBadge from 'components/RarityBadge'
 import ItemImage from 'components/ItemImage'
+import ConfirmDelete from 'components/ConfirmDelete'
 import { Props } from './CollectionItem.types'
 import ResetItemButton from './ResetItemButton'
 import styles from './CollectionItem.module.css'
@@ -42,9 +43,9 @@ export default class CollectionItem extends React.PureComponent<Props> {
     onNavigate(locations.itemEditor({ itemId: item.id, collectionId: item.collectionId }))
   }
 
-  handleRemoveFromCollection = () => {
-    const { item, onRemoveFromCollection } = this.props
-    onRemoveFromCollection(item, null)
+  handleRemoveItem = () => {
+    const { item, onRemoveItem } = this.props
+    onRemoveItem(item)
   }
 
   renderPrice() {
@@ -149,7 +150,11 @@ export default class CollectionItem extends React.PureComponent<Props> {
                       <Dropdown.Item text={t('collection_item.edit_price')} onClick={this.handleEditPriceAndBeneficiary} />
                     ) : null}
                     {!item.isPublished ? (
-                      <Dropdown.Item text={t('collection_item.remove_from_collection')} onClick={this.handleRemoveFromCollection} />
+                      <ConfirmDelete
+                        name={item.name}
+                        onDelete={this.handleRemoveItem}
+                        trigger={<Dropdown.Item text={t('collection_item.remove_item')} />}
+                      />
                     ) : null}
                     <ResetItemButton itemId={item.id} />
                   </>

--- a/src/components/CollectionDetailPage/CollectionItem/CollectionItem.types.ts
+++ b/src/components/CollectionDetailPage/CollectionItem/CollectionItem.types.ts
@@ -3,7 +3,7 @@ import { CallHistoryMethodAction } from 'connected-react-router'
 import { Collection } from 'modules/collection/types'
 import { Item } from 'modules/item/types'
 import { openModal, OpenModalAction } from 'modules/modal/actions'
-import { setCollection, SetCollectionAction } from 'modules/item/actions'
+import { deleteItemRequest, DeleteItemRequestAction } from 'modules/item/actions'
 import { setItems, SetItemsAction } from 'modules/editor/actions'
 
 export type Props = {
@@ -12,10 +12,10 @@ export type Props = {
   item: Item
   onNavigate: (path: string) => void
   onOpenModal: typeof openModal
-  onRemoveFromCollection: typeof setCollection
+  onRemoveItem: typeof deleteItemRequest
   onSetItems: typeof setItems
 }
 
 export type MapStateProps = Pick<Props, 'ethAddress'>
-export type MapDispatchProps = Pick<Props, 'onNavigate' | 'onOpenModal' | 'onRemoveFromCollection' | 'onSetItems'>
-export type MapDispatch = Dispatch<CallHistoryMethodAction | OpenModalAction | SetCollectionAction | SetItemsAction>
+export type MapDispatchProps = Pick<Props, 'onNavigate' | 'onOpenModal' | 'onRemoveItem' | 'onSetItems'>
+export type MapDispatch = Dispatch<CallHistoryMethodAction | OpenModalAction | DeleteItemRequestAction | SetItemsAction>

--- a/src/components/CollectionDetailPage/CollectionItem/CollectionItem.types.ts
+++ b/src/components/CollectionDetailPage/CollectionItem/CollectionItem.types.ts
@@ -12,10 +12,10 @@ export type Props = {
   item: Item
   onNavigate: (path: string) => void
   onOpenModal: typeof openModal
-  onRemoveItem: typeof deleteItemRequest
+  onDeleteItem: typeof deleteItemRequest
   onSetItems: typeof setItems
 }
 
 export type MapStateProps = Pick<Props, 'ethAddress'>
-export type MapDispatchProps = Pick<Props, 'onNavigate' | 'onOpenModal' | 'onRemoveItem' | 'onSetItems'>
+export type MapDispatchProps = Pick<Props, 'onNavigate' | 'onOpenModal' | 'onDeleteItem' | 'onSetItems'>
 export type MapDispatch = Dispatch<CallHistoryMethodAction | OpenModalAction | DeleteItemRequestAction | SetItemsAction>

--- a/src/components/CollectionsPage/CollectionsPage.container.ts
+++ b/src/components/CollectionsPage/CollectionsPage.container.ts
@@ -14,7 +14,7 @@ import { getLoading as getLoadingCollections, getPaginatedCollections, getPagina
 import { setCollectionPageView } from 'modules/ui/collection/actions'
 import { getCollectionPageView } from 'modules/ui/collection/selectors'
 import { isThirdPartyManager } from 'modules/thirdParty/selectors'
-import { fetchItemsRequest, fetchOrphanItemRequest, FETCH_ITEMS_REQUEST } from 'modules/item/actions'
+import { fetchItemsRequest, fetchOrphanItemRequest, FETCH_ITEMS_REQUEST, FETCH_ORPHAN_ITEM_REQUEST } from 'modules/item/actions'
 import { fetchCollectionsRequest, FETCH_COLLECTIONS_REQUEST } from 'modules/collection/actions'
 import { MapStateProps, MapDispatchProps, MapDispatch } from './CollectionsPage.types'
 import CollectionsPage from './CollectionsPage'
@@ -37,6 +37,7 @@ const mapState = (state: RootState): MapStateProps => {
     isThirdPartyManager: isThirdPartyManager(state),
     isLoadingCollections: isLoadingType(getLoadingCollections(state), FETCH_COLLECTIONS_REQUEST),
     isLoadingItems: isLoadingType(getLoadingItems(state), FETCH_ITEMS_REQUEST),
+    isLoadingOrphanItem: isLoadingType(getLoadingItems(state), FETCH_ORPHAN_ITEM_REQUEST),
     isMVMFEnabled: getIsMVMFEnabled(state),
     hasUserOrphanItems: hasUserOrphanItems(state)
   }

--- a/src/components/CollectionsPage/CollectionsPage.container.ts
+++ b/src/components/CollectionsPage/CollectionsPage.container.ts
@@ -14,7 +14,7 @@ import { getLoading as getLoadingCollections, getPaginatedCollections, getPagina
 import { setCollectionPageView } from 'modules/ui/collection/actions'
 import { getCollectionPageView } from 'modules/ui/collection/selectors'
 import { isThirdPartyManager } from 'modules/thirdParty/selectors'
-import { fetchItemsRequest, FETCH_ITEMS_REQUEST } from 'modules/item/actions'
+import { fetchItemsRequest, fetchOrphanItemRequest, FETCH_ITEMS_REQUEST } from 'modules/item/actions'
 import { fetchCollectionsRequest, FETCH_COLLECTIONS_REQUEST } from 'modules/collection/actions'
 import { MapStateProps, MapDispatchProps, MapDispatch } from './CollectionsPage.types'
 import CollectionsPage from './CollectionsPage'
@@ -47,7 +47,8 @@ const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
   onSetView: view => dispatch(setCollectionPageView(view)),
   onOpenModal: (name, metadata) => dispatch(openModal(name, metadata)),
   onFetchOrphanItems: (address, params) => dispatch(fetchItemsRequest(address, params)),
-  onFetchCollections: (address, params) => dispatch(fetchCollectionsRequest(address, params))
+  onFetchCollections: (address, params) => dispatch(fetchCollectionsRequest(address, params)),
+  onFetchOrphanItem: address => dispatch(fetchOrphanItemRequest(address))
 })
 
 export default connect(mapState, mapDispatch)(CollectionsPage)

--- a/src/components/CollectionsPage/CollectionsPage.container.ts
+++ b/src/components/CollectionsPage/CollectionsPage.container.ts
@@ -7,7 +7,8 @@ import { openModal } from 'modules/modal/actions'
 import {
   getPaginationData as getItemsPaginationData,
   getLoading as getLoadingItems,
-  getPaginatedCollectionItems
+  getPaginatedCollectionItems,
+  hasUserOrphanItems
 } from 'modules/item/selectors'
 import { getLoading as getLoadingCollections, getPaginatedCollections, getPaginationData } from 'modules/collection/selectors'
 import { setCollectionPageView } from 'modules/ui/collection/actions'
@@ -36,7 +37,8 @@ const mapState = (state: RootState): MapStateProps => {
     isThirdPartyManager: isThirdPartyManager(state),
     isLoadingCollections: isLoadingType(getLoadingCollections(state), FETCH_COLLECTIONS_REQUEST),
     isLoadingItems: isLoadingType(getLoadingItems(state), FETCH_ITEMS_REQUEST),
-    isMVMFEnabled: getIsMVMFEnabled(state)
+    isMVMFEnabled: getIsMVMFEnabled(state),
+    hasUserOrphanItems: hasUserOrphanItems(state)
   }
 }
 

--- a/src/components/CollectionsPage/CollectionsPage.tsx
+++ b/src/components/CollectionsPage/CollectionsPage.tsx
@@ -39,21 +39,20 @@ export default class CollectionsPage extends React.PureComponent<Props> {
   }
 
   componentDidMount() {
-    const { address, onFetchCollections, onFetchOrphanItems } = this.props
+    const { address, onFetchCollections, onFetchOrphanItem } = this.props
     // fetch if already connected
     if (address) {
       onFetchCollections(address, { page: 1, limit: PAGE_SIZE })
-      onFetchOrphanItems(address, { page: 1, limit: 1 })
+      onFetchOrphanItem(address)
     }
   }
 
   componentDidUpdate(prevProps: Props) {
-    const { address, onFetchCollections, onFetchOrphanItems } = this.props
+    const { address, onFetchCollections, onFetchOrphanItem } = this.props
     // if it's the first page and it was not connected when mounting
     if (address && address !== prevProps.address) {
       onFetchCollections(address, { page: 1, limit: PAGE_SIZE })
-      // TODO: Remove this call when there are no users with orphan items
-      onFetchOrphanItems(address, { page: 1, limit: 1 })
+      onFetchOrphanItem(address)
     }
   }
 
@@ -199,6 +198,10 @@ export default class CollectionsPage extends React.PureComponent<Props> {
     const count = this.isCollectionTabActive() ? totalCollections : totalItems
     const totalPages = this.isCollectionTabActive() ? collectionsPaginationData?.totalPages : itemsPaginationData?.totalPages
 
+    if (isLoadingItems || isLoadingCollections || count === undefined) {
+      return <Loader active size="large" />
+    }
+
     return (
       <>
         <EventBanner />
@@ -225,9 +228,7 @@ export default class CollectionsPage extends React.PureComponent<Props> {
           </Container>
         </div>
 
-        {isLoadingItems || isLoadingCollections || count === undefined ? (
-          <Loader active size="large" />
-        ) : count > 0 ? (
+        {count > 0 ? (
           <>
             {view === CollectionPageView.GRID ? this.renderGrid() : view === CollectionPageView.LIST ? this.renderList() : null}
             {!!totalPages && totalPages > 1 && (

--- a/src/components/CollectionsPage/CollectionsPage.tsx
+++ b/src/components/CollectionsPage/CollectionsPage.tsx
@@ -39,18 +39,21 @@ export default class CollectionsPage extends React.PureComponent<Props> {
   }
 
   componentDidMount() {
-    const { onFetchCollections, address } = this.props
+    const { address, onFetchCollections, onFetchOrphanItems } = this.props
     // fetch if already connected
     if (address) {
       onFetchCollections(address, { page: 1, limit: PAGE_SIZE })
+      onFetchOrphanItems(address, { page: 1, limit: 1 })
     }
   }
 
   componentDidUpdate(prevProps: Props) {
-    const { onFetchCollections, address } = this.props
+    const { address, onFetchCollections, onFetchOrphanItems } = this.props
     // if it's the first page and it was not connected when mounting
     if (address && address !== prevProps.address) {
       onFetchCollections(address, { page: 1, limit: PAGE_SIZE })
+      // TODO: Remove this call when there are no users with orphan items
+      onFetchOrphanItems(address, { page: 1, limit: 1 })
     }
   }
 
@@ -189,21 +192,20 @@ export default class CollectionsPage extends React.PureComponent<Props> {
   }
 
   renderPage() {
-    const { collectionsPaginationData, items, itemsPaginationData, view, isLoadingItems, isLoadingCollections } = this.props
+    const { collectionsPaginationData, itemsPaginationData, view, isLoadingItems, isLoadingCollections, hasUserOrphanItems } = this.props
     const { page } = this.state
     const totalCollections = collectionsPaginationData?.total
     const totalItems = itemsPaginationData?.total
     const count = this.isCollectionTabActive() ? totalCollections : totalItems
     const totalPages = this.isCollectionTabActive() ? collectionsPaginationData?.totalPages : itemsPaginationData?.totalPages
-    // TODO: Remove tabs when there are no users with orphan items
-    const hasOrphanItems = items.some(item => item.collectionId === null)
 
     return (
       <>
         <EventBanner />
         <div className="filters">
           <Container>
-            {hasOrphanItems && (
+            {hasUserOrphanItems && (
+              // TODO: Remove tabs when there are no users with orphan items
               <Tabs isFullscreen>
                 <Tabs.Tab active={this.isCollectionTabActive()} onClick={() => this.handleTabChange(TABS.COLLECTIONS)}>
                   {t('collections_page.collections')}
@@ -218,7 +220,7 @@ export default class CollectionsPage extends React.PureComponent<Props> {
               <Column>
                 <Row>{!isLoadingItems && !!count && count > 0 && <Header sub>{t('collections_page.results', { count })}</Header>}</Row>
               </Column>
-              {!hasOrphanItems && this.renderRightActions()}
+              {!hasUserOrphanItems && this.renderRightActions()}
             </Row>
           </Container>
         </div>

--- a/src/components/CollectionsPage/CollectionsPage.tsx
+++ b/src/components/CollectionsPage/CollectionsPage.tsx
@@ -143,74 +143,82 @@ export default class CollectionsPage extends React.PureComponent<Props> {
     this.setState({ page: +props.activePage! }, this.isCollectionTabActive() ? this.fetchCollections : this.fetchItems)
   }
 
+  renderRightActions = () => {
+    const { view, isThirdPartyManager, onSetView } = this.props
+    return (
+      <Column align="right">
+        <Row className="actions">
+          {this.isCollectionTabActive() && (
+            <Dropdown
+              trigger={
+                <Button basic className="create-item">
+                  <Icon name="add-active" />
+                </Button>
+              }
+              inline
+              direction="left"
+            >
+              <Dropdown.Menu>
+                <>
+                  <Dropdown.Item text={t('collections_page.new_collection')} onClick={this.handleNewCollection} />
+                  {isThirdPartyManager && (
+                    <Dropdown.Item text={t('collections_page.new_third_party_collection')} onClick={this.handleNewThirdPartyCollection} />
+                  )}
+                </>
+              </Dropdown.Menu>
+            </Dropdown>
+          )}
+          <Button className="open-editor" primary onClick={this.handleOpenEditor} size="tiny">
+            {t('item_editor.open')}
+          </Button>
+          <Chip
+            className="grid"
+            icon="grid"
+            isActive={view === CollectionPageView.GRID}
+            onClick={() => onSetView(CollectionPageView.GRID)}
+          />
+          <Chip
+            className="list"
+            icon="table"
+            isActive={view === CollectionPageView.LIST}
+            onClick={() => onSetView(CollectionPageView.LIST)}
+          />
+        </Row>
+      </Column>
+    )
+  }
+
   renderPage() {
-    const { collectionsPaginationData, itemsPaginationData, view, isThirdPartyManager, onSetView, isLoadingItems, isLoadingCollections } =
-      this.props
+    const { collectionsPaginationData, items, itemsPaginationData, view, isLoadingItems, isLoadingCollections } = this.props
     const { page } = this.state
     const totalCollections = collectionsPaginationData?.total
     const totalItems = itemsPaginationData?.total
     const count = this.isCollectionTabActive() ? totalCollections : totalItems
     const totalPages = this.isCollectionTabActive() ? collectionsPaginationData?.totalPages : itemsPaginationData?.totalPages
+    // TODO: Remove tabs when there are no users with orphan items
+    const hasOrphanItems = items.some(item => item.collectionId === null)
 
     return (
       <>
         <EventBanner />
         <div className="filters">
           <Container>
-            <Tabs isFullscreen>
-              <Tabs.Tab active={this.isCollectionTabActive()} onClick={() => this.handleTabChange(TABS.COLLECTIONS)}>
-                {t('collections_page.collections')}
-              </Tabs.Tab>
-              <Tabs.Tab active={!this.isCollectionTabActive()} onClick={() => this.handleTabChange(TABS.ITEMS)}>
-                {t('collections_page.single_items')}
-              </Tabs.Tab>
-              <Column align="right">
-                <Row className="actions">
-                  {this.isCollectionTabActive() && (
-                    <Dropdown
-                      trigger={
-                        <Button basic className="create-item">
-                          <Icon name="add-active" />
-                        </Button>
-                      }
-                      inline
-                      direction="left"
-                    >
-                      <Dropdown.Menu>
-                        <>
-                          <Dropdown.Item text={t('collections_page.new_collection')} onClick={this.handleNewCollection} />
-                          {isThirdPartyManager && (
-                            <Dropdown.Item
-                              text={t('collections_page.new_third_party_collection')}
-                              onClick={this.handleNewThirdPartyCollection}
-                            />
-                          )}
-                        </>
-                      </Dropdown.Menu>
-                    </Dropdown>
-                  )}
-                  <Button className="open-editor" primary onClick={this.handleOpenEditor} size="tiny">
-                    {t('item_editor.open')}
-                  </Button>
-                  <Chip
-                    className="grid"
-                    icon="grid"
-                    isActive={view === CollectionPageView.GRID}
-                    onClick={() => onSetView(CollectionPageView.GRID)}
-                  />
-                  <Chip
-                    className="list"
-                    icon="table"
-                    isActive={view === CollectionPageView.LIST}
-                    onClick={() => onSetView(CollectionPageView.LIST)}
-                  />
-                </Row>
-              </Column>
-            </Tabs>
+            {hasOrphanItems && (
+              <Tabs isFullscreen>
+                <Tabs.Tab active={this.isCollectionTabActive()} onClick={() => this.handleTabChange(TABS.COLLECTIONS)}>
+                  {t('collections_page.collections')}
+                </Tabs.Tab>
+                <Tabs.Tab active={!this.isCollectionTabActive()} onClick={() => this.handleTabChange(TABS.ITEMS)}>
+                  {t('collections_page.single_items')}
+                </Tabs.Tab>
+                {this.renderRightActions()}
+              </Tabs>
+            )}
             <Row height={30}>
               <Column>
                 <Row>{!isLoadingItems && !!count && count > 0 && <Header sub>{t('collections_page.results', { count })}</Header>}</Row>
               </Column>
+              {!hasOrphanItems && this.renderRightActions()}
             </Row>
           </Container>
         </div>

--- a/src/components/CollectionsPage/CollectionsPage.tsx
+++ b/src/components/CollectionsPage/CollectionsPage.tsx
@@ -166,31 +166,29 @@ export default class CollectionsPage extends React.PureComponent<Props> {
               </Tabs.Tab>
               <Column align="right">
                 <Row className="actions">
-                  <Dropdown
-                    trigger={
-                      <Button basic className="create-item">
-                        <Icon name="add-active" />
-                      </Button>
-                    }
-                    inline
-                    direction="left"
-                  >
-                    <Dropdown.Menu>
-                      {this.isCollectionTabActive() ? (
+                  {this.isCollectionTabActive() && (
+                    <Dropdown
+                      trigger={
+                        <Button basic className="create-item">
+                          <Icon name="add-active" />
+                        </Button>
+                      }
+                      inline
+                      direction="left"
+                    >
+                      <Dropdown.Menu>
                         <>
                           <Dropdown.Item text={t('collections_page.new_collection')} onClick={this.handleNewCollection} />
-                          {isThirdPartyManager ? (
+                          {isThirdPartyManager && (
                             <Dropdown.Item
                               text={t('collections_page.new_third_party_collection')}
                               onClick={this.handleNewThirdPartyCollection}
                             />
-                          ) : null}
+                          )}
                         </>
-                      ) : (
-                        <Dropdown.Item text={t('collections_page.new_item')} onClick={this.handleNewItem} />
-                      )}
-                    </Dropdown.Menu>
-                  </Dropdown>
+                      </Dropdown.Menu>
+                    </Dropdown>
+                  )}
                   <Button className="open-editor" primary onClick={this.handleOpenEditor} size="tiny">
                     {t('item_editor.open')}
                   </Button>

--- a/src/components/CollectionsPage/CollectionsPage.types.ts
+++ b/src/components/CollectionsPage/CollectionsPage.types.ts
@@ -26,6 +26,7 @@ export type Props = {
   isLoadingCollections: boolean
   isLoadingItems: boolean
   isMVMFEnabled: boolean
+  hasUserOrphanItems: boolean
   onNavigate: (path: string) => void
   onSetView: typeof setCollectionPageView
   onOpenModal: typeof openModal
@@ -45,6 +46,7 @@ export type MapStateProps = Pick<
   | 'isLoadingCollections'
   | 'isLoadingItems'
   | 'isMVMFEnabled'
+  | 'hasUserOrphanItems'
 >
 export type MapDispatchProps = Pick<Props, 'onNavigate' | 'onSetView' | 'onOpenModal' | 'onFetchOrphanItems' | 'onFetchCollections'>
 export type MapDispatch = Dispatch<

--- a/src/components/CollectionsPage/CollectionsPage.types.ts
+++ b/src/components/CollectionsPage/CollectionsPage.types.ts
@@ -25,6 +25,7 @@ export type Props = {
   isThirdPartyManager: boolean
   isLoadingCollections: boolean
   isLoadingItems: boolean
+  isLoadingOrphanItem: boolean
   isMVMFEnabled: boolean
   hasUserOrphanItems: boolean | undefined
   onNavigate: (path: string) => void
@@ -46,6 +47,7 @@ export type MapStateProps = Pick<
   | 'isThirdPartyManager'
   | 'isLoadingCollections'
   | 'isLoadingItems'
+  | 'isLoadingOrphanItem'
   | 'isMVMFEnabled'
   | 'hasUserOrphanItems'
 >

--- a/src/components/CollectionsPage/CollectionsPage.types.ts
+++ b/src/components/CollectionsPage/CollectionsPage.types.ts
@@ -5,7 +5,7 @@ import { setCollectionPageView, SetCollectionPageViewAction } from 'modules/ui/c
 import { CollectionPageView } from 'modules/ui/collection/types'
 import { Item } from 'modules/item/types'
 import { Collection } from 'modules/collection/types'
-import { fetchItemsRequest, FetchItemsRequestAction } from 'modules/item/actions'
+import { fetchItemsRequest, FetchItemsRequestAction, fetchOrphanItemRequest, FetchOrphanItemRequestAction } from 'modules/item/actions'
 import { fetchCollectionsRequest, FetchCollectionsRequestAction } from 'modules/collection/actions'
 import { CollectionPaginationData } from 'modules/collection/reducer'
 import { ItemPaginationData } from 'modules/item/reducer'
@@ -26,12 +26,13 @@ export type Props = {
   isLoadingCollections: boolean
   isLoadingItems: boolean
   isMVMFEnabled: boolean
-  hasUserOrphanItems: boolean
+  hasUserOrphanItems: boolean | undefined
   onNavigate: (path: string) => void
   onSetView: typeof setCollectionPageView
   onOpenModal: typeof openModal
   onFetchOrphanItems: typeof fetchItemsRequest
   onFetchCollections: typeof fetchCollectionsRequest
+  onFetchOrphanItem: typeof fetchOrphanItemRequest
 }
 
 export type MapStateProps = Pick<
@@ -48,7 +49,15 @@ export type MapStateProps = Pick<
   | 'isMVMFEnabled'
   | 'hasUserOrphanItems'
 >
-export type MapDispatchProps = Pick<Props, 'onNavigate' | 'onSetView' | 'onOpenModal' | 'onFetchOrphanItems' | 'onFetchCollections'>
+export type MapDispatchProps = Pick<
+  Props,
+  'onNavigate' | 'onSetView' | 'onOpenModal' | 'onFetchOrphanItems' | 'onFetchCollections' | 'onFetchOrphanItem'
+>
 export type MapDispatch = Dispatch<
-  CallHistoryMethodAction | SetCollectionPageViewAction | OpenModalAction | FetchItemsRequestAction | FetchCollectionsRequestAction
+  | CallHistoryMethodAction
+  | SetCollectionPageViewAction
+  | OpenModalAction
+  | FetchItemsRequestAction
+  | FetchCollectionsRequestAction
+  | FetchOrphanItemRequestAction
 >

--- a/src/components/ItemEditorPage/CenterPanel/CenterPanel.container.ts
+++ b/src/components/ItemEditorPage/CenterPanel/CenterPanel.container.ts
@@ -28,7 +28,7 @@ import {
   isPlayingEmote
 } from 'modules/editor/selectors'
 import { fetchCollectionItemsRequest, fetchItemsRequest } from 'modules/item/actions'
-import { getEmotes, getItem } from 'modules/item/selectors'
+import { getEmotes, getItem, hasUserOrphanItems } from 'modules/item/selectors'
 import { ItemType } from 'modules/item/types'
 import { getSelectedCollectionId, getSelectedItemId } from 'modules/location/selectors'
 import { MapStateProps, MapDispatchProps, MapDispatch } from './CenterPanel.types'
@@ -74,7 +74,8 @@ const mapState = (state: RootState): MapStateProps => {
     wearableController: getWearablePreviewController(state),
     emotes,
     isPlayingEmote: isPLayingIdleEmote ? false : isPlayingEmote(state),
-    isImportFilesModalOpen
+    isImportFilesModalOpen,
+    hasUserOrphanItems: hasUserOrphanItems(state)
   }
 }
 

--- a/src/components/ItemEditorPage/CenterPanel/CenterPanel.tsx
+++ b/src/components/ItemEditorPage/CenterPanel/CenterPanel.tsx
@@ -44,6 +44,7 @@ export default class CenterPanel extends React.PureComponent<Props, State> {
       if (collection && !isTPCollection(collection)) {
         onFetchCollectionItems(collection.id)
       } else if (address) {
+        // TODO: Remove this call when there are no users with orphan items
         onFetchOrphanItems(address)
       }
     }

--- a/src/components/ItemEditorPage/CenterPanel/CenterPanel.tsx
+++ b/src/components/ItemEditorPage/CenterPanel/CenterPanel.tsx
@@ -43,8 +43,8 @@ export default class CenterPanel extends React.PureComponent<Props, State> {
       // The TP collections wouldn't have emotes soon, for this reason, we are fetching only standard collections to show in the Play Emote dropdown
       if (collection && !isTPCollection(collection)) {
         onFetchCollectionItems(collection.id)
-      } else {
-        onFetchOrphanItems(address!)
+      } else if (address) {
+        onFetchOrphanItems(address)
       }
     }
 

--- a/src/components/ItemEditorPage/CenterPanel/CenterPanel.tsx
+++ b/src/components/ItemEditorPage/CenterPanel/CenterPanel.tsx
@@ -28,6 +28,7 @@ export default class CenterPanel extends React.PureComponent<Props, State> {
       collection,
       emotes,
       selectedBaseWearables: bodyShapeBaseWearables,
+      hasUserOrphanItems,
       onFetchBaseWearables,
       onFetchOrphanItems,
       onFetchCollectionItems
@@ -43,7 +44,7 @@ export default class CenterPanel extends React.PureComponent<Props, State> {
       // The TP collections wouldn't have emotes soon, for this reason, we are fetching only standard collections to show in the Play Emote dropdown
       if (collection && !isTPCollection(collection)) {
         onFetchCollectionItems(collection.id)
-      } else if (address) {
+      } else if (address && hasUserOrphanItems) {
         // TODO: Remove this call when there are no users with orphan items
         onFetchOrphanItems(address)
       }

--- a/src/components/ItemEditorPage/CenterPanel/CenterPanel.types.ts
+++ b/src/components/ItemEditorPage/CenterPanel/CenterPanel.types.ts
@@ -46,6 +46,7 @@ export type Props = {
   emotes: Item[]
   isPlayingEmote: boolean
   isImportFilesModalOpen: boolean
+  hasUserOrphanItems: boolean | undefined
   onSetBodyShape: typeof setBodyShape
   onSetAvatarAnimation: typeof setEmote
   onSetSkinColor: typeof setSkinColor
@@ -81,6 +82,7 @@ export type MapStateProps = Pick<
   | 'emotes'
   | 'isPlayingEmote'
   | 'isImportFilesModalOpen'
+  | 'hasUserOrphanItems'
 >
 export type MapDispatchProps = Pick<
   Props,

--- a/src/components/ItemEditorPage/LeftPanel/Header/Header.container.ts
+++ b/src/components/ItemEditorPage/LeftPanel/Header/Header.container.ts
@@ -9,6 +9,7 @@ import { openModal } from 'modules/modal/actions'
 import { deleteCollectionRequest } from 'modules/collection/actions'
 import { deleteItemRequest } from 'modules/item/actions'
 import { isLoggedIn } from 'modules/identity/selectors'
+import { hasUserOrphanItems } from 'modules/item/selectors'
 import { MapStateProps, MapDispatchProps, MapDispatch } from './Header.types'
 import Header from './Header'
 
@@ -25,7 +26,8 @@ const mapState = (state: RootState): MapStateProps => {
     isLoggedIn: isLoggedIn(state),
     isReviewing: isReviewing(state),
     collection,
-    hasEditRights: collection !== undefined && address !== undefined && hasViewAndEditRights(state, address, collection)
+    hasEditRights: collection !== undefined && address !== undefined && hasViewAndEditRights(state, address, collection),
+    hasUserOrphanItems: hasUserOrphanItems(state)
   }
 }
 

--- a/src/components/ItemEditorPage/LeftPanel/Header/Header.tsx
+++ b/src/components/ItemEditorPage/LeftPanel/Header/Header.tsx
@@ -50,7 +50,7 @@ export default class Header extends React.PureComponent<Props> {
   }
 
   renderSelectedCollection() {
-    const { collection, address = '' } = this.props
+    const { collection, address = '', userHasOrphanItems = false } = this.props
     const isOwner = collection && isEqual(collection.owner, address)
     return collection ? (
       <>
@@ -63,7 +63,9 @@ export default class Header extends React.PureComponent<Props> {
             <Dropdown.Menu>
               <Dropdown.Item onClick={this.handleEditName}>{t('item_editor.left_panel.actions.edit_name')}</Dropdown.Item>
               <Dropdown.Item onClick={this.handleAddNewItem}>{t('item_editor.left_panel.actions.new_item')}</Dropdown.Item>
-              <Dropdown.Item onClick={this.handleAddExistingItem}>{t('item_editor.left_panel.actions.add_existing_item')}</Dropdown.Item>
+              {userHasOrphanItems && (
+                <Dropdown.Item onClick={this.handleAddExistingItem}>{t('item_editor.left_panel.actions.add_existing_item')}</Dropdown.Item>
+              )}
               <ConfirmDelete name={collection.name} onDelete={this.handleDelete} trigger={<Dropdown.Item text={t('global.delete')} />} />
             </Dropdown.Menu>
           </Dropdown>

--- a/src/components/ItemEditorPage/LeftPanel/Header/Header.tsx
+++ b/src/components/ItemEditorPage/LeftPanel/Header/Header.tsx
@@ -50,7 +50,7 @@ export default class Header extends React.PureComponent<Props> {
   }
 
   renderSelectedCollection() {
-    const { collection, address = '', userHasOrphanItems = false } = this.props
+    const { collection, address = '', hasUserOrphanItems } = this.props
     const isOwner = collection && isEqual(collection.owner, address)
     return collection ? (
       <>
@@ -63,7 +63,7 @@ export default class Header extends React.PureComponent<Props> {
             <Dropdown.Menu>
               <Dropdown.Item onClick={this.handleEditName}>{t('item_editor.left_panel.actions.edit_name')}</Dropdown.Item>
               <Dropdown.Item onClick={this.handleAddNewItem}>{t('item_editor.left_panel.actions.new_item')}</Dropdown.Item>
-              {userHasOrphanItems && (
+              {hasUserOrphanItems && (
                 <Dropdown.Item onClick={this.handleAddExistingItem}>{t('item_editor.left_panel.actions.add_existing_item')}</Dropdown.Item>
               )}
               <ConfirmDelete name={collection.name} onDelete={this.handleDelete} trigger={<Dropdown.Item text={t('global.delete')} />} />

--- a/src/components/ItemEditorPage/LeftPanel/Header/Header.tsx
+++ b/src/components/ItemEditorPage/LeftPanel/Header/Header.tsx
@@ -81,7 +81,6 @@ export default class Header extends React.PureComponent<Props> {
         {isLoggedIn ? (
           <Dropdown trigger={<div className="block add" />} inline direction="left">
             <Dropdown.Menu>
-              <Dropdown.Item onClick={this.handleNewItem}>{t('item_editor.left_panel.actions.new_item')}</Dropdown.Item>
               <Dropdown.Item onClick={this.handleNewCollection}>{t('item_editor.left_panel.actions.new_collection')}</Dropdown.Item>
             </Dropdown.Menu>
           </Dropdown>

--- a/src/components/ItemEditorPage/LeftPanel/Header/Header.types.ts
+++ b/src/components/ItemEditorPage/LeftPanel/Header/Header.types.ts
@@ -8,7 +8,6 @@ import { deleteItemRequest, DeleteItemRequestAction } from 'modules/item/actions
 export type Props = {
   address?: string
   collection?: Collection
-  userHasOrphanItems?: boolean
   isLoggedIn: boolean
   isReviewing: boolean
   onOpenModal: typeof openModal
@@ -16,8 +15,9 @@ export type Props = {
   onDeleteCollection: typeof deleteCollectionRequest
   onDeleteItem: typeof deleteItemRequest
   hasEditRights: boolean
+  hasUserOrphanItems: boolean
 }
 
-export type MapStateProps = Pick<Props, 'address' | 'collection' | 'isLoggedIn' | 'isReviewing' | 'hasEditRights'>
+export type MapStateProps = Pick<Props, 'address' | 'collection' | 'isLoggedIn' | 'isReviewing' | 'hasEditRights' | 'hasUserOrphanItems'>
 export type MapDispatchProps = Pick<Props, 'onNavigate' | 'onOpenModal' | 'onDeleteCollection' | 'onDeleteItem'>
 export type MapDispatch = Dispatch<OpenModalAction | CallHistoryMethodAction | DeleteCollectionRequestAction | DeleteItemRequestAction>

--- a/src/components/ItemEditorPage/LeftPanel/Header/Header.types.ts
+++ b/src/components/ItemEditorPage/LeftPanel/Header/Header.types.ts
@@ -15,7 +15,7 @@ export type Props = {
   onDeleteCollection: typeof deleteCollectionRequest
   onDeleteItem: typeof deleteItemRequest
   hasEditRights: boolean
-  hasUserOrphanItems: boolean
+  hasUserOrphanItems: boolean | undefined
 }
 
 export type MapStateProps = Pick<Props, 'address' | 'collection' | 'isLoggedIn' | 'isReviewing' | 'hasEditRights' | 'hasUserOrphanItems'>

--- a/src/components/ItemEditorPage/LeftPanel/Header/Header.types.ts
+++ b/src/components/ItemEditorPage/LeftPanel/Header/Header.types.ts
@@ -8,6 +8,7 @@ import { deleteItemRequest, DeleteItemRequestAction } from 'modules/item/actions
 export type Props = {
   address?: string
   collection?: Collection
+  userHasOrphanItems?: boolean
   isLoggedIn: boolean
   isReviewing: boolean
   onOpenModal: typeof openModal

--- a/src/components/ItemEditorPage/LeftPanel/LeftPanel.container.ts
+++ b/src/components/ItemEditorPage/LeftPanel/LeftPanel.container.ts
@@ -4,7 +4,14 @@ import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors
 import { isConnected, getAddress } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import { getSelectedCollectionId, getSelectedItemId, isReviewing } from 'modules/location/selectors'
 import { getBodyShape, getVisibleItems, getWearablePreviewController, isPlayingEmote } from 'modules/editor/selectors'
-import { getItems, getLoading, getPaginatedWalletOrphanItems, getPaginationData, getWalletOrphanItems } from 'modules/item/selectors'
+import {
+  getItems,
+  getLoading,
+  getPaginatedWalletOrphanItems,
+  getPaginationData,
+  getWalletOrphanItems,
+  hasUserOrphanItems
+} from 'modules/item/selectors'
 import { fetchCollectionsRequest } from 'modules/collection/actions'
 import { getAuthorizedCollections, getPaginationData as getCollectionsPaginationData } from 'modules/collection/selectors'
 import { setItems } from 'modules/editor/actions'
@@ -40,7 +47,8 @@ const mapState = (state: RootState): MapStateProps => {
     wearableController: getWearablePreviewController(state),
     isReviewing: isReviewing(state),
     isLoading: isLoadingType(getLoading(state), FETCH_ITEMS_REQUEST),
-    isPlayingEmote: isPlayingEmote(state)
+    isPlayingEmote: isPlayingEmote(state),
+    hasUserOrphanItems: hasUserOrphanItems(state)
   }
 }
 

--- a/src/components/ItemEditorPage/LeftPanel/LeftPanel.container.ts
+++ b/src/components/ItemEditorPage/LeftPanel/LeftPanel.container.ts
@@ -15,7 +15,13 @@ import {
 import { fetchCollectionsRequest } from 'modules/collection/actions'
 import { getAuthorizedCollections, getPaginationData as getCollectionsPaginationData } from 'modules/collection/selectors'
 import { setItems } from 'modules/editor/actions'
-import { fetchItemsRequest, FETCH_ITEMS_REQUEST, setCollection } from 'modules/item/actions'
+import {
+  fetchItemsRequest,
+  fetchOrphanItemRequest,
+  FETCH_ITEMS_REQUEST,
+  FETCH_ORPHAN_ITEM_REQUEST,
+  setCollection
+} from 'modules/item/actions'
 import { MapStateProps, MapDispatchProps, MapDispatch } from './LeftPanel.types'
 import LeftPanel from './LeftPanel'
 
@@ -46,7 +52,7 @@ const mapState = (state: RootState): MapStateProps => {
     bodyShape: getBodyShape(state),
     wearableController: getWearablePreviewController(state),
     isReviewing: isReviewing(state),
-    isLoading: isLoadingType(getLoading(state), FETCH_ITEMS_REQUEST),
+    isLoading: isLoadingType(getLoading(state), FETCH_ITEMS_REQUEST) || isLoadingType(getLoading(state), FETCH_ORPHAN_ITEM_REQUEST),
     isPlayingEmote: isPlayingEmote(state),
     hasUserOrphanItems: hasUserOrphanItems(state)
   }
@@ -56,7 +62,8 @@ const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
   onSetItems: items => dispatch(setItems(items)),
   onSetCollection: (item, collectionId) => dispatch(setCollection(item, collectionId)),
   onFetchCollections: (address, params) => dispatch(fetchCollectionsRequest(address, params)),
-  onFetchOrphanItems: (address, params) => dispatch(fetchItemsRequest(address, params))
+  onFetchOrphanItems: (address, params) => dispatch(fetchItemsRequest(address, params)),
+  onFetchOrphanItem: address => dispatch(fetchOrphanItemRequest(address))
 })
 
 export default connect(mapState, mapDispatch)(LeftPanel)

--- a/src/components/ItemEditorPage/LeftPanel/LeftPanel.tsx
+++ b/src/components/ItemEditorPage/LeftPanel/LeftPanel.tsx
@@ -145,7 +145,8 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
       onSetReviewedItems
     } = this.props
     const { pages } = this.state
-    const showTabs = !selectedCollectionId
+    const hasOrphanItems = allItems.some(item => item.collectionId === null)
+    const showTabs = !selectedCollectionId && hasOrphanItems
     const showCollections = this.isCollectionTabActive() && !selectedCollectionId
     const showItems = !this.isCollectionTabActive() || selectedCollectionId
     return (
@@ -180,7 +181,7 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
               } else if (items.length === 0 && selectedCollectionId) {
                 return (
                   <>
-                    <Header />
+                    <Header userHasOrphanItems={hasOrphanItems} />
                     <div className="empty">
                       <div className="subtitle">
                         {isReviewing ? t('item_editor.left_panel.no_items_to_review') : t('item_editor.left_panel.empty_collection')}
@@ -192,7 +193,7 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
 
               return (
                 <>
-                  <Header />
+                  <Header userHasOrphanItems={hasOrphanItems} />
                   {showTabs ? (
                     <Tabs isFullscreen>
                       <Tabs.Tab active={isCollectionTab} onClick={() => this.handleTabChange(ItemEditorTabs.COLLECTIONS)}>

--- a/src/components/ItemEditorPage/LeftPanel/LeftPanel.tsx
+++ b/src/components/ItemEditorPage/LeftPanel/LeftPanel.tsx
@@ -45,11 +45,26 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
   }
 
   componentDidMount() {
+    const { address, onFetchOrphanItems } = this.props
     this.fetchResource()
+    // TODO: Remove this call when there are no users with orphan items
+    if (address) {
+      onFetchOrphanItems(address, { limit: 1, page: 1 })
+    }
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
-    const { isConnected, address, selectedCollectionId, selectedItemId, orphanItems, totalItems, visibleItems, onSetItems } = this.props
+    const {
+      isConnected,
+      address,
+      selectedCollectionId,
+      selectedItemId,
+      orphanItems,
+      totalItems,
+      visibleItems,
+      onSetItems,
+      onFetchOrphanItems
+    } = this.props
     const { initialPage, pages } = this.state
     // when a newly created item redirects to the item editor, iterate over the pages until finding it
     if (
@@ -77,6 +92,10 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
       }
       if (prevProps.selectedCollectionId !== selectedCollectionId) {
         this.setState({ pages: [INITIAL_PAGE] })
+      }
+      // TODO: Remove this call when there are no users with orphan items
+      if (address && address !== prevProps.address) {
+        onFetchOrphanItems(address, { limit: 1, page: 1 })
       }
     }
   }
@@ -139,14 +158,14 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
       isPlayingEmote,
       isConnected,
       wearableController,
+      isLoading: isLoadingOrphanItems,
+      hasUserOrphanItems,
       onSetItems,
       onSetCollection,
-      isLoading: isLoadingOrphanItems,
       onSetReviewedItems
     } = this.props
     const { pages } = this.state
-    const hasOrphanItems = allItems.some(item => item.collectionId === null)
-    const showTabs = !selectedCollectionId && hasOrphanItems
+    const showTabs = !selectedCollectionId && hasUserOrphanItems
     const showCollections = this.isCollectionTabActive() && !selectedCollectionId
     const showItems = !this.isCollectionTabActive() || selectedCollectionId
     return (
@@ -181,7 +200,7 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
               } else if (items.length === 0 && selectedCollectionId) {
                 return (
                   <>
-                    <Header userHasOrphanItems={hasOrphanItems} />
+                    <Header />
                     <div className="empty">
                       <div className="subtitle">
                         {isReviewing ? t('item_editor.left_panel.no_items_to_review') : t('item_editor.left_panel.empty_collection')}
@@ -193,7 +212,7 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
 
               return (
                 <>
-                  <Header userHasOrphanItems={hasOrphanItems} />
+                  <Header />
                   {showTabs ? (
                     <Tabs isFullscreen>
                       <Tabs.Tab active={isCollectionTab} onClick={() => this.handleTabChange(ItemEditorTabs.COLLECTIONS)}>

--- a/src/components/ItemEditorPage/LeftPanel/LeftPanel.tsx
+++ b/src/components/ItemEditorPage/LeftPanel/LeftPanel.tsx
@@ -45,11 +45,11 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
   }
 
   componentDidMount() {
-    const { address, onFetchOrphanItems } = this.props
+    const { address, onFetchOrphanItem } = this.props
     this.fetchResource()
     // TODO: Remove this call when there are no users with orphan items
     if (address) {
-      onFetchOrphanItems(address, { limit: 1, page: 1 })
+      onFetchOrphanItem(address)
     }
   }
 
@@ -63,7 +63,7 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
       totalItems,
       visibleItems,
       onSetItems,
-      onFetchOrphanItems
+      onFetchOrphanItem
     } = this.props
     const { initialPage, pages } = this.state
     // when a newly created item redirects to the item editor, iterate over the pages until finding it
@@ -95,7 +95,7 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
       }
       // TODO: Remove this call when there are no users with orphan items
       if (address && address !== prevProps.address) {
-        onFetchOrphanItems(address, { limit: 1, page: 1 })
+        onFetchOrphanItem(address)
       }
     }
   }

--- a/src/components/ItemEditorPage/LeftPanel/LeftPanel.tsx
+++ b/src/components/ItemEditorPage/LeftPanel/LeftPanel.tsx
@@ -45,10 +45,10 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
   }
 
   componentDidMount() {
-    const { address, onFetchOrphanItem } = this.props
+    const { address, hasUserOrphanItems, onFetchOrphanItem } = this.props
     this.fetchResource()
     // TODO: Remove this call when there are no users with orphan items
-    if (address) {
+    if (address && hasUserOrphanItems === undefined) {
       onFetchOrphanItem(address)
     }
   }
@@ -62,6 +62,7 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
       orphanItems,
       totalItems,
       visibleItems,
+      hasUserOrphanItems,
       onSetItems,
       onFetchOrphanItem
     } = this.props
@@ -94,7 +95,7 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
         this.setState({ pages: [INITIAL_PAGE] })
       }
       // TODO: Remove this call when there are no users with orphan items
-      if (address && address !== prevProps.address) {
+      if (address && address !== prevProps.address && hasUserOrphanItems === undefined) {
         onFetchOrphanItem(address)
       }
     }

--- a/src/components/ItemEditorPage/LeftPanel/LeftPanel.types.ts
+++ b/src/components/ItemEditorPage/LeftPanel/LeftPanel.types.ts
@@ -8,6 +8,8 @@ import {
   FetchCollectionItemsRequestAction,
   fetchItemsRequest,
   FetchItemsRequestAction,
+  fetchOrphanItemRequest,
+  FetchOrphanItemRequestAction,
   setCollection,
   SetCollectionAction
 } from 'modules/item/actions'
@@ -33,12 +35,13 @@ export type Props = {
   isLoading: boolean
   isPlayingEmote: boolean
   wearableController: IPreviewController | null
-  hasUserOrphanItems: boolean
+  hasUserOrphanItems: boolean | undefined
   onSetItems: typeof setItems
   onSetCollection: typeof setCollection
   onFetchOrphanItems: typeof fetchItemsRequest
   onFetchCollections: typeof fetchCollectionsRequest
   onSetReviewedItems: (itemIds: Item[]) => void
+  onFetchOrphanItem: typeof fetchOrphanItemRequest
 }
 
 export type State = {
@@ -66,7 +69,15 @@ export type MapStateProps = Pick<
   | 'isPlayingEmote'
   | 'hasUserOrphanItems'
 >
-export type MapDispatchProps = Pick<Props, 'onSetItems' | 'onSetCollection' | 'onFetchOrphanItems' | 'onFetchCollections'>
+export type MapDispatchProps = Pick<
+  Props,
+  'onSetItems' | 'onSetCollection' | 'onFetchOrphanItems' | 'onFetchCollections' | 'onFetchOrphanItem'
+>
 export type MapDispatch = Dispatch<
-  SetItemsAction | SetCollectionAction | FetchCollectionItemsRequestAction | FetchItemsRequestAction | FetchCollectionsRequestAction
+  | SetItemsAction
+  | SetCollectionAction
+  | FetchCollectionItemsRequestAction
+  | FetchItemsRequestAction
+  | FetchCollectionsRequestAction
+  | FetchOrphanItemRequestAction
 >

--- a/src/components/ItemEditorPage/LeftPanel/LeftPanel.types.ts
+++ b/src/components/ItemEditorPage/LeftPanel/LeftPanel.types.ts
@@ -33,6 +33,7 @@ export type Props = {
   isLoading: boolean
   isPlayingEmote: boolean
   wearableController: IPreviewController | null
+  hasUserOrphanItems: boolean
   onSetItems: typeof setItems
   onSetCollection: typeof setCollection
   onFetchOrphanItems: typeof fetchItemsRequest
@@ -63,6 +64,7 @@ export type MapStateProps = Pick<
   | 'isReviewing'
   | 'isLoading'
   | 'isPlayingEmote'
+  | 'hasUserOrphanItems'
 >
 export type MapDispatchProps = Pick<Props, 'onSetItems' | 'onSetCollection' | 'onFetchOrphanItems' | 'onFetchCollections'>
 export type MapDispatch = Dispatch<

--- a/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
@@ -228,13 +228,6 @@ export default class RightPanel extends React.PureComponent<Props, State> {
     }
   }
 
-  handleRemoveFromCollection = () => {
-    const { selectedItem, onSetCollection } = this.props
-    if (selectedItem) {
-      onSetCollection(selectedItem, null)
-    }
-  }
-
   handleOpenThumbnailDialog = () => {
     const { selectedItem, onOpenModal } = this.props
 
@@ -405,9 +398,6 @@ export default class RightPanel extends React.PureComponent<Props, State> {
                               })}
                               onClick={this.handleAddRepresentationToItem}
                             />
-                          ) : null}
-                          {item.collectionId ? (
-                            <Dropdown.Item text={t('collection_item.remove_from_collection')} onClick={this.handleRemoveFromCollection} />
                           ) : null}
                           <ConfirmDelete
                             name={name}

--- a/src/modules/collection/utils.ts
+++ b/src/modules/collection/utils.ts
@@ -70,7 +70,7 @@ export function getCollectionType(collection: Collection): CollectionType {
     case URNType.BASE_AVATARS:
       return CollectionType.STANDARD
     default:
-      throw new Error(`Tried to get a collection type from an invalid URN: ${collection.urn}`)
+      throw new Error(`Tried to get a collection type from an invalid URN: ${collection.urn}` as unknown as string)
   }
 }
 

--- a/src/modules/item/actions.ts
+++ b/src/modules/item/actions.ts
@@ -22,6 +22,20 @@ export type FetchItemsRequestAction = ReturnType<typeof fetchItemsRequest>
 export type FetchItemsSuccessAction = ReturnType<typeof fetchItemsSuccess>
 export type FetchItemsFailureAction = ReturnType<typeof fetchItemsFailure>
 
+// Fetch Orphan items
+
+export const FETCH_ORPHAN_ITEM_REQUEST = '[Request] Fetch Orphan Item'
+export const FETCH_ORPHAN_ITEM_SUCCESS = '[Success] Fetch Orphan Item'
+export const FETCH_ORPHAN_ITEM_FAILURE = '[Failure] Fetch Orphan Item'
+
+export const fetchOrphanItemRequest = (address: string) => action(FETCH_ORPHAN_ITEM_REQUEST, { address })
+export const fetchOrphanItemSuccess = (items: Item[]) => action(FETCH_ORPHAN_ITEM_SUCCESS, { items })
+export const fetchOrphanItemFailure = (error: string) => action(FETCH_ORPHAN_ITEM_FAILURE, { error })
+
+export type FetchOrphanItemRequestAction = ReturnType<typeof fetchOrphanItemRequest>
+export type FetchOrphanItemSuccessAction = ReturnType<typeof fetchOrphanItemSuccess>
+export type FetchOrphanItemFailureAction = ReturnType<typeof fetchOrphanItemFailure>
+
 // Fetch item
 
 export const FETCH_ITEM_REQUEST = '[Request] Fetch Item'

--- a/src/modules/item/actions.ts
+++ b/src/modules/item/actions.ts
@@ -29,7 +29,7 @@ export const FETCH_ORPHAN_ITEM_SUCCESS = '[Success] Fetch Orphan Item'
 export const FETCH_ORPHAN_ITEM_FAILURE = '[Failure] Fetch Orphan Item'
 
 export const fetchOrphanItemRequest = (address: string) => action(FETCH_ORPHAN_ITEM_REQUEST, { address })
-export const fetchOrphanItemSuccess = (items: Item[]) => action(FETCH_ORPHAN_ITEM_SUCCESS, { items })
+export const fetchOrphanItemSuccess = (hasUserOrphanItems: boolean) => action(FETCH_ORPHAN_ITEM_SUCCESS, { hasUserOrphanItems })
 export const fetchOrphanItemFailure = (error: string) => action(FETCH_ORPHAN_ITEM_FAILURE, { error })
 
 export type FetchOrphanItemRequestAction = ReturnType<typeof fetchOrphanItemRequest>

--- a/src/modules/item/reducer.spec.ts
+++ b/src/modules/item/reducer.spec.ts
@@ -12,7 +12,10 @@ import {
   rescueItemsChunkSuccess,
   rescueItemsRequest,
   rescueItemsSuccess,
-  fetchCollectionItemsSuccess
+  fetchCollectionItemsSuccess,
+  fetchOrphanItemRequest,
+  fetchOrphanItemSuccess,
+  fetchOrphanItemFailure
 } from './actions'
 import { INITIAL_STATE, itemReducer, ItemState } from './reducer'
 import { Item } from './types'
@@ -344,6 +347,78 @@ describe('when reducing an action of a successful fetch of collection items', ()
           ...toItemObject(items)
         }
       })
+    })
+  })
+})
+
+describe('when an action of type FETCH_ORPHAN_ITEM_REQUEST is called', () => {
+  const address = '0x0'
+  it('should add a fetchOrphanItemRequest to the loading array', () => {
+    expect(itemReducer(INITIAL_STATE, fetchOrphanItemRequest(address))).toStrictEqual({
+      ...INITIAL_STATE,
+      loading: [fetchOrphanItemRequest(address)]
+    })
+  })
+})
+
+describe('when an action of type FETCH_ORPHAN_ITEM_SUCCESS is called', () => {
+  const address = '0x0'
+  describe('and there are orphan items', () => {
+    it('should remove a fetchOrphanItemRequest from the loading array, set hasUserOrphanItems true and null the error', () => {
+      expect(
+        itemReducer(
+          {
+            ...INITIAL_STATE,
+            loading: [fetchOrphanItemRequest(address)],
+            error
+          },
+          fetchOrphanItemSuccess(true)
+        )
+      ).toStrictEqual({
+        ...INITIAL_STATE,
+        loading: [],
+        hasUserOrphanItems: true,
+        error: null
+      })
+    })
+  })
+
+  describe('and there are not orphan items', () => {
+    it('should remove a fetchOrphanItemRequest from the loading array, set hasUserOrphanItems false and null the error', () => {
+      expect(
+        itemReducer(
+          {
+            ...INITIAL_STATE,
+            loading: [fetchOrphanItemRequest(address)],
+            error
+          },
+          fetchOrphanItemSuccess(false)
+        )
+      ).toStrictEqual({
+        ...INITIAL_STATE,
+        loading: [],
+        hasUserOrphanItems: false,
+        error: null
+      })
+    })
+  })
+})
+
+describe('when an action of type FETCH_ORPHAN_ITEM_FAILURE is called', () => {
+  const address = '0x0'
+  it('should remove a fetchOrphanItemRequest from the loading array and set the error', () => {
+    expect(
+      itemReducer(
+        {
+          ...INITIAL_STATE,
+          loading: [fetchOrphanItemRequest(address)]
+        },
+        fetchOrphanItemFailure(error)
+      )
+    ).toStrictEqual({
+      ...INITIAL_STATE,
+      loading: [],
+      error
     })
   })
 })

--- a/src/modules/item/reducer.ts
+++ b/src/modules/item/reducer.ts
@@ -212,8 +212,8 @@ export function itemReducer(state: ItemState = INITIAL_STATE, action: ItemReduce
         loading: loadingReducer(state.loading, action)
       }
     }
-    // TODO: Remove this reducer when there are no users with orphan items
     case FETCH_ORPHAN_ITEM_REQUEST: {
+      // TODO: Remove this reducer when there are no users with orphan items
       return {
         ...state,
         hasUserOrphanItems: undefined,
@@ -248,13 +248,12 @@ export function itemReducer(state: ItemState = INITIAL_STATE, action: ItemReduce
         error: null
       }
     }
-    // TODO: Remove this reducer when there are no users with orphan items
     case FETCH_ORPHAN_ITEM_SUCCESS: {
-      const { items } = action.payload
-
+      // TODO: Remove this reducer when there are no users with orphan items
+      const { hasUserOrphanItems } = action.payload
       return {
         ...state,
-        hasUserOrphanItems: items.length > 0,
+        hasUserOrphanItems,
         loading: loadingReducer(state.loading, action),
         error: null
       }
@@ -327,8 +326,8 @@ export function itemReducer(state: ItemState = INITIAL_STATE, action: ItemReduce
         error: action.payload.error
       }
     }
-    // TODO: Remove this reducer when there are no users with orphan items
     case FETCH_ORPHAN_ITEM_FAILURE: {
+      // TODO: Remove this reducer when there are no users with orphan items
       return {
         ...state,
         loading: loadingReducer(state.loading, action),

--- a/src/modules/item/reducer.ts
+++ b/src/modules/item/reducer.ts
@@ -116,6 +116,7 @@ export type ItemState = {
   data: Record<string, Item>
   rarities: Rarity[]
   loading: LoadingState
+  hasUserOrphanItems: boolean
   error: string | null
   pagination: Record<string, ItemPaginationData> | null
 }
@@ -124,6 +125,7 @@ export const INITIAL_STATE: ItemState = {
   data: {},
   rarities: [],
   loading: [],
+  hasUserOrphanItems: false,
   error: null,
   pagination: null
 }
@@ -205,6 +207,8 @@ export function itemReducer(state: ItemState = INITIAL_STATE, action: ItemReduce
     case FETCH_COLLECTION_ITEMS_SUCCESS: {
       const { paginationIndex, items, paginationStats } = action.payload
       const hasPagination = paginationStats !== undefined
+      const hasUserOrphanItems =
+        action.type === FETCH_ITEMS_SUCCESS ? items.some(item => item.collectionId === undefined) : state.hasUserOrphanItems
       return {
         ...state,
         data: {
@@ -226,6 +230,7 @@ export function itemReducer(state: ItemState = INITIAL_STATE, action: ItemReduce
               }
             : {})
         },
+        hasUserOrphanItems,
         error: null
       }
     }

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -203,8 +203,8 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
         limit: 1,
         collectionId: 'null'
       })
-      const { results } = response
-      yield put(fetchOrphanItemSuccess(results))
+      const { total } = response
+      yield put(fetchOrphanItemSuccess(total !== 0))
     } catch (error) {
       yield put(fetchOrphanItemFailure(error.message))
     }

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -91,7 +91,11 @@ import {
   FETCH_COLLECTION_THUMBNAILS_REQUEST,
   fetchCollectionThumbnailsSuccess,
   fetchCollectionThumbnailsFailure,
-  FetchCollectionThumbnailsRequestAction
+  FetchCollectionThumbnailsRequestAction,
+  FETCH_ORPHAN_ITEM_REQUEST,
+  FetchOrphanItemRequestAction,
+  fetchOrphanItemSuccess,
+  fetchOrphanItemFailure
 } from './actions'
 import { fromRemoteItem } from 'lib/api/transformations'
 import { isThirdParty } from 'lib/urn'
@@ -134,6 +138,7 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
   const createOrEditProgressChannel = channel()
   yield takeEvery(FETCH_ITEMS_REQUEST, handleFetchItemsRequest)
   yield takeEvery(FETCH_ITEM_REQUEST, handleFetchItemRequest)
+  yield takeEvery(FETCH_ORPHAN_ITEM_REQUEST, handleFetchOrphanItemRequest)
   yield takeEvery(FETCH_COLLECTION_ITEMS_REQUEST, handleFetchCollectionItemsRequest)
   yield takeEvery(FETCH_COLLECTION_THUMBNAILS_REQUEST, handleFetchCollectionThumbnailsRequest)
   yield takeEvery(SAVE_ITEM_REQUEST, handleSaveItemRequest)
@@ -185,6 +190,23 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
       yield put(fetchItemSuccess(id, item))
     } catch (error) {
       yield put(fetchItemFailure(id, error.message))
+    }
+  }
+
+  function* handleFetchOrphanItemRequest(action: FetchOrphanItemRequestAction) {
+    // TODO: Remove this method when there are no users with orphan items
+    const { address } = action.payload
+    try {
+      // fetch just one orphan item for the address
+      const response: PaginatedResource<Item> = yield call([legacyBuilder, 'fetchItems'], address, {
+        page: 1,
+        limit: 1,
+        collectionId: 'null'
+      })
+      const { results } = response
+      yield put(fetchOrphanItemSuccess(results))
+    } catch (error) {
+      yield put(fetchOrphanItemFailure(error.message))
     }
   }
 

--- a/src/modules/item/selectors.spec.ts
+++ b/src/modules/item/selectors.spec.ts
@@ -23,6 +23,7 @@ import {
   getStatusForItemIds,
   getWalletItems,
   getWalletOrphanItems,
+  hasUserOrphanItems,
   hasViewAndEditRights
 } from './selectors'
 import { Item, ItemRarity, ItemType, SyncStatus } from './types'
@@ -659,6 +660,54 @@ describe('Item selectors', () => {
             expect(hasViewAndEditRights(state, address, collection, item)).toBe(false)
           })
         })
+      })
+    })
+  })
+
+  describe('when getting if the user has orphan items', () => {
+    describe('when requesting orphan items', () => {
+      beforeEach(() => {
+        state = {
+          ...state,
+          item: {
+            ...state.item,
+            hasUserOrphanItems: undefined
+          }
+        } as RootState
+      })
+
+      it('should return undefined', () => {
+        expect(hasUserOrphanItems(state)).toEqual(undefined)
+      })
+    })
+    describe('when there are orphan items', () => {
+      beforeEach(() => {
+        state = {
+          ...state,
+          item: {
+            ...state.item,
+            hasUserOrphanItems: true
+          }
+        } as RootState
+      })
+
+      it('should return true', () => {
+        expect(hasUserOrphanItems(state)).toEqual(true)
+      })
+    })
+    describe('when there are not orphan items', () => {
+      beforeEach(() => {
+        state = {
+          ...state,
+          item: {
+            ...state.item,
+            hasUserOrphanItems: false
+          }
+        } as RootState
+      })
+
+      it('should return false', () => {
+        expect(hasUserOrphanItems(state)).toEqual(false)
       })
     })
   })

--- a/src/modules/item/selectors.ts
+++ b/src/modules/item/selectors.ts
@@ -34,7 +34,7 @@ export const getItem = (state: RootState, itemId: string) => {
   return items.find(item => item.id === itemId) || null
 }
 
-export const hasUserOrphanItems = (state: RootState): boolean => getState(state).hasUserOrphanItems
+export const hasUserOrphanItems = (state: RootState): boolean | undefined => getState(state).hasUserOrphanItems
 
 export const getWalletItems = createSelector<RootState, Item[], string | undefined, Item[]>(getItems, getAddress, (items, address) =>
   items.filter(item => address && isEqual(item.owner, address))

--- a/src/modules/item/selectors.ts
+++ b/src/modules/item/selectors.ts
@@ -34,6 +34,8 @@ export const getItem = (state: RootState, itemId: string) => {
   return items.find(item => item.id === itemId) || null
 }
 
+export const hasUserOrphanItems = (state: RootState): boolean => getState(state).hasUserOrphanItems
+
 export const getWalletItems = createSelector<RootState, Item[], string | undefined, Item[]>(getItems, getAddress, (items, address) =>
   items.filter(item => address && isEqual(item.owner, address))
 )

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -1247,7 +1247,7 @@
     "incomplete": "Incomplete",
     "edit_item": "edit",
     "mint_item": "mint",
-    "remove_item": "Remove item",
+    "delete_item": "Delete item",
     "edit_price": "Edit price",
     "see_details": "See details",
     "edit_urn": "Edit URN",

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -1247,7 +1247,7 @@
     "incomplete": "Incomplete",
     "edit_item": "edit",
     "mint_item": "mint",
-    "remove_from_collection": "Remove from collection",
+    "remove_item": "Remove item",
     "edit_price": "Edit price",
     "see_details": "See details",
     "edit_urn": "Edit URN",

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -1256,7 +1256,7 @@
     "incomplete": "Incompleto",
     "edit_item": "editar",
     "mint_item": "crear",
-    "remove_item": "Eliminar item",
+    "delete_item": "Eliminar item",
     "edit_price": "Editar precio",
     "see_details": "Ver detalles",
     "edit_urn": "Editar URN",

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -1256,7 +1256,7 @@
     "incomplete": "Incompleto",
     "edit_item": "editar",
     "mint_item": "crear",
-    "remove_from_collection": "Eliminar de la colección",
+    "remove_item": "Eliminar item",
     "edit_price": "Editar precio",
     "see_details": "Ver detalles",
     "edit_urn": "Editar URN",

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -1238,7 +1238,7 @@
     "incomplete": "不完整",
     "edit_item": "编辑",
     "mint_item": "铸币",
-    "remove_item": "除去项目",
+    "delte_item": "删除项目",
     "edit_price": "修改价格",
     "see_details": "查看详细信息",
     "edit_urn": "编辑 URN",

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -1238,7 +1238,7 @@
     "incomplete": "不完整",
     "edit_item": "编辑",
     "mint_item": "铸币",
-    "remove_from_collection": "从收藏中删除",
+    "remove_item": "除去项目",
     "edit_price": "修改价格",
     "see_details": "查看详细信息",
     "edit_urn": "编辑 URN",


### PR DESCRIPTION
This PR updates the single items section, avoid creating new single items and lets the users move the currents to existing collections or delete them.

* Disable ability to create new single items
![image](https://user-images.githubusercontent.com/3170051/203167845-e2e46dde-3fa4-4035-9f10-79bdfc63cfea.png)

* Replace "Remove from collection" action in dropdown with "Remove item"
![image](https://user-images.githubusercontent.com/3170051/203168025-5c5c7ee7-3d19-4f7e-8cb1-3e2b10aff231.png)

* Add confirm to the Remove item action
![image](https://user-images.githubusercontent.com/3170051/203168087-ffefb01d-fa8c-47e7-9acd-58274eac6f66.png)

* Remove Collections/Single Items tabs if the user has no single items
    * ![image](https://user-images.githubusercontent.com/3170051/203168245-666e9a3a-c3f1-4a7b-803b-ba248b67bbb7.png)
    * ![image](https://user-images.githubusercontent.com/3170051/203168309-89dd4b5c-b5e8-4833-a8d3-2f50695269dc.png)



Closes #2346 