### PR TITLE
chore: Update decentraland dapps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "decentraland-ecs": "file:ecs/decentraland-ecs-6.6.1-20201020183014.commit-bdc29ef-hotfix.tgz",
         "decentraland-experiments": "^1.0.2",
         "decentraland-transactions": "^1.42.0",
-        "decentraland-ui": "^3.63.0",
+        "decentraland-ui": "^3.92.2",
         "ethers": "^5.6.8",
         "file-saver": "^2.0.1",
         "graphql": "^15.8.0",
@@ -10906,9 +10906,9 @@
       "integrity": "sha512-JJf6xrQJIFoS5DGzL6ZgSuRd5PtO5HOqK1pxLkxtShGmUFnVAV+gIqBA8o2oTzUzGc6uPXdR0zBar7/eyY6f8w=="
     },
     "node_modules/decentraland-ui": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.92.0.tgz",
-      "integrity": "sha512-MShuwYPSidG9/4sNaRITz3jEaQhS6d+VuYtydHKzHDChR/wrMHC4SDqckVjV0pNs7m09IP4NhQ6oJY1vv5WdPA==",
+      "version": "3.92.2",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.92.2.tgz",
+      "integrity": "sha512-d+z15kGxaUQCm3pOgBVsf+vrlQ1bzHdFZEbSO3oPKKqxKmCwb5IPko7/fhxUWUO28mc22FImZcDwNaiOZDYIbQ==",
       "dependencies": {
         "@dcl/schemas": "^6.10.0",
         "balloon-css": "^0.5.0",
@@ -10922,7 +10922,7 @@
         "react-dom": "^17.0.2",
         "react-responsive": "^9.0.0-beta.3",
         "react-semantic-ui-datepickers": "^2.17.2",
-        "react-tile-map": "^0.4.0",
+        "react-tile-map": "^0.4.1",
         "recharts": "^2.3.2",
         "semantic-ui-css": "^2.4.1",
         "semantic-ui-react": "^2.0.3"
@@ -24264,9 +24264,9 @@
       }
     },
     "node_modules/react-tile-map": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/react-tile-map/-/react-tile-map-0.4.0.tgz",
-      "integrity": "sha512-tJT9LR7WnzjSAn8xHLGGZXpevc1G8NFz8IVICND8PLK/mHtiAVO5MOdOuJWVPYhXc+TpLmOt9mK041hC4Qtc0A==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/react-tile-map/-/react-tile-map-0.4.1.tgz",
+      "integrity": "sha512-aBcZY4a3X17cngvEo9TAnn030PFqh9uyx4vVbeaS6MYOAbTnftSF+rkDPSabYWONWzhVIxOEuI4dM8tYckmAdw==",
       "dependencies": {
         "impetus": "^0.8.8",
         "mouse-wheel": "^1.2.0",
@@ -39497,9 +39497,9 @@
       "integrity": "sha512-JJf6xrQJIFoS5DGzL6ZgSuRd5PtO5HOqK1pxLkxtShGmUFnVAV+gIqBA8o2oTzUzGc6uPXdR0zBar7/eyY6f8w=="
     },
     "decentraland-ui": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.92.0.tgz",
-      "integrity": "sha512-MShuwYPSidG9/4sNaRITz3jEaQhS6d+VuYtydHKzHDChR/wrMHC4SDqckVjV0pNs7m09IP4NhQ6oJY1vv5WdPA==",
+      "version": "3.92.2",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.92.2.tgz",
+      "integrity": "sha512-d+z15kGxaUQCm3pOgBVsf+vrlQ1bzHdFZEbSO3oPKKqxKmCwb5IPko7/fhxUWUO28mc22FImZcDwNaiOZDYIbQ==",
       "requires": {
         "@dcl/schemas": "^6.10.0",
         "balloon-css": "^0.5.0",
@@ -39513,7 +39513,7 @@
         "react-dom": "^17.0.2",
         "react-responsive": "^9.0.0-beta.3",
         "react-semantic-ui-datepickers": "^2.17.2",
-        "react-tile-map": "^0.4.0",
+        "react-tile-map": "^0.4.1",
         "recharts": "^2.3.2",
         "semantic-ui-css": "^2.4.1",
         "semantic-ui-react": "^2.0.3"
@@ -50198,9 +50198,9 @@
       }
     },
     "react-tile-map": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/react-tile-map/-/react-tile-map-0.4.0.tgz",
-      "integrity": "sha512-tJT9LR7WnzjSAn8xHLGGZXpevc1G8NFz8IVICND8PLK/mHtiAVO5MOdOuJWVPYhXc+TpLmOt9mK041hC4Qtc0A==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/react-tile-map/-/react-tile-map-0.4.1.tgz",
+      "integrity": "sha512-aBcZY4a3X17cngvEo9TAnn030PFqh9uyx4vVbeaS6MYOAbTnftSF+rkDPSabYWONWzhVIxOEuI4dM8tYckmAdw==",
       "requires": {
         "impetus": "^0.8.8",
         "mouse-wheel": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "dcl-scene-writer": "^1.1.2",
         "decentraland": "^3.3.0",
         "decentraland-builder-scripts": "^0.24.0",
-        "decentraland-dapps": "^13.41.0",
+        "decentraland-dapps": "^13.45.1",
         "decentraland-ecs": "file:ecs/decentraland-ecs-6.6.1-20201020183014.commit-bdc29ef-hotfix.tgz",
         "decentraland-experiments": "^1.0.2",
         "decentraland-transactions": "^1.42.0",
@@ -5107,25 +5107,6 @@
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router": "*"
-      }
-    },
-    "node_modules/@types/react-virtualized": {
-      "version": "9.21.21",
-      "resolved": "https://registry.npmjs.org/@types/react-virtualized/-/react-virtualized-9.21.21.tgz",
-      "integrity": "sha512-Exx6I7p4Qn+BBA1SRyj/UwQlZ0I0Pq7g7uhAp0QQ4JWzZunqEqNBGTmCmMmS/3N9wFgAGWuBD16ap7k8Y14VPA==",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/react": "^17"
-      }
-    },
-    "node_modules/@types/react-virtualized/node_modules/@types/react": {
-      "version": "17.0.52",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.52.tgz",
-      "integrity": "sha512-vwk8QqVODi0VaZZpDXQCmEmiOuyjEFPY7Ttaw5vjM112LOq37yz1CDJGrRJwA1fYEq4Iitd5rnjd1yWAc/bT+A==",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/redux-logger": {
@@ -10654,9 +10635,9 @@
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
     },
     "node_modules/decentraland-dapps": {
-      "version": "13.41.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.41.0.tgz",
-      "integrity": "sha512-nrYJu420VekIsWrxZD3xiDZwF6EeI3y9PUbwv2/EeHDmVaFjogbQgulcZleHnKz7CZE5y1AkdrFm0RvIEbIEvA==",
+      "version": "13.45.1",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.45.1.tgz",
+      "integrity": "sha512-EAHatDlp5UN/Qhln2Nij/p2ejugQnSA3NEGa3CWbyiN+VSO+Hz8jKc/wt0yq8F5mYOHuNye9atrIjXGDqLAjmg==",
       "dependencies": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
@@ -10670,7 +10651,7 @@
         "dcl-catalyst-client": "^14.0.9",
         "decentraland-connect": "^3.5.0",
         "decentraland-transactions": "^1.43.1",
-        "decentraland-ui": "^3.81.0",
+        "decentraland-ui": "^3.84.0",
         "ethers": "^5.6.8",
         "events": "^3.3.0",
         "flat": "^5.0.2",
@@ -10925,9 +10906,9 @@
       "integrity": "sha512-JJf6xrQJIFoS5DGzL6ZgSuRd5PtO5HOqK1pxLkxtShGmUFnVAV+gIqBA8o2oTzUzGc6uPXdR0zBar7/eyY6f8w=="
     },
     "node_modules/decentraland-ui": {
-      "version": "3.82.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.82.0.tgz",
-      "integrity": "sha512-B2BpPoeAJMlV/XrWM+UQeuaoVZolsactWIRxfE4uk5b3U2gyTFR8GGmM+m1UzywIB8l7eEhfIubGrV6/tR0ssg==",
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.92.0.tgz",
+      "integrity": "sha512-MShuwYPSidG9/4sNaRITz3jEaQhS6d+VuYtydHKzHDChR/wrMHC4SDqckVjV0pNs7m09IP4NhQ6oJY1vv5WdPA==",
       "dependencies": {
         "@dcl/schemas": "^6.10.0",
         "balloon-css": "^0.5.0",
@@ -10941,7 +10922,7 @@
         "react-dom": "^17.0.2",
         "react-responsive": "^9.0.0-beta.3",
         "react-semantic-ui-datepickers": "^2.17.2",
-        "react-tile-map": "^0.3.3",
+        "react-tile-map": "^0.4.0",
         "recharts": "^2.3.2",
         "semantic-ui-css": "^2.4.1",
         "semantic-ui-react": "^2.0.3"
@@ -11521,15 +11502,6 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "dependencies": {
         "utila": "~0.4"
-      }
-    },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -24292,37 +24264,19 @@
       }
     },
     "node_modules/react-tile-map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/react-tile-map/-/react-tile-map-0.3.3.tgz",
-      "integrity": "sha512-MdWc8Qs24kY+YHA5t3KYmtei7uO6QbcP8KvqBVUZ7e+QF+KTjnIQFmzfLs3b6Td0lRHhpt7uoZFYW1vsXpgYeQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/react-tile-map/-/react-tile-map-0.4.0.tgz",
+      "integrity": "sha512-tJT9LR7WnzjSAn8xHLGGZXpevc1G8NFz8IVICND8PLK/mHtiAVO5MOdOuJWVPYhXc+TpLmOt9mK041hC4Qtc0A==",
       "dependencies": {
-        "@types/react-virtualized": "^9.21.2",
         "impetus": "^0.8.8",
         "mouse-wheel": "^1.2.0",
-        "react-virtualized": "^9.21.1",
+        "react-virtualized-auto-sizer": "^1.0.9",
         "touch-pinch": "^1.0.1",
         "touch-position": "^2.0.0"
       },
       "peerDependencies": {
         "react": ">=16.8.6",
         "react-dom": ">=16.8.6"
-      }
-    },
-    "node_modules/react-tile-map/node_modules/react-virtualized": {
-      "version": "9.22.3",
-      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.3.tgz",
-      "integrity": "sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "clsx": "^1.0.4",
-        "dom-helpers": "^5.1.3",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-lifecycles-compat": "^3.0.4"
-      },
-      "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0-alpha",
-        "react-dom": "^15.3.0 || ^16.0.0-alpha"
       }
     },
     "node_modules/react-transition-group": {
@@ -24346,6 +24300,15 @@
       "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
       "dependencies": {
         "@babel/runtime": "^7.1.2"
+      }
+    },
+    "node_modules/react-virtualized-auto-sizer": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.11.tgz",
+      "integrity": "sha512-v2YlC4KCnjEF7V5KtxrHCy50vPhbL73BS1qNOXFYaaE1XGeRqZHrGP+F4BE0QDv2pP+f1t9twL1n5pRp5GPMkQ==",
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc"
       }
     },
     "node_modules/read-pkg": {
@@ -34923,27 +34886,6 @@
         "@types/react-router": "*"
       }
     },
-    "@types/react-virtualized": {
-      "version": "9.21.21",
-      "resolved": "https://registry.npmjs.org/@types/react-virtualized/-/react-virtualized-9.21.21.tgz",
-      "integrity": "sha512-Exx6I7p4Qn+BBA1SRyj/UwQlZ0I0Pq7g7uhAp0QQ4JWzZunqEqNBGTmCmMmS/3N9wFgAGWuBD16ap7k8Y14VPA==",
-      "requires": {
-        "@types/prop-types": "*",
-        "@types/react": "^17"
-      },
-      "dependencies": {
-        "@types/react": {
-          "version": "17.0.52",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.52.tgz",
-          "integrity": "sha512-vwk8QqVODi0VaZZpDXQCmEmiOuyjEFPY7Ttaw5vjM112LOq37yz1CDJGrRJwA1fYEq4Iitd5rnjd1yWAc/bT+A==",
-          "requires": {
-            "@types/prop-types": "*",
-            "@types/scheduler": "*",
-            "csstype": "^3.0.2"
-          }
-        }
-      }
-    },
     "@types/redux-logger": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/@types/redux-logger/-/redux-logger-3.0.9.tgz",
@@ -39350,9 +39292,9 @@
       }
     },
     "decentraland-dapps": {
-      "version": "13.41.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.41.0.tgz",
-      "integrity": "sha512-nrYJu420VekIsWrxZD3xiDZwF6EeI3y9PUbwv2/EeHDmVaFjogbQgulcZleHnKz7CZE5y1AkdrFm0RvIEbIEvA==",
+      "version": "13.45.1",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.45.1.tgz",
+      "integrity": "sha512-EAHatDlp5UN/Qhln2Nij/p2ejugQnSA3NEGa3CWbyiN+VSO+Hz8jKc/wt0yq8F5mYOHuNye9atrIjXGDqLAjmg==",
       "requires": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
@@ -39366,7 +39308,7 @@
         "dcl-catalyst-client": "^14.0.9",
         "decentraland-connect": "^3.5.0",
         "decentraland-transactions": "^1.43.1",
-        "decentraland-ui": "^3.81.0",
+        "decentraland-ui": "^3.84.0",
         "ethers": "^5.6.8",
         "events": "^3.3.0",
         "flat": "^5.0.2",
@@ -39555,9 +39497,9 @@
       "integrity": "sha512-JJf6xrQJIFoS5DGzL6ZgSuRd5PtO5HOqK1pxLkxtShGmUFnVAV+gIqBA8o2oTzUzGc6uPXdR0zBar7/eyY6f8w=="
     },
     "decentraland-ui": {
-      "version": "3.82.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.82.0.tgz",
-      "integrity": "sha512-B2BpPoeAJMlV/XrWM+UQeuaoVZolsactWIRxfE4uk5b3U2gyTFR8GGmM+m1UzywIB8l7eEhfIubGrV6/tR0ssg==",
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.92.0.tgz",
+      "integrity": "sha512-MShuwYPSidG9/4sNaRITz3jEaQhS6d+VuYtydHKzHDChR/wrMHC4SDqckVjV0pNs7m09IP4NhQ6oJY1vv5WdPA==",
       "requires": {
         "@dcl/schemas": "^6.10.0",
         "balloon-css": "^0.5.0",
@@ -39571,7 +39513,7 @@
         "react-dom": "^17.0.2",
         "react-responsive": "^9.0.0-beta.3",
         "react-semantic-ui-datepickers": "^2.17.2",
-        "react-tile-map": "^0.3.3",
+        "react-tile-map": "^0.4.0",
         "recharts": "^2.3.2",
         "semantic-ui-css": "^2.4.1",
         "semantic-ui-react": "^2.0.3"
@@ -40026,15 +39968,6 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "requires": {
         "utila": "~0.4"
-      }
-    },
-    "dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "requires": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
       }
     },
     "dom-serializer": {
@@ -50265,31 +50198,15 @@
       }
     },
     "react-tile-map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/react-tile-map/-/react-tile-map-0.3.3.tgz",
-      "integrity": "sha512-MdWc8Qs24kY+YHA5t3KYmtei7uO6QbcP8KvqBVUZ7e+QF+KTjnIQFmzfLs3b6Td0lRHhpt7uoZFYW1vsXpgYeQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/react-tile-map/-/react-tile-map-0.4.0.tgz",
+      "integrity": "sha512-tJT9LR7WnzjSAn8xHLGGZXpevc1G8NFz8IVICND8PLK/mHtiAVO5MOdOuJWVPYhXc+TpLmOt9mK041hC4Qtc0A==",
       "requires": {
-        "@types/react-virtualized": "^9.21.2",
         "impetus": "^0.8.8",
         "mouse-wheel": "^1.2.0",
-        "react-virtualized": "^9.21.1",
+        "react-virtualized-auto-sizer": "^1.0.9",
         "touch-pinch": "^1.0.1",
         "touch-position": "^2.0.0"
-      },
-      "dependencies": {
-        "react-virtualized": {
-          "version": "9.22.3",
-          "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.3.tgz",
-          "integrity": "sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==",
-          "requires": {
-            "@babel/runtime": "^7.7.2",
-            "clsx": "^1.0.4",
-            "dom-helpers": "^5.1.3",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.7.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        }
       }
     },
     "react-transition-group": {
@@ -50312,6 +50229,12 @@
           }
         }
       }
+    },
+    "react-virtualized-auto-sizer": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.11.tgz",
+      "integrity": "sha512-v2YlC4KCnjEF7V5KtxrHCy50vPhbL73BS1qNOXFYaaE1XGeRqZHrGP+F4BE0QDv2pP+f1t9twL1n5pRp5GPMkQ==",
+      "requires": {}
     },
     "read-pkg": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "decentraland-ecs": "file:ecs/decentraland-ecs-6.6.1-20201020183014.commit-bdc29ef-hotfix.tgz",
     "decentraland-experiments": "^1.0.2",
     "decentraland-transactions": "^1.42.0",
-    "decentraland-ui": "^3.63.0",
+    "decentraland-ui": "^3.92.2",
     "ethers": "^5.6.8",
     "file-saver": "^2.0.1",
     "graphql": "^15.8.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dcl-scene-writer": "^1.1.2",
     "decentraland": "^3.3.0",
     "decentraland-builder-scripts": "^0.24.0",
-    "decentraland-dapps": "^13.41.0",
+    "decentraland-dapps": "^13.45.1",
     "decentraland-ecs": "file:ecs/decentraland-ecs-6.6.1-20201020183014.commit-bdc29ef-hotfix.tgz",
     "decentraland-experiments": "^1.0.2",
     "decentraland-transactions": "^1.42.0",


### PR DESCRIPTION
This PR updates decentraland dapps to its latest version to include:
- The fix for the dropped transactions when changing network.
- The partially supported network alert.