### PR TITLE
feat: Fetch templates manifest from templates/:id/manifest endpoint

### DIFF
--- a/src/components/Modals/CloneTemplateModal/CloneTemplateModal.tsx
+++ b/src/components/Modals/CloneTemplateModal/CloneTemplateModal.tsx
@@ -29,7 +29,7 @@ const CloneTemplateModal: React.FC<Props> = ({ metadata, alias, name, isLoading,
 
   const handleCloneTemplate = useCallback(() => {
     const project = { ...metadata.template, title, description }
-    onDuplicate(project, PreviewType.PUBLIC)
+    onDuplicate(project, PreviewType.TEMPLATE)
   }, [title, description, metadata, onDuplicate])
 
   const handleOnTitleChange = useCallback((_: React.ChangeEvent<HTMLInputElement>, { value }: InputOnChangeData) => {

--- a/src/lib/api/builder.ts
+++ b/src/lib/api/builder.ts
@@ -642,7 +642,10 @@ export class BuilderAPI extends BaseAPI {
     await this.request('delete', `/projects/${id}`)
   }
 
-  async fetchManifest(id: string, type: PreviewType.PROJECT | PreviewType.POOL | PreviewType.PUBLIC = PreviewType.PROJECT) {
+  async fetchManifest(
+    id: string,
+    type: PreviewType.PROJECT | PreviewType.POOL | PreviewType.PUBLIC | PreviewType.TEMPLATE = PreviewType.PROJECT
+  ) {
     const remoteManifest = await this.request('get', `/${type}s/${id}/manifest`)
     const manifest = {
       ...remoteManifest,

--- a/src/lib/api/builder.ts
+++ b/src/lib/api/builder.ts
@@ -642,10 +642,7 @@ export class BuilderAPI extends BaseAPI {
     await this.request('delete', `/projects/${id}`)
   }
 
-  async fetchManifest(
-    id: string,
-    type: PreviewType.PROJECT | PreviewType.POOL | PreviewType.PUBLIC | PreviewType.TEMPLATE = PreviewType.PROJECT
-  ) {
+  async fetchManifest(id: string, type: PreviewType = PreviewType.PROJECT) {
     const remoteManifest = await this.request('get', `/${type}s/${id}/manifest`)
     const manifest = {
       ...remoteManifest,

--- a/src/modules/editor/types.ts
+++ b/src/modules/editor/types.ts
@@ -34,7 +34,8 @@ export type UnityKeyboardEvent = 'DownArrow' | 'UpArrow' | 'LeftArrow' | 'RightA
 export enum PreviewType {
   PROJECT = 'project',
   PUBLIC = 'public',
-  POOL = 'pool'
+  POOL = 'pool',
+  TEMPLATE = 'template'
 }
 
 export type OpenEditorOptions = {

--- a/src/modules/project/actions.ts
+++ b/src/modules/project/actions.ts
@@ -72,14 +72,8 @@ export const DUPLICATE_PROJECT_REQUEST = '[Request] Duplicate project'
 export const DUPLICATE_PROJECT_SUCCESS = '[Success] Duplicate project'
 export const DUPLICATE_PROJECT_FAILURE = '[Failure] Duplicate project'
 
-export const duplicateProjectRequest = (
-  project: Project,
-  type?: PreviewType.PROJECT | PreviewType.PUBLIC | PreviewType.POOL | PreviewType.TEMPLATE
-) => action(DUPLICATE_PROJECT_REQUEST, { project, type })
-export const duplicateProjectSuccess = (
-  project: Project,
-  type?: PreviewType.PROJECT | PreviewType.PUBLIC | PreviewType.POOL | PreviewType.TEMPLATE
-) => action(DUPLICATE_PROJECT_SUCCESS, { project, type })
+export const duplicateProjectRequest = (project: Project, type?: PreviewType) => action(DUPLICATE_PROJECT_REQUEST, { project, type })
+export const duplicateProjectSuccess = (project: Project, type?: PreviewType) => action(DUPLICATE_PROJECT_SUCCESS, { project, type })
 export const duplicateProjectFailure = (error: string) => action(DUPLICATE_PROJECT_FAILURE, { error })
 
 export type DuplicateProjectRequestAction = ReturnType<typeof duplicateProjectRequest>
@@ -155,10 +149,7 @@ export const LOAD_MANIFEST_REQUEST = '[Request] Load manifest'
 export const LOAD_MANIFEST_SUCCESS = '[Success] Load manifest'
 export const LOAD_MANIFEST_FAILURE = '[Failure] Load manifest'
 
-export const loadManifestRequest = (
-  id: string,
-  type: PreviewType.PROJECT | PreviewType.PUBLIC | PreviewType.POOL | PreviewType.TEMPLATE = PreviewType.PROJECT
-) => action(LOAD_MANIFEST_REQUEST, { id, type })
+export const loadManifestRequest = (id: string, type: PreviewType = PreviewType.PROJECT) => action(LOAD_MANIFEST_REQUEST, { id, type })
 export const loadManifestSuccess = (manifest: Manifest) => action(LOAD_MANIFEST_SUCCESS, { manifest })
 export const loadManifestFailure = (error: string) => action(LOAD_MANIFEST_FAILURE, { error })
 
@@ -171,10 +162,8 @@ export const LOAD_PROJECT_SCENE_REQUEST = '[Request] Load project scene'
 export const LOAD_PROJECT_SCENE_SUCCESS = '[Success] Load project scene'
 export const LOAD_PROJECT_SCENE_FAILURE = '[Failure] Load project scene'
 
-export const loadProjectSceneRequest = (
-  project: Project,
-  type: PreviewType.PROJECT | PreviewType.PUBLIC | PreviewType.POOL | PreviewType.TEMPLATE = PreviewType.PROJECT
-) => action(LOAD_PROJECT_SCENE_REQUEST, { project, type })
+export const loadProjectSceneRequest = (project: Project, type: PreviewType = PreviewType.PROJECT) =>
+  action(LOAD_PROJECT_SCENE_REQUEST, { project, type })
 export const loadProjectSceneSuccess = (scene: Scene) => action(LOAD_PROJECT_SCENE_SUCCESS, { scene })
 export const loadProjectSceneFailure = (error: string) => action(LOAD_PROJECT_SCENE_FAILURE, { error })
 

--- a/src/modules/project/actions.ts
+++ b/src/modules/project/actions.ts
@@ -72,8 +72,14 @@ export const DUPLICATE_PROJECT_REQUEST = '[Request] Duplicate project'
 export const DUPLICATE_PROJECT_SUCCESS = '[Success] Duplicate project'
 export const DUPLICATE_PROJECT_FAILURE = '[Failure] Duplicate project'
 
-export const duplicateProjectRequest = (project: Project, type?: PreviewType) => action(DUPLICATE_PROJECT_REQUEST, { project, type })
-export const duplicateProjectSuccess = (project: Project, type?: PreviewType) => action(DUPLICATE_PROJECT_SUCCESS, { project, type })
+export const duplicateProjectRequest = (
+  project: Project,
+  type?: PreviewType.PROJECT | PreviewType.PUBLIC | PreviewType.POOL | PreviewType.TEMPLATE
+) => action(DUPLICATE_PROJECT_REQUEST, { project, type })
+export const duplicateProjectSuccess = (
+  project: Project,
+  type?: PreviewType.PROJECT | PreviewType.PUBLIC | PreviewType.POOL | PreviewType.TEMPLATE
+) => action(DUPLICATE_PROJECT_SUCCESS, { project, type })
 export const duplicateProjectFailure = (error: string) => action(DUPLICATE_PROJECT_FAILURE, { error })
 
 export type DuplicateProjectRequestAction = ReturnType<typeof duplicateProjectRequest>
@@ -149,8 +155,10 @@ export const LOAD_MANIFEST_REQUEST = '[Request] Load manifest'
 export const LOAD_MANIFEST_SUCCESS = '[Success] Load manifest'
 export const LOAD_MANIFEST_FAILURE = '[Failure] Load manifest'
 
-export const loadManifestRequest = (id: string, type: PreviewType.PROJECT | PreviewType.PUBLIC | PreviewType.POOL = PreviewType.PROJECT) =>
-  action(LOAD_MANIFEST_REQUEST, { id, type })
+export const loadManifestRequest = (
+  id: string,
+  type: PreviewType.PROJECT | PreviewType.PUBLIC | PreviewType.POOL | PreviewType.TEMPLATE = PreviewType.PROJECT
+) => action(LOAD_MANIFEST_REQUEST, { id, type })
 export const loadManifestSuccess = (manifest: Manifest) => action(LOAD_MANIFEST_SUCCESS, { manifest })
 export const loadManifestFailure = (error: string) => action(LOAD_MANIFEST_FAILURE, { error })
 
@@ -165,7 +173,7 @@ export const LOAD_PROJECT_SCENE_FAILURE = '[Failure] Load project scene'
 
 export const loadProjectSceneRequest = (
   project: Project,
-  type: PreviewType.PROJECT | PreviewType.PUBLIC | PreviewType.POOL = PreviewType.PROJECT
+  type: PreviewType.PROJECT | PreviewType.PUBLIC | PreviewType.POOL | PreviewType.TEMPLATE = PreviewType.PROJECT
 ) => action(LOAD_PROJECT_SCENE_REQUEST, { project, type })
 export const loadProjectSceneSuccess = (scene: Scene) => action(LOAD_PROJECT_SCENE_SUCCESS, { scene })
 export const loadProjectSceneFailure = (error: string) => action(LOAD_PROJECT_SCENE_FAILURE, { error })

--- a/src/modules/project/utils.ts
+++ b/src/modules/project/utils.ts
@@ -70,7 +70,7 @@ export function getParcelOrientation(layout: Layout, point: Coordinate, rotation
 export async function getImageAsDataUrl(url: string, isTemplate = false): Promise<string> {
   const reader = new FileReader()
   const headers = !isTemplate ? NO_CACHE_HEADERS : {}
-  const res = await fetch(url, headers)
+  const res = await fetch(url, { headers })
   const blob = await res.blob()
 
   const out = new Promise<string>((resolve, reject) => {

--- a/src/modules/scene/utils.ts
+++ b/src/modules/scene/utils.ts
@@ -102,7 +102,7 @@ export function areEqualMappings(mappingsA: Record<string, string> = {}, mapping
 
 export function* getSceneByProjectId(
   projectId: string,
-  type: PreviewType.PROJECT | PreviewType.PUBLIC | PreviewType.POOL = PreviewType.PROJECT
+  type: PreviewType.PROJECT | PreviewType.PUBLIC | PreviewType.POOL | PreviewType.TEMPLATE = PreviewType.PROJECT
 ) {
   const projects: ReturnType<typeof getProjects> = yield select(getProjects)
   const pools: ReturnType<typeof getPools> = yield select(getPools)

--- a/src/modules/scene/utils.ts
+++ b/src/modules/scene/utils.ts
@@ -100,10 +100,7 @@ export function areEqualMappings(mappingsA: Record<string, string> = {}, mapping
   return true
 }
 
-export function* getSceneByProjectId(
-  projectId: string,
-  type: PreviewType.PROJECT | PreviewType.PUBLIC | PreviewType.POOL | PreviewType.TEMPLATE = PreviewType.PROJECT
-) {
+export function* getSceneByProjectId(projectId: string, type: PreviewType = PreviewType.PROJECT) {
   const projects: ReturnType<typeof getProjects> = yield select(getProjects)
   const pools: ReturnType<typeof getPools> = yield select(getPools)
   const scenes: ReturnType<typeof getScenes> = yield select(getScenes)


### PR DESCRIPTION
This PR fetches the templates manifest from `templates/:id/manifest` endpoint.

Depends on: https://github.com/decentraland/builder-server/pull/667