### PR TITLE
fix: Share on Twitter wording

### DIFF
--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -435,7 +435,7 @@
         "title": "Your scene is published!",
         "subtitle": "You can now explore and play in your World:",
         "jump_in": "Jump In",
-        "share_in_twitter": "Share in Twitter",
+        "share_in_twitter": "Share on Twitter",
         "share_in_twitter_text": "I just published new content on my World✨\n\nCheck it out:\n📍"
       },
       "failure": {


### PR DESCRIPTION
This PR updates the `Share in Twitter` wording to `Share on Twitter`.