### PR TITLE
fix: add ellipsis to large urn in third party collections

### DIFF
--- a/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.css
+++ b/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.css
@@ -8,11 +8,22 @@
   width: 100%;
 }
 
+.ThirdPartyCollectionDetailPage .urn-container {
+  max-width: 100%;
+}
+
 .ThirdPartyCollectionDetailPage .urn {
   cursor: pointer;
   font-size: 13px;
   margin-top: 8px;
   color: var(--secondary-text);
+  max-width: 100%;
+}
+
+.ThirdPartyCollectionDetailPage .urn .urn-text {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .ThirdPartyCollectionDetailPage .header-row .ui.header.name {
@@ -37,7 +48,8 @@
 
 .ThirdPartyCollectionDetailPage .section .header-row:hover .edit-collection-name,
 .ThirdPartyCollectionDetailPage .urn:hover .copy {
-  display: inline-block;
+  display: flex;
+  align-items: center;
 }
 
 .ThirdPartyCollectionDetailPage .section .header-row:hover {

--- a/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.tsx
+++ b/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.tsx
@@ -17,7 +17,8 @@ import {
   CheckboxProps,
   Loader,
   Dropdown,
-  DropdownProps
+  DropdownProps,
+  Popup
 } from 'decentraland-ui'
 import { t, T } from 'decentraland-dapps/dist/modules/translation/utils'
 import { ContractName } from 'decentraland-transactions'
@@ -223,13 +224,18 @@ export default class ThirdPartyCollectionDetailPage extends React.PureComponent<
                     </Header>
                     <BuilderIcon name="edit" className="edit-collection-name" />
                   </Row>
-                  <Row>
+                  <Row className="urn-container">
                     <small className="urn">
                       <CopyToClipboard text={collection.urn}>
-                        <div>
-                          {collection.urn}
+                        <Row>
+                          <Popup
+                            content={collection.urn}
+                            position="bottom center"
+                            trigger={<span className="urn-text">{collection.urn}</span>}
+                            on="hover"
+                          />
                           <Icon aria-label="Copy urn" aria-hidden="false" className="link copy" name="copy outline" />
-                        </div>
+                        </Row>
                       </CopyToClipboard>
                     </small>
                   </Row>


### PR DESCRIPTION
This PR fixes the visual error happening when third party collections urn has a width that occupies all available space in the container, causing the copy icon to appear in the next line.

## Before

https://user-images.githubusercontent.com/11800206/205935288-e69a8b72-c6b7-4b13-955f-714f39458957.mov


## After


https://user-images.githubusercontent.com/11800206/205935347-dd7ec89f-3106-4108-99f7-1c73eb03d803.mov


