### PR TITLE
feat: bump decentraland dapps version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "dcl-scene-writer": "^1.1.2",
         "decentraland": "^3.3.0",
         "decentraland-builder-scripts": "^0.24.0",
-        "decentraland-dapps": "^13.63.2",
+        "decentraland-dapps": "^13.64.0",
         "decentraland-ecs": "^6.6.1-20201020183014.commit-bdc29ef-hotfix",
         "decentraland-experiments": "^1.0.2",
         "decentraland-transactions": "^1.42.0",
@@ -10870,9 +10870,9 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "13.63.2",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.63.2.tgz",
-      "integrity": "sha512-ekooRL+LqZrDjy3cETxO6pfwN9azSelHEhmxLAEwKiw1CyQX9RT1hko5VMXIWo/YRWFTFMYFc7GL4ctOTwnNrw==",
+      "version": "13.64.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.64.0.tgz",
+      "integrity": "sha512-NqjFMurl9Up/jSRHMk0BqoPJ61fUwWYyKAhfIFfuudaReWPT+xf3zyqGk63WW4XtHE3ETta9d7JXJkdozDG5Fw==",
       "dependencies": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
@@ -41201,9 +41201,9 @@
       }
     },
     "decentraland-dapps": {
-      "version": "13.63.2",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.63.2.tgz",
-      "integrity": "sha512-ekooRL+LqZrDjy3cETxO6pfwN9azSelHEhmxLAEwKiw1CyQX9RT1hko5VMXIWo/YRWFTFMYFc7GL4ctOTwnNrw==",
+      "version": "13.64.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.64.0.tgz",
+      "integrity": "sha512-NqjFMurl9Up/jSRHMk0BqoPJ61fUwWYyKAhfIFfuudaReWPT+xf3zyqGk63WW4XtHE3ETta9d7JXJkdozDG5Fw==",
       "requires": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dcl-scene-writer": "^1.1.2",
     "decentraland": "^3.3.0",
     "decentraland-builder-scripts": "^0.24.0",
-    "decentraland-dapps": "^13.63.2",
+    "decentraland-dapps": "^13.64.0",
     "decentraland-ecs": "^6.6.1-20201020183014.commit-bdc29ef-hotfix",
     "decentraland-experiments": "^1.0.2",
     "decentraland-transactions": "^1.42.0",


### PR DESCRIPTION
Bump decentraland dapps version to include https://github.com/decentraland/decentraland-dapps/pull/443