### PR TITLE
fix: Deploy Scene to Land

### DIFF
--- a/src/components/Modals/DeployModal/DeployToLand/DeployToLand.container.ts
+++ b/src/components/Modals/DeployModal/DeployToLand/DeployToLand.container.ts
@@ -2,6 +2,7 @@ import { connect } from 'react-redux'
 import { push } from 'connected-react-router'
 import { getError as getWalletError, isConnecting, isConnected, getAddress } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import {
+  isLoading,
   isUploadingAssets,
   getProgress as getUploadProgress,
   getError as getDeploymentError,
@@ -30,6 +31,7 @@ const mapState = (state: RootState): MapStateProps => ({
   isUploadingAssets: isUploadingAssets(state),
   isUploadingRecording: isUploadingRecording(state),
   isCreatingFiles: isCreatingFiles(state),
+  isLoading: isLoading(state),
   isLoggedIn: isLoggedIn(state),
   walletError: !!getWalletError(state),
   media: getMedia(state),

--- a/src/components/Modals/DeployModal/DeployToLand/DeployToLand.tsx
+++ b/src/components/Modals/DeployModal/DeployToLand/DeployToLand.tsx
@@ -33,7 +33,7 @@ export default class DeployToLand extends React.PureComponent<Props, State> {
       const landDeployments = deployments.filter(deployment => !deployment.world)
       const deployment = getDeployment(project, landDeployments)
       this.setState({
-        placement: { ...deployment.placement }
+        placement: { ...deployment?.placement }
       })
     }
   }
@@ -51,6 +51,7 @@ export default class DeployToLand extends React.PureComponent<Props, State> {
       isUploadingAssets,
       isCreatingFiles,
       isUploadingRecording,
+      isLoading: isDeploymentLoading,
       media,
       project,
       deploymentsByCoord,
@@ -58,7 +59,7 @@ export default class DeployToLand extends React.PureComponent<Props, State> {
       landTiles
     } = this.props
     const { coords, needsConfirmation } = this.state
-    const isLoading = isRecording || isUploadingAssets || isCreatingFiles || isUploadingRecording
+    const isLoading = isRecording || isUploadingAssets || isCreatingFiles || isUploadingRecording || isDeploymentLoading
     let view: DeployToLandView = DeployToLandView.NONE
 
     const deployment = coords && deploymentsByCoord[coords]
@@ -67,7 +68,7 @@ export default class DeployToLand extends React.PureComponent<Props, State> {
       view = DeployToLandView.CONNECT
     } else if (isConnected && isLoading && !error) {
       view = DeployToLandView.PROGRESS
-    } else if (isConnected && media && !landTiles.length) {
+    } else if (isConnected && media && !Object.keys(landTiles).length) {
       view = DeployToLandView.EMPTY
     } else if (isConnected && media && !needsConfirmation) {
       view = DeployToLandView.MAP
@@ -237,7 +238,8 @@ export default class DeployToLand extends React.PureComponent<Props, State> {
 
   renderMap = () => {
     const { media, project, deployments, deploymentsByCoord, landTiles, isLoggedIn } = this.props
-    const deployment = getDeployment(project, deployments)
+    const landDeployments = deployments.filter(deployment => !deployment.world)
+    const deployment = getDeployment(project, landDeployments)
     return (
       <div className="DeployToLand atlas">
         <div className="modal-header">

--- a/src/components/Modals/DeployModal/DeployToLand/DeployToLand.types.ts
+++ b/src/components/Modals/DeployModal/DeployToLand/DeployToLand.types.ts
@@ -20,6 +20,7 @@ export type Props = {
   isUploadingAssets: boolean
   isCreatingFiles: boolean
   isUploadingRecording: boolean
+  isLoading: boolean
   isLoggedIn: boolean
   mediaProgress: number
   deploymentProgress: DeploymentState['progress']
@@ -61,6 +62,7 @@ export type MapStateProps = Pick<
   | 'isUploadingRecording'
   | 'isCreatingFiles'
   | 'isConnected'
+  | 'isLoading'
   | 'isLoggedIn'
   | 'ethAddress'
   | 'project'

--- a/src/modules/deployment/reducer.ts
+++ b/src/modules/deployment/reducer.ts
@@ -126,7 +126,8 @@ export const deploymentReducer = (state = INITIAL_STATE, action: DeploymentReduc
     case DEPLOY_TO_LAND_REQUEST: {
       return {
         ...state,
-        error: null
+        error: null,
+        loading: loadingReducer(state.loading, action)
       }
     }
     case DEPLOY_TO_LAND_SUCCESS: {
@@ -147,7 +148,9 @@ export const deploymentReducer = (state = INITIAL_STATE, action: DeploymentReduc
         progress: {
           stage: ProgressStage.NONE,
           value: 0
-        }
+        },
+        error: null,
+        loading: loadingReducer(state.loading, action)
       }
     }
     case DEPLOY_TO_LAND_FAILURE: {


### PR DESCRIPTION
This PR fixes the deploy scene to land.

Currently, when you're trying to deploy a scene to land, the modal that shows the map doesn't appear, or the flow breaks because you couldn't find a valid deployment(if it exists) to display the current cords.