### PR TITLE
Feat/cache move items collections request

### DIFF
--- a/src/components/CollectionDetailPage/CollectionDetailPage.container.ts
+++ b/src/components/CollectionDetailPage/CollectionDetailPage.container.ts
@@ -5,7 +5,7 @@ import { getData as getWallet } from 'decentraland-dapps/dist/modules/wallet/sel
 import { RootState } from 'modules/common/types'
 import { getCollectionId } from 'modules/location/selectors'
 import { getCollection, isOnSaleLoading, getLoading as getLoadingCollection } from 'modules/collection/selectors'
-import { FETCH_COLLECTIONS_REQUEST, DELETE_COLLECTION_REQUEST } from 'modules/collection/actions'
+import { DELETE_COLLECTION_REQUEST } from 'modules/collection/actions'
 import { openModal } from 'modules/modal/actions'
 import { getCollectionItems } from 'modules/item/selectors'
 import { ItemType } from 'modules/item/types'
@@ -23,9 +23,7 @@ const mapState = (state: RootState): MapStateProps => {
     collection,
     isOnSaleLoading: isOnSaleLoading(state),
     items: getCollectionItems(state, collectionId),
-    isLoading:
-      isLoadingType(getLoadingCollection(state), FETCH_COLLECTIONS_REQUEST) ||
-      isLoadingType(getLoadingCollection(state), DELETE_COLLECTION_REQUEST)
+    isLoading: isLoadingType(getLoadingCollection(state), DELETE_COLLECTION_REQUEST)
   }
 }
 

--- a/src/components/CollectionDropdown/CollectionDropdown.container.ts
+++ b/src/components/CollectionDropdown/CollectionDropdown.container.ts
@@ -1,18 +1,21 @@
 import { connect } from 'react-redux'
 import { getAddress } from 'decentraland-dapps/dist/modules/wallet/selectors'
+import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 import { RootState } from 'modules/common/types'
 import { getAuthorizedCollections } from 'modules/collection/selectors'
-import { fetchCollectionsRequest } from 'modules/collection/actions'
+import { fetchCollectionsRequest, FETCH_COLLECTIONS_REQUEST } from 'modules/collection/actions'
+import { getLoading as getLoadingCollection } from 'modules/collection/selectors'
 import { MapStateProps, MapDispatchProps, MapDispatch } from './CollectionDropdown.types'
 import ItemDropdown from './CollectionDropdown'
 
 const mapState = (state: RootState): MapStateProps => ({
   address: getAddress(state),
-  collections: getAuthorizedCollections(state)
+  collections: getAuthorizedCollections(state),
+  isLoading: isLoadingType(getLoadingCollection(state), FETCH_COLLECTIONS_REQUEST)
 })
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
-  onFetchCollections: (address, params) => dispatch(fetchCollectionsRequest(address, params))
+  onFetchCollections: (address, params) => dispatch(fetchCollectionsRequest(address, params, true))
 })
 
 export default connect(mapState, mapDispatch)(ItemDropdown)

--- a/src/components/CollectionDropdown/CollectionDropdown.tsx
+++ b/src/components/CollectionDropdown/CollectionDropdown.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Dropdown, DropdownItemProps, DropdownProps, Row } from 'decentraland-ui'
+import { Dropdown, DropdownItemProps, DropdownProps, Loader, Row } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Props } from './CollectionDropdown.types'
 import './CollectionDropdown.css'
@@ -47,9 +47,11 @@ export default class CollectionDropdown extends React.PureComponent<Props> {
   }
 
   render() {
-    const { isDisabled } = this.props
+    const { isDisabled, isLoading } = this.props
     const options = this.getOptions()
-    return (
+    return isLoading ? (
+      <Loader active size="mini" />
+    ) : (
       <Dropdown
         className="CollectionDropdown"
         trigger={this.renderTrigger(options)}

--- a/src/components/CollectionDropdown/CollectionDropdown.types.ts
+++ b/src/components/CollectionDropdown/CollectionDropdown.types.ts
@@ -12,7 +12,7 @@ export type Props = {
   fetchCollectionParams?: FetchCollectionsParams
   onChange: (collection: Collection) => void
   isDisabled?: boolean
-  onFetchCollections: typeof fetchCollectionsRequest,
+  onFetchCollections: typeof fetchCollectionsRequest
   isLoading: boolean
 }
 

--- a/src/components/CollectionDropdown/CollectionDropdown.types.ts
+++ b/src/components/CollectionDropdown/CollectionDropdown.types.ts
@@ -12,10 +12,11 @@ export type Props = {
   fetchCollectionParams?: FetchCollectionsParams
   onChange: (collection: Collection) => void
   isDisabled?: boolean
-  onFetchCollections: typeof fetchCollectionsRequest
+  onFetchCollections: typeof fetchCollectionsRequest,
+  isLoading: boolean
 }
 
-export type MapStateProps = Pick<Props, 'collections' | 'address'>
+export type MapStateProps = Pick<Props, 'collections' | 'address' | 'isLoading'>
 export type MapDispatchProps = Pick<Props, 'onFetchCollections'>
 export type MapDispatch = Dispatch<FetchCollectionsRequestAction>
 export type OwnProps = Pick<Props, 'filter' | 'onChange'>

--- a/src/components/Modals/MoveItemToAnotherCollectionModal/MoveItemToAnotherCollectionModal.container.ts
+++ b/src/components/Modals/MoveItemToAnotherCollectionModal/MoveItemToAnotherCollectionModal.container.ts
@@ -1,10 +1,10 @@
 import { connect } from 'react-redux'
+import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 import { RootState } from 'modules/common/types'
 import { SAVE_ITEM_REQUEST, setItemCollection } from 'modules/item/actions'
 import { getLoading } from 'modules/item/selectors'
 import { MapStateProps, MapDispatchProps, MapDispatch } from './MoveItemToAnotherCollectionModal.types'
 import MoveItemToAnotherCollectionModal from './MoveItemToAnotherCollectionModal'
-import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 
 const mapState = (state: RootState): MapStateProps => ({
   isLoading: isLoadingType(getLoading(state), SAVE_ITEM_REQUEST)

--- a/src/components/Modals/MoveItemToAnotherCollectionModal/MoveItemToAnotherCollectionModal.tsx
+++ b/src/components/Modals/MoveItemToAnotherCollectionModal/MoveItemToAnotherCollectionModal.tsx
@@ -1,12 +1,11 @@
 import React, { useState, useCallback } from 'react'
-import { ModalNavigation, ModalContent, ModalActions, Button, ButtonProps } from 'decentraland-ui'
+import { ModalNavigation, ModalContent, ModalActions, Button } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import Modal from 'decentraland-dapps/dist/containers/Modal'
-import { Props, MoveItemToAnotherCollectionModalMetadata } from './MoveItemToAnotherCollectionModal.types'
 import { Collection } from 'modules/collection/types'
-import CollectionDropdown from 'components/CollectionDropdown'
 import { isTPCollection } from 'modules/collection/utils'
-
+import CollectionDropdown from 'components/CollectionDropdown'
+import { Props, MoveItemToAnotherCollectionModalMetadata } from './MoveItemToAnotherCollectionModal.types'
 import './MoveItemToAnotherCollectionModal.css'
 
 export const MoveItemToAnotherCollectionModal: React.FC<Props> = props => {
@@ -18,16 +17,12 @@ export const MoveItemToAnotherCollectionModal: React.FC<Props> = props => {
     setCollection(collection)
   }, [])
 
-  const handleSubmit = useCallback(
-    (_event: React.MouseEvent<HTMLButtonElement>, _data: ButtonProps) => {
-      const { metadata, onSubmit } = props
-      const { item } = metadata as MoveItemToAnotherCollectionModalMetadata
-      if (collection) {
-        onSubmit(item, collection.id)
-      }
-    },
-    [collection, props]
-  )
+  const handleSubmit = useCallback(() => {
+    const { onSubmit } = props
+    if (collection) {
+      onSubmit(item, collection.id)
+    }
+  }, [collection, item, props])
 
   return (
     <Modal name={name} onClose={onClose} size="tiny" closeOnDimmerClick={false}>
@@ -38,7 +33,7 @@ export const MoveItemToAnotherCollectionModal: React.FC<Props> = props => {
       />
       <ModalContent>
         <>
-          <p className="collection-dropdown-label">Collection</p>
+          <p className="collection-dropdown-label">{t('item.collection')}</p>
           <CollectionDropdown
             value={collection}
             onChange={handleChangeCollection}

--- a/src/modules/collection/actions.ts
+++ b/src/modules/collection/actions.ts
@@ -12,10 +12,10 @@ export const FETCH_COLLECTIONS_REQUEST = '[Request] Fetch Collections'
 export const FETCH_COLLECTIONS_SUCCESS = '[Success] Fetch Collections'
 export const FETCH_COLLECTIONS_FAILURE = '[Failure] Fetch Collections'
 
-export const fetchCollectionsRequest = (address?: string, params?: FetchCollectionsParams) =>
-  action(FETCH_COLLECTIONS_REQUEST, { address, params })
-export const fetchCollectionsSuccess = (collections: Collection[], paginationStats?: PaginationStats) =>
-  action(FETCH_COLLECTIONS_SUCCESS, { collections, paginationStats })
+export const fetchCollectionsRequest = (address?: string, params?: FetchCollectionsParams, useCachedResults = false) =>
+  action(FETCH_COLLECTIONS_REQUEST, { address, params, useCachedResults })
+export const fetchCollectionsSuccess = (collections: Collection[], paginationStats?: PaginationStats, params?: FetchCollectionsParams) =>
+  action(FETCH_COLLECTIONS_SUCCESS, { collections, paginationStats, params })
 export const fetchCollectionsFailure = (error: string) => action(FETCH_COLLECTIONS_FAILURE, { error })
 
 export type FetchCollectionsRequestAction = ReturnType<typeof fetchCollectionsRequest>

--- a/src/modules/collection/reducer.spec.ts
+++ b/src/modules/collection/reducer.spec.ts
@@ -1,7 +1,8 @@
 import { fetchTransactionSuccess } from 'decentraland-dapps/dist/modules/transaction/actions'
+import { FetchCollectionsParams } from 'lib/api/builder'
 import { PaginationStats } from 'lib/api/pagination'
 import { closeAllModals, closeModal } from 'modules/modal/actions'
-import { fetchCollectionsSuccess, PUBLISH_COLLECTION_SUCCESS } from './actions'
+import { fetchCollectionsRequest, fetchCollectionsSuccess, PUBLISH_COLLECTION_SUCCESS } from './actions'
 import { collectionReducer as reducer, CollectionState } from './reducer'
 import { Collection } from './types'
 import { toCollectionObject } from './utils'
@@ -47,6 +48,44 @@ describe('when FETCH_TRANSACTION_SUCCESS', () => {
       expect(state.data.id.createdAt).toBe(mockNow)
       expect(state.data.id.reviewedAt).toBe(mockNow)
       expect(state.data.id.updatedAt).toBe(mockNow)
+    })
+  })
+})
+
+describe('when FETCH_COLLECTIONS_REQUEST', () => {
+  const anExistingCollectionId = 'id'
+  let mockedFetchCollectionParams: FetchCollectionsParams
+  let initialState: CollectionState
+  beforeEach(() => {
+    mockedFetchCollectionParams = {
+      assignee: 'anAssignee',
+      isPublished: false
+    } as FetchCollectionsParams
+    initialState = {
+      data: {
+        [anExistingCollectionId]: {
+          id: 'anExistingCollectionId'
+        }
+      },
+      lastFetchParams: mockedFetchCollectionParams,
+      loading: []
+    } as any
+  })
+
+  describe('and it sends the flag to re-use existing results and same parameters', () => {
+    it('should not set the loading state', () => {
+      const state = reducer(initialState, fetchCollectionsRequest(undefined, mockedFetchCollectionParams, true))
+      expect(reducer(initialState, fetchCollectionsRequest(undefined, mockedFetchCollectionParams, true))).toEqual(state)
+    })
+  })
+
+  describe('and it does not send the flag to re-use existing results', () => {
+    it('should set the loading state', () => {
+      const state = reducer(initialState, fetchCollectionsRequest(undefined, mockedFetchCollectionParams))
+      expect(reducer(initialState, fetchCollectionsRequest(undefined, mockedFetchCollectionParams))).toEqual({
+        ...state,
+        loading: [fetchCollectionsRequest(undefined, mockedFetchCollectionParams)]
+      })
     })
   })
 })

--- a/src/modules/collection/sagas.spec.ts
+++ b/src/modules/collection/sagas.spec.ts
@@ -86,6 +86,7 @@ import {
 import { collectionSaga } from './sagas'
 import { Collection } from './types'
 import { getData, getPaginationData as getCollectionPaginationData, getLastFetchParams } from './selectors'
+import { CollectionPaginationData } from './reducer'
 import { UNSYNCED_COLLECTION_ERROR_PREFIX } from './utils'
 
 const getCollectionMock = (props: Partial<Collection> = {}): Collection =>
@@ -1868,17 +1869,51 @@ describe('when handling the fetch of collections', () => {
       }
     })
 
-    it('should put the success action with the data without pagination information', () => {
-      return expectSaga(collectionSaga, mockBuilder, mockBuilderClient, mockCatalyst)
-        .provide([
-          [select(getWalletItems), []],
-          [select(getLastFetchParams), mockedFetchParameters],
-          [select(getData), alreadyFetchedCollections],
-          [select(getCollectionPaginationData), undefined]
-        ])
-        .put(fetchCollectionsSuccess([collection], undefined, mockedFetchParameters))
-        .dispatch(fetchCollectionsRequest(undefined, mockedFetchParameters, true))
-        .run({ silenceTimeout: true })
+    describe('and it has pagination information', () => {
+      let paginationData: CollectionPaginationData
+      let paginationStats: PaginationStats
+      beforeEach(() => {
+        paginationData = {
+          currentPage: 1,
+          ids: [],
+          limit: 1,
+          total: 1,
+          totalPages: 1
+        }
+        paginationStats = {
+          limit: 1,
+          page: 1,
+          pages: 1,
+          total: 1
+        }
+      })
+      it('should put the success action with the data without pagination information', () => {
+        return expectSaga(collectionSaga, mockBuilder, mockBuilderClient, mockCatalyst)
+          .provide([
+            [select(getWalletItems), []],
+            [select(getLastFetchParams), mockedFetchParameters],
+            [select(getData), alreadyFetchedCollections],
+            [select(getCollectionPaginationData), paginationData]
+          ])
+          .put(fetchCollectionsSuccess([collection], paginationStats, mockedFetchParameters))
+          .dispatch(fetchCollectionsRequest(undefined, mockedFetchParameters, true))
+          .run({ silenceTimeout: true })
+      })
+    })
+
+    describe('and it does not have pagination information', () => {
+      it('should put the success action with the data without pagination information', () => {
+        return expectSaga(collectionSaga, mockBuilder, mockBuilderClient, mockCatalyst)
+          .provide([
+            [select(getWalletItems), []],
+            [select(getLastFetchParams), mockedFetchParameters],
+            [select(getData), alreadyFetchedCollections],
+            [select(getCollectionPaginationData), undefined]
+          ])
+          .put(fetchCollectionsSuccess([collection], undefined, mockedFetchParameters))
+          .dispatch(fetchCollectionsRequest(undefined, mockedFetchParameters, true))
+          .run({ silenceTimeout: true })
+      })
     })
   })
 })

--- a/src/modules/collection/sagas.ts
+++ b/src/modules/collection/sagas.ts
@@ -219,7 +219,6 @@ export function* collectionSaga(legacyBuilderClient: BuilderAPI, client: Builder
         }
       }
     } catch (error) {
-      console.log('error: ', error)
       yield put(fetchCollectionsFailure(error.message))
     }
   }

--- a/src/modules/collection/selectors.ts
+++ b/src/modules/collection/selectors.ts
@@ -30,6 +30,7 @@ export const getState = (state: RootState) => state.collection
 export const getData = (state: RootState) => getState(state).data
 export const getLoading = (state: RootState) => getState(state).loading
 export const getPaginationData = (state: RootState) => getState(state).pagination
+export const getLastFetchParams = (state: RootState) => getState(state).lastFetchParams
 export const getError = (state: RootState) => getState(state).error
 
 export const getPaginatedCollections = (state: RootState, pageSize?: number) => {

--- a/src/modules/collection/utils.spec.ts
+++ b/src/modules/collection/utils.spec.ts
@@ -4,8 +4,16 @@ import { buildCatalystItemURN, buildThirdPartyURN } from 'lib/urn'
 import { Item } from 'modules/item/types'
 import { Collection, CollectionType } from 'modules/collection/types'
 import { Mint } from './types'
-import { getTotalAmountOfMintedItems, isLocked, getCollectionType, isTPCollection, getTPThresholdToReview } from './utils'
+import {
+  getTotalAmountOfMintedItems,
+  isLocked,
+  getCollectionType,
+  isTPCollection,
+  getTPThresholdToReview,
+  toPaginationStats
+} from './utils'
 import { MAX_TP_ITEMS_TO_REVIEW, MIN_TP_ITEMS_TO_REVIEW, TP_TRESHOLD_TO_REVIEW } from './constants'
+import { CollectionPaginationData } from './reducer'
 
 jest.mock('modules/item/export')
 
@@ -202,6 +210,24 @@ describe('when getting the threshold of items to review for a TP collection', ()
     })
     it('should return the minum percentage to review of the collection', () => {
       expect(getTPThresholdToReview(totalItems)).toBe(MAX_TP_ITEMS_TO_REVIEW)
+    })
+  })
+})
+
+describe('when transforming a CollectionPaginationData to PaginationStats', () => {
+  const collectionPaginationData: CollectionPaginationData = {
+    currentPage: 1,
+    ids: ['1', '2', '3'],
+    limit: 10,
+    total: 1,
+    totalPages: 1
+  }
+  it('should return a PaginationStats instance with the right data', () => {
+    expect(toPaginationStats(collectionPaginationData)).toStrictEqual({
+      limit: collectionPaginationData.limit,
+      total: collectionPaginationData.total,
+      pages: collectionPaginationData.totalPages,
+      page: collectionPaginationData.currentPage
     })
   })
 })

--- a/src/modules/collection/utils.ts
+++ b/src/modules/collection/utils.ts
@@ -3,11 +3,13 @@ import { ContractName, getContract } from 'decentraland-transactions'
 import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 import { config } from 'config'
 import { locations } from 'routing/locations'
+import { PaginationStats } from 'lib/api/pagination'
 import { isEqual, includes } from 'lib/address'
 import { decodeURN, isThirdParty, URNType } from 'lib/urn'
 import { Item, SyncStatus } from 'modules/item/types'
 import { Collection, Access, Mint, CollectionType } from './types'
 import { MAX_TP_ITEMS_TO_REVIEW, MIN_TP_ITEMS_TO_REVIEW, TP_TRESHOLD_TO_REVIEW } from './constants'
+import { CollectionPaginationData } from './reducer'
 
 export const UNSYNCED_COLLECTION_ERROR_PREFIX = 'UnsyncedCollection:'
 
@@ -170,3 +172,13 @@ export class ThirdPartyCurationUpdateError extends Error {
 }
 
 export type ThirdPartyError = ThirdPartyBuildEntityError | ThirdPartyDeploymentError
+
+export const toPaginationStats = (collectionPaginationData: CollectionPaginationData): PaginationStats => {
+  const { limit, currentPage, totalPages, total } = collectionPaginationData
+  return {
+    limit,
+    total,
+    pages: totalPages,
+    page: currentPage
+  }
+}


### PR DESCRIPTION
The Modal that shows the collections where the item can be moved, was fetching all the collections unpublished every single time it was opened, making the background change to a loading spinner and also re-fetching data unnecessary, because it could be re-used.