### PR TITLE
fix: Only show error when not loading ENS names

### DIFF
--- a/src/components/LoggedInDetailPage/LoggedInDetailPage.tsx
+++ b/src/components/LoggedInDetailPage/LoggedInDetailPage.tsx
@@ -58,10 +58,10 @@ export default class LoggedInDetailPage extends React.PureComponent<Props> {
         <Navbar isFullscreen />
         {hasNavigation ? <Navigation activeTab={activeTab} isFullscreen={isNavigationFullscreen} /> : null}
         <Page className={classNames('LoggedInDetailPage', className)} isFullscreen={isPageFullscreen}>
-          {isLoading && !error ? this.renderLoading() : null}
+          {isLoading ? this.renderLoading() : null}
           {!isLoggedIn && !isLoading && !error ? this.renderLogin() : null}
-          {isLoggedIn && !isLoading && !error ? children : null}
-          {error ? this.renderError() : null}
+          {isLoggedIn && !isLoading ? children : null}
+          {!isLoading && error ? this.renderError() : null}
         </Page>
         <Footer isFullscreen={isFooterFullscreen} />
       </>


### PR DESCRIPTION
This PR fixes an issue that made the error be shown when it shouldn't as it was needed to be waited for the loading state to finish before showing it.