### PR TITLE
fix: Load templates thumbnail and video from public folder

### DIFF
--- a/src/components/SceneCard/SceneCard.tsx
+++ b/src/components/SceneCard/SceneCard.tsx
@@ -10,16 +10,26 @@ export const SceneCard: React.FC<Props> = ({ title, subtitle, description, video
   const [hovered, setHovered] = useState(false)
   const video = useRef<HTMLVideoElement>(null)
 
+  const isVideoPlaying = () => {
+    return (
+      video.current &&
+      video.current.currentTime > 0 &&
+      !video.current.paused &&
+      !video.current.ended &&
+      video.current.readyState > video.current.HAVE_CURRENT_DATA
+    )
+  }
+
   const handleMouseEnter = useCallback(async () => {
     setHovered(true)
-    if (video.current) {
+    if (video.current && !isVideoPlaying()) {
       await video.current.play()
     }
   }, [])
 
   const handleMouseLeave = useCallback(() => {
     setHovered(false)
-    if (video.current) {
+    if (video.current && isVideoPlaying()) {
       video.current.pause()
       video.current.currentTime = 0
     }
@@ -38,7 +48,7 @@ export const SceneCard: React.FC<Props> = ({ title, subtitle, description, video
         {videoSrc && (
           <video
             className={classNames(styles.thumbnail, { [styles.hidden]: !hovered })}
-            src={`${PUBLIC_URL}/${videoSrc}`}
+            src={`${PUBLIC_URL}${videoSrc}`}
             muted
             ref={video}
           />
@@ -46,7 +56,7 @@ export const SceneCard: React.FC<Props> = ({ title, subtitle, description, video
         <img
           className={classNames(styles.thumbnail, { [styles.hidden]: !!hovered && videoSrc })}
           alt={title}
-          src={`${PUBLIC_URL}/${imgSrc}`}
+          src={`${PUBLIC_URL}${imgSrc}`}
         />
       </div>
       <div className={styles.cardInfo}>

--- a/src/components/SceneCard/SceneCard.tsx
+++ b/src/components/SceneCard/SceneCard.tsx
@@ -4,6 +4,8 @@ import { Badge } from 'decentraland-ui'
 import { Props } from './SceneCard.types'
 import styles from './SceneCard.module.css'
 
+const PUBLIC_URL = process.env.PUBLIC_URL
+
 export const SceneCard: React.FC<Props> = ({ title, subtitle, description, videoSrc, imgSrc, disabled, tag, onClick }) => {
   const [hovered, setHovered] = useState(false)
   const video = useRef<HTMLVideoElement>(null)
@@ -33,8 +35,19 @@ export const SceneCard: React.FC<Props> = ({ title, subtitle, description, video
       aria-label={title}
     >
       <div className={styles.media}>
-        {videoSrc && <video className={classNames(styles.thumbnail, { [styles.hidden]: !hovered })} src={videoSrc} muted ref={video} />}
-        <img className={classNames(styles.thumbnail, { [styles.hidden]: !!hovered && videoSrc })} alt={title} src={imgSrc} />
+        {videoSrc && (
+          <video
+            className={classNames(styles.thumbnail, { [styles.hidden]: !hovered })}
+            src={`${PUBLIC_URL}/${videoSrc}`}
+            muted
+            ref={video}
+          />
+        )}
+        <img
+          className={classNames(styles.thumbnail, { [styles.hidden]: !!hovered && videoSrc })}
+          alt={title}
+          src={`${PUBLIC_URL}/${imgSrc}`}
+        />
       </div>
       <div className={styles.cardInfo}>
         <div className={styles.description}>


### PR DESCRIPTION
This PR fixes the loading of the templates' thumbnail and video from public folder