### PR TITLE
fix: Share pool scene modal

### DIFF
--- a/src/components/Modals/ShareModal/ShareModal.css
+++ b/src/components/Modals/ShareModal/ShareModal.css
@@ -98,6 +98,9 @@
 }
 
 .ShareModal .share-modal .copy-group .copy-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background: var(--innocence);
   border-radius: 0 8px 8px 0;
   border-left: 1px solid;
@@ -109,7 +112,7 @@
   cursor: pointer;
   text-transform: uppercase;
   text-align: center;
-  width: 120px;
+  width: 75px;
   color: var(--primary);
 }
 

--- a/src/components/Modals/ShareModal/ShareModal.tsx
+++ b/src/components/Modals/ShareModal/ShareModal.tsx
@@ -162,8 +162,8 @@ export default class ShareModal extends React.PureComponent<Props, State> {
           </div>
           <div className="copy-group">
             <input ref={this.input} className="copy-input" readOnly={true} value={this.getShareLink()} onFocus={this.handleFocusLink} />
-            <CopyToClipboard role="button" text={this.getShareLink()} onCopy={this.handleCopyLink}>
-              <span className="copy-button">{copied ? t('share_modal.copied') : t('share_modal.copy')}</span>
+            <CopyToClipboard role="button" className="copy-button" text={this.getShareLink()} onCopy={this.handleCopyLink}>
+              <span>{copied ? t('share_modal.copied') : t('share_modal.copy')}</span>
             </CopyToClipboard>
           </div>
         </div>


### PR DESCRIPTION
This PR fixes the copy link button misalignment in the Share Scene Pool Modal.

Before:
<img width="520" alt="image" src="https://github.com/decentraland/builder/assets/3170051/590fcce2-f779-4a16-88cd-87e7d4e2cb44">

After:
<img width="520" alt="image" src="https://github.com/decentraland/builder/assets/3170051/a29fc38a-0fd5-4309-9b21-ec908f006174">
