### PR TITLE
feat: Add underline to Collection Name in Item Editor page when hover

### DIFF
--- a/src/components/ItemEditorPage/LeftPanel/Header/Header.css
+++ b/src/components/ItemEditorPage/LeftPanel/Header/Header.css
@@ -26,6 +26,10 @@
   color: var(--text);
 }
 
+.Header .title > a:hover {
+  text-decoration: underline;
+}
+
 .Header .CollectionBadge,
 .Header .CollectionStatus {
   margin-left: 5px;


### PR DESCRIPTION
This PR adds underling to the Collection Name in the Item Editor page when hovering.