### PR TITLE
fix: Load intercom when adblockers on

### DIFF
--- a/src/components/Intercom/Intercom.tsx
+++ b/src/components/Intercom/Intercom.tsx
@@ -2,27 +2,26 @@ import React, { useState, useCallback, useEffect } from 'react'
 import IntercomWidget from 'decentraland-dapps/dist/components/Intercom'
 import { getAnalytics, getAnonymousId } from 'decentraland-dapps/dist/modules/analytics/utils'
 import { config } from 'config'
+import { IntercomUserData } from './Intercom.types'
 
 const APP_ID = config.get('INTERCOM_APP_ID', '')
 const analytics = getAnalytics()
 
 export const Intercom: React.FC = () => {
-  const [dclAnonymousUserID, setDclAnonymousUserID] = useState('')
+  const [intercomUserData, setIntercomUserData] = useState<IntercomUserData>()
 
   const analyticsReadyCallback = useCallback(() => {
     const dclAnonymousUserID = getAnonymousId()
     if (dclAnonymousUserID) {
-      setDclAnonymousUserID(dclAnonymousUserID)
+      setIntercomUserData({ ...intercomUserData, anon_id: dclAnonymousUserID })
     }
-  }, [])
+  }, [intercomUserData])
 
   useEffect(() => {
     analytics.ready(analyticsReadyCallback)
   }, [analyticsReadyCallback])
 
-  return dclAnonymousUserID ? (
-    <IntercomWidget appId={APP_ID} data={{ anon_id: dclAnonymousUserID }} settings={{ alignment: 'right' }} />
-  ) : null
+  return <IntercomWidget appId={APP_ID} data={intercomUserData} settings={{ alignment: 'right' }} />
 }
 
 export default Intercom

--- a/src/components/Intercom/Intercom.types.ts
+++ b/src/components/Intercom/Intercom.types.ts
@@ -1,0 +1,3 @@
+export interface IntercomUserData {
+  anon_id: string | undefined
+}


### PR DESCRIPTION
This PR fixes intercom loading when adblockers are on. The current component implementation depends on the segment `anon_id` field, but if an adblocker is on, the segment library won't load, and the intercom component will be closed.