### PR TITLE
fix: Loading Scene Editor

### DIFF
--- a/src/components/Preview/Preview.css
+++ b/src/components/Preview/Preview.css
@@ -120,3 +120,8 @@
     content: '100%';
   }
 }
+
+.SceneEditorErrorModal > .content {
+  text-align: center !important;
+  line-height: 35px !important;
+}

--- a/src/components/Preview/Preview.css
+++ b/src/components/Preview/Preview.css
@@ -121,7 +121,16 @@
   }
 }
 
-.SceneEditorErrorModal > .content {
-  text-align: center !important;
-  line-height: 35px !important;
+.ui.modals > .ui.modal.SceneEditorErrorModal {
+  display: flex !important;
+  flex-direction: column;
+}
+
+.ui.modals > .ui.modal.SceneEditorErrorModal > .content {
+  max-width: 400px;
+  margin-bottom: 0;
+  align-self: center;
+  overflow-wrap: break-word;
+  text-align: center;
+  line-height: 24px;
 }

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -120,15 +120,15 @@ class Preview extends React.Component<Props & CollectedProps> {
   }
 
   renderError() {
-    const forceBackReload = () => window.location.replace(locations.sceneDetail(this.props.project.id))
+    const { project } = this.props
     return (
-      <Modal name="SceneEditorErrorModal" onClose={forceBackReload} size="tiny">
+      <Modal name="SceneEditorErrorModal" size="tiny">
         <Modal.Content>{t('editor_preview.loading_unity_error', { br: <br /> })}</Modal.Content>
         <Modal.Actions>
-          <Button secondary onClick={forceBackReload}>
+          <Button secondary as="a" href={locations.sceneDetail(project.id)}>
             {t('global.back')}
           </Button>
-          <Button primary onClick={() => window.location.reload()}>
+          <Button primary as="a" href={locations.sceneEditor(project.id)}>
             {t('global.reload')}
           </Button>
         </Modal.Actions>

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -1822,7 +1822,7 @@
   },
   "editor_preview": {
     "loading_unity": "Loading Unity...",
-    "loading_unity_error": "There was an unexpected error loading your scene.{br}Please reload your browser."
+    "loading_unity_error": "Please reload your browser. If the problem persist, try using a lighter scene or contact support."
   },
   "approval_flow": {
     "loading": {

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -607,6 +607,7 @@
     "project": "Scene",
     "read_more": "Read more",
     "retry_tx": "Retry",
+    "reload": "Reload",
     "save": "Save",
     "send": "Send",
     "share": "Share",
@@ -1820,7 +1821,8 @@
     "unsynced": "Unsynced"
   },
   "editor_preview": {
-    "loading_unity": "Loading Unity..."
+    "loading_unity": "Loading Unity...",
+    "loading_unity_error": "There was an unexpected error loading your scene.{br}Please reload your browser."
   },
   "approval_flow": {
     "loading": {

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -1841,7 +1841,7 @@
   },
   "editor_preview": {
     "loading_unity": "Cargando Unity...",
-    "loading_unity_error": "Hubo un error inesperado cargando su escena.{br}Por favor, recargue su navegador."
+    "loading_unity_error": "Por favor vuelva a cargar su navegador. Si el problema persiste, intente usar una escena más ligera o contacte a soporte."
   },
   "approval_flow": {
     "loading": {

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -608,6 +608,7 @@
     "project": "Escena",
     "read_more": "Leer más",
     "retry_tx": "Re Enviar",
+    "reload": "Recargar",
     "save": "Salvar",
     "skip": "Saltar",
     "send": "Enviar",
@@ -1839,7 +1840,8 @@
     "unsynced": "Desincronizado"
   },
   "editor_preview": {
-    "loading_unity": "Cargando Unity..."
+    "loading_unity": "Cargando Unity...",
+    "loading_unity_error": "Hubo un error inesperado cargando su escena.{br}Por favor, recargue su navegador."
   },
   "approval_flow": {
     "loading": {

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -601,6 +601,7 @@
     "project": "场景",
     "read_more": "阅读更多",
     "retry_tx": "重试",
+    "reload": "重新加载",
     "save": "保存",
     "skip": "跳过",
     "send": "发送",
@@ -1824,7 +1825,8 @@
     "unsynced": "未同步"
   },
   "editor_preview": {
-    "loading_unity": "正在加载统一..."
+    "loading_unity": "正在加载统一...",
+    "loading_unity_error": "加载您的场景有一个意外的错误。{br}请重新加载浏览器。"
   },
   "approval_flow": {
     "loading": {

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -1826,7 +1826,7 @@
   },
   "editor_preview": {
     "loading_unity": "正在加载统一...",
-    "loading_unity_error": "加载您的场景有一个意外的错误。{br}请重新加载浏览器。"
+    "loading_unity_error": "请重新加载您的浏览器。 如果问题持续存在，请尝试使用更轻的场景或联系支持。"
   },
   "approval_flow": {
     "loading": {


### PR DESCRIPTION
This PR shows a Modal when the unity editor fails to load a scene.

The `Back button` and `Close Modal Action` redirect to the scene details page, forcing a fresh load to clean unity scripts.

The `Reload button` forces the browser to reload and load unity scripts again.

<img width="620" alt="image" src="https://github.com/decentraland/builder/assets/3170051/d8d97da2-a0c6-4c4e-977a-f83e331c3f5a">

