### PR TITLE
chore: Avoid install git hooks on CI/CD

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -24,6 +24,8 @@ jobs:
           only-update-versions: true
       - name: Install
         run: npm ci --legacy-peer-deps
+        env:
+          HUSKY: 0
       - name: Build
         run: npm run build
         env:


### PR DESCRIPTION
This PR adds `HUSKY=0` to env vars when installing dependencies to avoid installing git hooks on CI/CD