### PR TITLE
fix: Hardcode realm

### DIFF
--- a/src/modules/collection/utils.ts
+++ b/src/modules/collection/utils.ts
@@ -55,7 +55,7 @@ export function getExplorerURL({
   }
   const EXPLORER_URL = config.get('EXPLORER_URL', '')
   const BUILDER_SERVER_URL = config.get('BUILDER_SERVER_URL', '')
-  let URL = `${EXPLORER_URL}?BUILDER_SERVER_URL=${BUILDER_SERVER_URL}&NETWORK=goerli&DEBUG_MODE=true&realm=artemis`
+  let URL = `${EXPLORER_URL}?BUILDER_SERVER_URL=${BUILDER_SERVER_URL}&NETWORK=goerli&DEBUG_MODE=true&realm=zeus`
 
   if (collectionId) {
     URL += `&WITH_COLLECTIONS=${collectionId}`

--- a/src/modules/collection/utils.ts
+++ b/src/modules/collection/utils.ts
@@ -55,7 +55,7 @@ export function getExplorerURL({
   }
   const EXPLORER_URL = config.get('EXPLORER_URL', '')
   const BUILDER_SERVER_URL = config.get('BUILDER_SERVER_URL', '')
-  let URL = `${EXPLORER_URL}?BUILDER_SERVER_URL=${BUILDER_SERVER_URL}&NETWORK=goerli&DEBUG_MODE=true`
+  let URL = `${EXPLORER_URL}?BUILDER_SERVER_URL=${BUILDER_SERVER_URL}&NETWORK=goerli&DEBUG_MODE=true&realm=artemis`
 
   if (collectionId) {
     URL += `&WITH_COLLECTIONS=${collectionId}`


### PR DESCRIPTION
Hardcode the realm to prevent it from using `poseidon` that currently has Sepolia content