### PR TITLE
fix: Set rentals contract address in production

### DIFF
--- a/src/config/env/prod.json
+++ b/src/config/env/prod.json
@@ -22,7 +22,7 @@
   "RESOLVER_CONTRACT_ADDRESS": "0x4976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41",
   "CONTROLLER_CONTRACT_ADDRESS": "0x6843291bd86857d97f0d269e698939fb10d60772",
   "REGISTRAR_CONTRACT_ADDRESS": "0x2a187453064356c898cae034eaed119e1663acb8",
-  "RENTALS_CONTRACT_ADDRESS": "0xcc94a49c7a81f59f07e0c381b929c4081c437de2",
+  "RENTALS_CONTRACT_ADDRESS": "0x3a1469499d0be105d4f77045ca403a5f6dc2f3f5",
   "IPFS_URL": "https://ipfs.infura.io:5001/api/v0/add?pin=false",
   "EXPLORER_URL": "https://play.decentraland.org",
   "TRANSACTIONS_API_URL": "https://transactions-api.decentraland.org/v1",

--- a/src/config/env/stg.json
+++ b/src/config/env/stg.json
@@ -22,7 +22,7 @@
   "RESOLVER_CONTRACT_ADDRESS": "0x4976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41",
   "CONTROLLER_CONTRACT_ADDRESS": "0x6843291bd86857d97f0d269e698939fb10d60772",
   "REGISTRAR_CONTRACT_ADDRESS": "0x2a187453064356c898cae034eaed119e1663acb8",
-  "RENTALS_CONTRACT_ADDRESS": "0xcc94a49c7a81f59f07e0c381b929c4081c437de2",
+  "RENTALS_CONTRACT_ADDRESS": "0x3a1469499d0be105d4f77045ca403a5f6dc2f3f5",
   "IPFS_URL": "https://ipfs.infura.io:5001/api/v0/add?pin=false",
   "EXPLORER_URL": "https://play.decentraland.org",
   "TRANSACTIONS_API_URL": "https://transactions-api.decentraland.today/v1",


### PR DESCRIPTION
This PR solves the issue of not being able to set the update operator on a rented LAND due to the UI pointing to the old rentals contract on the production environments.
Contracts site: [https://contracts.decentraland.org/addresses.json](https://contracts.decentraland.org/addresses.json)