### PR TITLE
fix: mobile homepage unity compatibility

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -80,8 +80,5 @@
     </div>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <script src="%PUBLIC_URL%/unity/Build/hls.min.js"></script>
-    <script src="%PUBLIC_URL%/editor.js"></script>
-    <script src="%PUBLIC_URL%/UnityLoader.js"></script>
   </body>
 </html>

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -77,9 +77,8 @@ class Preview extends React.Component<Props & CollectedProps> {
     try {
       isDCLInitialized = true
       window.devicePixelRatio = 1 // without this unity blows up majestically 💥🌈🦄🔥🤷🏼‍♂️
-      await injectScript(`${PUBLIC_URL}/unity/Build/hls.min.js`)
-      await injectScript(`${PUBLIC_URL}/editor.js`)
-      await injectScript(`${PUBLIC_URL}/UnityLoader.js`)
+      const scriptsURLs = ['unity/Build/hls.min.js', 'editor.js', 'UnityLoader.js']
+      await Promise.all<void>(scriptsURLs.map(script => injectScript(`${PUBLIC_URL}/${script}`)))
       await editorWindow.editor.initEngine(this.canvasContainer.current, PUBLIC_URL + '/unity/Build/unity.json')
       if (!unityDebugParams) {
         canvas = await editorWindow.editor.getDCLCanvas()

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -7,6 +7,7 @@ import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { ASSET_TYPE } from 'components/AssetCard/AssetCard.dnd'
 import { PreviewType } from 'modules/editor/types'
 import { convertToUnityKeyboardEvent } from 'modules/editor/utils'
+import { injectScript } from 'routing/utils'
 import { previewTarget, collect, CollectedProps } from './Preview.dnd'
 import { EditorWindow, Props } from './Preview.types'
 import animationData from './loader.json'
@@ -76,6 +77,9 @@ class Preview extends React.Component<Props & CollectedProps> {
     try {
       isDCLInitialized = true
       window.devicePixelRatio = 1 // without this unity blows up majestically 💥🌈🦄🔥🤷🏼‍♂️
+      await injectScript(`${PUBLIC_URL}/unity/Build/hls.min.js`)
+      await injectScript(`${PUBLIC_URL}/editor.js`)
+      await injectScript(`${PUBLIC_URL}/UnityLoader.js`)
       await editorWindow.editor.initEngine(this.canvasContainer.current, PUBLIC_URL + '/unity/Build/unity.json')
       if (!unityDebugParams) {
         canvas = await editorWindow.editor.getDCLCanvas()

--- a/src/lib/urn.ts
+++ b/src/lib/urn.ts
@@ -36,10 +36,6 @@ const collectionsSuffixMatcher = '((?<=collections-v2:)(?<collectionAddress>0x[a
 const thirdPartySuffixMatcher =
   '((?<=collections-thirdparty:)(?<thirdPartyName>[^:|\\s]+)(:(?<thirdPartyCollectionId>[^:|\\s]+))?(:(?<thirdPartyTokenId>[^:|\\s]+))?)'
 
-const urnRegExp = new RegExp(
-  `${baseMatcher}:${protocolMatcher}:${typeMatcher}:(?<suffix>${baseAvatarsSuffixMatcher}|${collectionsSuffixMatcher}|${thirdPartySuffixMatcher})`
-)
-
 export enum URNProtocol {
   MAINNET = 'mainnet',
   GOERLI = 'goerli',
@@ -122,6 +118,9 @@ export function isThirdParty(urn?: string) {
 }
 
 export function decodeURN(urn: URN): DecodedURN {
+  const urnRegExp = new RegExp(
+    `${baseMatcher}:${protocolMatcher}:${typeMatcher}:(?<suffix>${baseAvatarsSuffixMatcher}|${collectionsSuffixMatcher}|${thirdPartySuffixMatcher})`
+  )
   const matches = urnRegExp.exec(urn)
 
   if (!matches || !matches.groups) {

--- a/src/routing/Routes.tsx
+++ b/src/routing/Routes.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { Switch, Route, Redirect } from 'react-router-dom'
+import isMobile from 'ismobilejs'
 import { Center, Page, Responsive } from 'decentraland-ui'
 import Intercom from 'decentraland-dapps/dist/components/Intercom'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
@@ -42,6 +43,9 @@ import { isDevelopment } from 'lib/environment'
 
 import { Props, State } from './Routes.types'
 import { config } from 'config'
+import { injectScript } from './utils'
+
+const PUBLIC_URL = process.env.PUBLIC_URL
 
 export default class Routes extends React.Component<Props, State> {
   state = {
@@ -58,6 +62,11 @@ export default class Routes extends React.Component<Props, State> {
 
   componentDidMount() {
     document.body.classList.remove('loading-overlay')
+    if (!isMobile().any) {
+      injectScript(`${PUBLIC_URL}/unity/Build/hls.min.js`)
+      injectScript(`${PUBLIC_URL}/editor.js`)
+      injectScript(`${PUBLIC_URL}/UnityLoader.js`)
+    }
   }
 
   renderMaintainancePage() {

--- a/src/routing/Routes.tsx
+++ b/src/routing/Routes.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { Switch, Route, Redirect } from 'react-router-dom'
-import isMobile from 'ismobilejs'
 import { Center, Page, Responsive } from 'decentraland-ui'
 import Intercom from 'decentraland-dapps/dist/components/Intercom'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
@@ -43,9 +42,6 @@ import { isDevelopment } from 'lib/environment'
 
 import { Props, State } from './Routes.types'
 import { config } from 'config'
-import { injectScript } from './utils'
-
-const PUBLIC_URL = process.env.PUBLIC_URL
 
 export default class Routes extends React.Component<Props, State> {
   state = {
@@ -62,11 +58,6 @@ export default class Routes extends React.Component<Props, State> {
 
   componentDidMount() {
     document.body.classList.remove('loading-overlay')
-    if (!isMobile().any) {
-      injectScript(`${PUBLIC_URL}/unity/Build/hls.min.js`)
-      injectScript(`${PUBLIC_URL}/editor.js`)
-      injectScript(`${PUBLIC_URL}/UnityLoader.js`)
-    }
   }
 
   renderMaintainancePage() {

--- a/src/routing/utils.ts
+++ b/src/routing/utils.ts
@@ -105,3 +105,13 @@ export function getSortOrder(value: string | null | undefined, defaultValue: 'de
 
   return value as 'desc' | 'asc'
 }
+
+export function injectScript(url: string) {
+  const script = document.createElement('script')
+
+  script.src = url
+  script.type = 'text/javascript'
+  script.async = true
+
+  document.body.appendChild(script)
+}

--- a/src/routing/utils.ts
+++ b/src/routing/utils.ts
@@ -106,12 +106,17 @@ export function getSortOrder(value: string | null | undefined, defaultValue: 'de
   return value as 'desc' | 'asc'
 }
 
-export function injectScript(url: string) {
-  const script = document.createElement('script')
+export async function injectScript(url: string) {
+  return new Promise<void>((resolve, reject) => {
+    const script = document.createElement('script')
 
-  script.src = url
-  script.type = 'text/javascript'
-  script.async = true
+    script.src = url
+    script.type = 'text/javascript'
+    script.async = true
 
-  document.body.appendChild(script)
+    document.body.appendChild(script)
+
+    script.onload = () => resolve()
+    script.onerror = () => reject(`Error loading the script: ${url}`)
+  })
 }


### PR DESCRIPTION
This PR avoids loading unity scripts in mobile browsers because the scenes editor is only available for the desktop experience.

Closes #2441