### PR TITLE
feat: change operator description to better understand the behavior

### DIFF
--- a/src/components/LandOperatorPage/LandOperatorPage.tsx
+++ b/src/components/LandOperatorPage/LandOperatorPage.tsx
@@ -14,7 +14,16 @@ export default class LandOperatorPage extends React.PureComponent<Props> {
           <LandAction
             land={land}
             title={t('operator_page.title')}
-            subtitle={<T id="operator_page.subtitle" values={{ name: <strong>{land.name}</strong> }} />}
+            subtitle={
+              <T
+                id="operator_page.subtitle"
+                values={{
+                  name: <strong>{land.name}</strong>,
+                  b: (chunks: string) => <strong>{chunks}</strong>,
+                  br: () => <br />
+                }}
+              />
+            }
           >
             <LandOperatorForm land={land} onSetOperator={onSetOperator} />
           </LandAction>

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -819,7 +819,7 @@
   },
   "operator_page": {
     "title": "Set Operator",
-    "subtitle": "Your are setting an operator for {name}.",
+    "subtitle": "You are setting an operator for {name}.<br></br>Operators can <b>only</b> deploy scenes to the LAND.",
     "address": "Address",
     "undo": "Undo",
     "revoke": "Revoke",

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -786,7 +786,7 @@
     "step_two_message": "Por favor inicia sesión con tu email para poder encontrar las escenas que necesitan ser migradas.",
     "step_two_cta": "Iniciar sesión",
     "step_three_title": "Conecta tu billetera",
-    "step_three_message": "Por favor conecta tu billetera para continuar. Si no tienes una bbilletera, ahi hay una {link} para conseguir una.",
+    "step_three_message": "Por favor conecta tu billetera para continuar. Si no tienes una billetera, ahi hay una {link} para conseguir una.",
     "step_three_link": "guía para principiantes",
     "step_three_cta": "Conectar",
     "step_three_error": "Por favor instala {metamask} u otra billetera de Ethereum para continuar.",
@@ -797,7 +797,7 @@
   },
   "operator_page": {
     "title": "Asignar Operador",
-    "subtitle": "Estas asignando un operador para {name}.",
+    "subtitle": "Estas asignando un operador para {name}.<br></br>Los operadores <b>solo</b> pueden publicar escenas en la tierra.",
     "address": "Dirección",
     "undo": "Deshacer",
     "revoke": "Revocar",

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -783,7 +783,7 @@
   },
   "operator_page": {
     "title": "设定操作者",
-    "subtitle": "您正在为{name}设置一个操作者。",
+    "subtitle": "您正在为 {name} 设置操作员。<br></br>o操作员可以<b>仅</b>将场景部署到土地上。",
     "address": "地址",
     "undo": "复原",
     "revoke": "撤消",


### PR DESCRIPTION
This PR changes the description shown when assigning an operator to the land so that the user better understands the permissions this operator has.

Closes #2419 

#### en
<img width="1187" alt="image" src="https://user-images.githubusercontent.com/11800206/206066943-cc225678-5f11-466a-a066-f3650a98ea5c.png">

#### es
<img width="1150" alt="image" src="https://user-images.githubusercontent.com/11800206/206066970-32d37eaa-c0ca-44d0-b3ad-32fc3a6141bf.png">


#### zh
<img width="1158" alt="image" src="https://user-images.githubusercontent.com/11800206/206067143-9e579792-e553-4ef4-825f-4598c4714e35.png">
