### PR TITLE
fix: Project card gap

### DIFF
--- a/src/components/ProjectCard/ProjectCard.css
+++ b/src/components/ProjectCard/ProjectCard.css
@@ -3,8 +3,6 @@
   width: var(--scenespage-card-width);
   height: var(--scenespage-card-height);
   border-radius: 12px;
-  margin-bottom: var(--scenespage-card-margin);
-  margin-right: var(--scenespage-card-margin);
   background: rgba(var(--bluish-steel-raw), 0.16);
   cursor: pointer;
   display: flex;

--- a/src/components/ScenesPage/ScenesPage.css
+++ b/src/components/ScenesPage/ScenesPage.css
@@ -47,6 +47,7 @@
   display: flex;
   flex-wrap: wrap;
   align-content: flex-start;
+  gap: var(--scenespage-card-margin)
 }
 
 .ScenesPage .project-cards .ProjectCard:nth-child(4n) {
@@ -150,6 +151,7 @@
   display: flex;
   overflow: auto;
   padding-top: 20px;
+  gap: var(--scenespage-card-margin);
 }
 
 .ScenesPage .scene-pool-projects .ProjectCard {


### PR DESCRIPTION
This PR fixes a CSS issue which overlapped some of the cards:
<img width="1140" alt="Screenshot 2023-02-01 at 16 19 35" src="https://user-images.githubusercontent.com/1120791/216083813-d1f753ab-2906-493c-9795-128ebfcbd990.png">
<img width="1789" alt="Screenshot 2023-02-01 at 16 39 34" src="https://user-images.githubusercontent.com/1120791/216089454-658ea646-33a0-435b-a150-8957a12ef124.png">
