### PR TITLE
fix: Fix authentication requirement when loading ENS names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babylonjs/core": "^4.2.0",
         "@babylonjs/loaders": "^4.2.0",
-        "@dcl/builder-client": "^2.2.0",
+        "@dcl/builder-client": "^2.3.0",
         "@dcl/content-hash-tree": "^1.1.3",
         "@dcl/crypto": "^3.0.1",
         "@dcl/hashing": "^1.1.0",
@@ -2181,9 +2181,9 @@
       }
     },
     "node_modules/@dcl/builder-client": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@dcl/builder-client/-/builder-client-2.2.0.tgz",
-      "integrity": "sha512-/PTvMdRgLQySZoOOa/VUA5Q8uhKd0g9xRzeWGV1t4RkJ51p5ArjouCzVmERD5l64j+cl2UsBf4INsrbsouUu+g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@dcl/builder-client/-/builder-client-2.3.0.tgz",
+      "integrity": "sha512-jCG7UwFnsdQhIF5bcgM5uHXXieTBENUXm7VUJ6Nm0P8cpDjkAlHKtc4EahHmfeSvPf+jWjlHnABHIWWvTZ3/6A==",
       "dependencies": {
         "@dcl/crypto": "^3.0.1",
         "@dcl/hashing": "^1.1.0",
@@ -2204,9 +2204,9 @@
       }
     },
     "node_modules/@dcl/builder-client/node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -6366,9 +6366,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -32140,9 +32140,9 @@
       }
     },
     "@dcl/builder-client": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@dcl/builder-client/-/builder-client-2.2.0.tgz",
-      "integrity": "sha512-/PTvMdRgLQySZoOOa/VUA5Q8uhKd0g9xRzeWGV1t4RkJ51p5ArjouCzVmERD5l64j+cl2UsBf4INsrbsouUu+g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@dcl/builder-client/-/builder-client-2.3.0.tgz",
+      "integrity": "sha512-jCG7UwFnsdQhIF5bcgM5uHXXieTBENUXm7VUJ6Nm0P8cpDjkAlHKtc4EahHmfeSvPf+jWjlHnABHIWWvTZ3/6A==",
       "requires": {
         "@dcl/crypto": "^3.0.1",
         "@dcl/hashing": "^1.1.0",
@@ -32159,9 +32159,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -35299,9 +35299,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@babylonjs/core": "^4.2.0",
     "@babylonjs/loaders": "^4.2.0",
-    "@dcl/builder-client": "^2.2.0",
+    "@dcl/builder-client": "^2.3.0",
     "@dcl/content-hash-tree": "^1.1.3",
     "@dcl/crypto": "^3.0.1",
     "@dcl/hashing": "^1.1.0",


### PR DESCRIPTION
This PR fixes the requirement of having an identity when requesting ENS names by updating the builder client to remove the authentication from those endpoints.