### PR TITLE
feat: do not reorder items in editor

### DIFF
--- a/src/components/ItemEditorPage/LeftPanel/LeftPanel.tsx
+++ b/src/components/ItemEditorPage/LeftPanel/LeftPanel.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react'
 import { Loader, Tabs } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
-import { sortByName } from 'lib/sort'
-import { isThirdParty } from 'lib/urn'
 import { Collection, CollectionType } from 'modules/collection/types'
 import { CurationStatus } from 'modules/curations/types'
 import { getCollectionType } from 'modules/collection/utils'
@@ -219,7 +217,7 @@ export default class LeftPanel extends React.PureComponent<Props, State> {
                   ) : null}
                   {showItems ? (
                     <Items
-                      items={!collection || !isThirdParty(collection.urn) ? items.sort(sortByName) : items}
+                      items={items}
                       totalItems={totalItems || items.length}
                       hasHeader={!selectedCollectionId && collections.length > 0}
                       selectedItemId={selectedItemId}


### PR DESCRIPTION
This PR removes ordering done in the ui for the collections items in editor so that the order of the items remains the same one as in the collection detail page.

Closes #2409 

### Before
#### Editor
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/11800206/206064051-79c380cd-2517-47eb-b684-787598a6226a.png">

#### Collection detail
<img width="1156" alt="image" src="https://user-images.githubusercontent.com/11800206/206064018-50685d03-8306-40bf-91e8-24ca09ad4bee.png">


### After
#### Editor
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/11800206/206063878-de7815b2-f7dd-48d4-9531-ae017d87e32f.png">
#### Collection detail
<img width="1331" alt="image" src="https://user-images.githubusercontent.com/11800206/206063947-db0541b3-34a2-4394-a1a6-38e3a64cae5b.png">
