### PR TITLE
feat: Hide high congestion error message in the publish collection modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "dcl-scene-writer": "^1.1.2",
         "decentraland": "^3.3.0",
         "decentraland-builder-scripts": "^0.24.0",
-        "decentraland-dapps": "^13.38.1",
+        "decentraland-dapps": "^13.41.0",
         "decentraland-ecs": "file:ecs/decentraland-ecs-6.6.1-20201020183014.commit-bdc29ef-hotfix.tgz",
         "decentraland-experiments": "^1.0.2",
         "decentraland-transactions": "^1.42.0",
@@ -10654,9 +10654,9 @@
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
     },
     "node_modules/decentraland-dapps": {
-      "version": "13.38.1",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.38.1.tgz",
-      "integrity": "sha512-gmF727GHT//PLEYwQ0el//+JHH0v0SGlMX54pW+N2ueqnf/bhvDjqKIhey1NhQcIsdGThBYTvnIiSf2h3Z1E8A==",
+      "version": "13.41.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.41.0.tgz",
+      "integrity": "sha512-nrYJu420VekIsWrxZD3xiDZwF6EeI3y9PUbwv2/EeHDmVaFjogbQgulcZleHnKz7CZE5y1AkdrFm0RvIEbIEvA==",
       "dependencies": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
@@ -39350,9 +39350,9 @@
       }
     },
     "decentraland-dapps": {
-      "version": "13.38.1",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.38.1.tgz",
-      "integrity": "sha512-gmF727GHT//PLEYwQ0el//+JHH0v0SGlMX54pW+N2ueqnf/bhvDjqKIhey1NhQcIsdGThBYTvnIiSf2h3Z1E8A==",
+      "version": "13.41.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.41.0.tgz",
+      "integrity": "sha512-nrYJu420VekIsWrxZD3xiDZwF6EeI3y9PUbwv2/EeHDmVaFjogbQgulcZleHnKz7CZE5y1AkdrFm0RvIEbIEvA==",
       "requires": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dcl-scene-writer": "^1.1.2",
     "decentraland": "^3.3.0",
     "decentraland-builder-scripts": "^0.24.0",
-    "decentraland-dapps": "^13.38.1",
+    "decentraland-dapps": "^13.41.0",
     "decentraland-ecs": "file:ecs/decentraland-ecs-6.6.1-20201020183014.commit-bdc29ef-hotfix.tgz",
     "decentraland-experiments": "^1.0.2",
     "decentraland-transactions": "^1.42.0",

--- a/src/modules/collection/sagas.ts
+++ b/src/modules/collection/sagas.ts
@@ -7,7 +7,7 @@ import { CatalystClient, DeploymentPreparationData } from 'dcl-catalyst-client'
 import { ChainId } from '@dcl/schemas'
 import { generateTree } from '@dcl/content-hash-tree'
 import { BuilderClient, ThirdParty } from '@dcl/builder-client'
-import { ContractData, ContractName, getContract } from 'decentraland-transactions'
+import { ContractData, ContractName, ErrorCode, getContract } from 'decentraland-transactions'
 import { getOpenModals } from 'decentraland-dapps/dist/modules/modal/selectors'
 import { ModalState } from 'decentraland-dapps/dist/modules/modal/reducer'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
@@ -420,7 +420,8 @@ export function* collectionSaga(legacyBuilderClient: BuilderAPI, client: Builder
 
       yield put(publishCollectionSuccess(collection, items, maticChainId, txHash))
     } catch (error) {
-      yield put(publishCollectionFailure(collection, items, error.message))
+      const message = error?.code === ErrorCode.HIGH_CONGESTION ? '' : error.message
+      yield put(publishCollectionFailure(collection, items, message))
     }
   }
 


### PR DESCRIPTION
This PR hides the high congestion error message in the modal to prioritize the toast error information.

![image](https://user-images.githubusercontent.com/3170051/226038207-10305f28-f13b-442a-aa09-1f719fb89dd6.png)

Depends on https://github.com/decentraland/decentraland-dapps/pull/385