### PR TITLE
fix: Homepage overview title vertical alignment

### DIFF
--- a/src/components/HomePage/HomePage.css
+++ b/src/components/HomePage/HomePage.css
@@ -9,10 +9,13 @@
 }
 
 .HomePage > .ui.container > .title {
-  margin-top: 132px;
-  margin-bottom: 40px;
+  margin: 60px 0px;
   font-size: 28px;
   line-height: 34px;
+}
+
+.HomePage > .ui.container > .ui.cards {
+  margin-top: 0;
 }
 
 .HomePage > .ui.container > .ui.cards > .ui.card {


### PR DESCRIPTION
This PR fixes the Homepage overview title vertical alignment.

![image](https://user-images.githubusercontent.com/3170051/204819965-fef4d3c8-05d6-433c-8901-3dee3152b3e9.png)
