### PR TITLE
feat: Add link to collection details in Collection name

### DIFF
--- a/src/components/ItemEditorPage/LeftPanel/Header/Header.css
+++ b/src/components/ItemEditorPage/LeftPanel/Header/Header.css
@@ -13,7 +13,8 @@
   cursor: pointer;
 }
 
-.Header .title {
+.Header .title,
+.Header .title > a {
   flex: 1 1 auto;
   text-align: center;
   text-overflow: ellipsis;
@@ -22,9 +23,11 @@
   line-height: 24px;
   font-weight: bold;
   white-space: nowrap;
+  color: var(--text);
 }
 
-.Header .CollectionBadge {
+.Header .CollectionBadge,
+.Header .CollectionStatus {
   margin-left: 5px;
 }
 

--- a/src/components/ItemEditorPage/LeftPanel/Header/Header.tsx
+++ b/src/components/ItemEditorPage/LeftPanel/Header/Header.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { Link } from 'react-router-dom'
 import { Dropdown, Row } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { locations } from 'routing/locations'
@@ -61,7 +62,8 @@ export default class Header extends React.PureComponent<Props> {
       <>
         <div className={`block ${isFromCollections ? 'close' : 'back'}`} onClick={this.handleBack} />
         <div className="title">
-          {collection.name} <CollectionStatus collection={collection} />
+          <Link to={locations.collectionDetail(collection.id)}>{collection.name}</Link>
+          <CollectionStatus collection={collection} />
         </div>
         {isOwner && !collection.isPublished ? (
           <Dropdown trigger={<div className="block actions" />} inline direction="left">


### PR DESCRIPTION
This PR adds a link to the collection name in the Item Editor, allowing the user to return to the collection's details.