### PR TITLE
feat: save sdk7 scenes

### DIFF
--- a/src/components/SceneViewPage/SceneViewPage.tsx
+++ b/src/components/SceneViewPage/SceneViewPage.tsx
@@ -71,10 +71,7 @@ export default class SceneViewPage extends React.PureComponent<Props> {
   getCurrentScene() {
     const { scenes } = this.props
     const project = this.getCurrentProject()
-    if (project) {
-      return scenes[project.sceneId]
-    }
-    return null
+    return (project && scenes[project.sceneId]) || null
   }
 
   getCurrentPool() {

--- a/src/modules/common/sagas.ts
+++ b/src/modules/common/sagas.ts
@@ -43,10 +43,11 @@ import { collectionCurationSaga } from 'modules/curations/collectionCuration/sag
 import { getPeerWithNoGBCollectorURL } from './utils'
 import { itemCurationSaga } from 'modules/curations/itemCuration/sagas'
 import { inspectorSaga } from 'modules/inspector/sagas'
+import { RootStore } from './types'
 
 const profileSaga = createProfileSaga({ peerUrl: PEER_URL, peerWithNoGbCollectorUrl: getPeerWithNoGBCollectorURL() })
 
-export function* rootSaga(builderAPI: BuilderAPI, newBuilderClient: BuilderClient, catalystClient: CatalystClient) {
+export function* rootSaga(builderAPI: BuilderAPI, newBuilderClient: BuilderClient, catalystClient: CatalystClient, store: RootStore) {
   yield all([
     analyticsSaga(),
     assetPackSaga(builderAPI),
@@ -83,6 +84,6 @@ export function* rootSaga(builderAPI: BuilderAPI, newBuilderClient: BuilderClien
     collectionCurationSaga(builderAPI),
     itemCurationSaga(builderAPI),
     featuresSaga({ polling: { apps: [ApplicationName.BUILDER], delay: 60000 /** 60 seconds */ } }),
-    inspectorSaga()
+    inspectorSaga(store)
   ])
 }

--- a/src/modules/common/store.ts
+++ b/src/modules/common/store.ts
@@ -171,7 +171,7 @@ const builderClientUrl: string = BUILDER_SERVER_URL.replace('/v1', '')
 
 const newBuilderClient = new BuilderClient(builderClientUrl, getClientAuthAuthority, getClientAddress, fetch)
 
-sagasMiddleware.run(rootSaga, builderAPI, newBuilderClient, catalystClient)
+sagasMiddleware.run(rootSaga, builderAPI, newBuilderClient, catalystClient, store)
 loadStorageMiddleware(store)
 
 if (isDevelopment) {

--- a/src/modules/inspector/actions.ts
+++ b/src/modules/inspector/actions.ts
@@ -1,4 +1,5 @@
 import { action } from 'typesafe-actions'
+import { IframeStorage } from '@dcl/inspector'
 
 export const OPEN_INSPECTOR = 'Open Inspector'
 export const openInspector = () => action(OPEN_INSPECTOR)
@@ -7,3 +8,17 @@ export type OpenInspectorAction = ReturnType<typeof openInspector>
 export const CONNECT_INSPECTOR = 'Connect Inspector'
 export const connectInspector = (iframeId: string) => action(CONNECT_INSPECTOR, { iframeId })
 export type ConnectInspectorAction = ReturnType<typeof connectInspector>
+
+export const RPC_REQUEST = '[Request] RPC'
+export const rpcRequest = (method: `${IframeStorage.Method}`, params: IframeStorage.Params[IframeStorage.Method], nonce: number) =>
+  action(RPC_REQUEST, { method, params, nonce })
+export type RPCRequestAction = ReturnType<typeof rpcRequest>
+
+export const RPC_SUCCESS = '[Success] RPC'
+export const rpcSuccess = (method: `${IframeStorage.Method}`, result: IframeStorage.Result[IframeStorage.Method], nonce: number) =>
+  action(RPC_SUCCESS, { method, result, nonce })
+export type RPCSuccessAction = ReturnType<typeof rpcSuccess>
+
+export const RPC_FAILURE = '[Failure] RPC'
+export const rpcFailure = (method: `${IframeStorage.Method}`, error: string, nonce: number) => action(RPC_FAILURE, { method, error, nonce })
+export type RPCFailureAction = ReturnType<typeof rpcFailure>

--- a/src/modules/inspector/actions.ts
+++ b/src/modules/inspector/actions.ts
@@ -20,5 +20,10 @@ export const rpcSuccess = (method: `${IframeStorage.Method}`, result: IframeStor
 export type RPCSuccessAction = ReturnType<typeof rpcSuccess>
 
 export const RPC_FAILURE = '[Failure] RPC'
-export const rpcFailure = (method: `${IframeStorage.Method}`, error: string, nonce: number) => action(RPC_FAILURE, { method, error, nonce })
+export const rpcFailure = (
+  method: `${IframeStorage.Method}`,
+  params: IframeStorage.Params[IframeStorage.Method],
+  error: string,
+  nonce: number
+) => action(RPC_FAILURE, { method, params, error, nonce })
 export type RPCFailureAction = ReturnType<typeof rpcFailure>

--- a/src/modules/inspector/sagas.ts
+++ b/src/modules/inspector/sagas.ts
@@ -80,14 +80,14 @@ export function* inspectorSaga(store: RootStore) {
       const project: Project = yield getProject(projectId)
 
       yield put(loadProjectSceneRequest(project))
-      {
-        const result: { success?: LoadProjectSceneSuccessAction; failure?: LoadProjectSceneFailureAction } = yield race({
-          success: take(LOAD_PROJECT_SCENE_SUCCESS),
-          failure: take(LOAD_PROJECT_SCENE_FAILURE)
-        })
-        if (result.failure) {
-          throw new Error('Could not load scene')
-        }
+
+      const result: { success?: LoadProjectSceneSuccessAction; failure?: LoadProjectSceneFailureAction } = yield race({
+        success: take(LOAD_PROJECT_SCENE_SUCCESS),
+        failure: take(LOAD_PROJECT_SCENE_FAILURE)
+      })
+
+      if (result.failure) {
+        throw new Error('Could not load scene')
       }
     } catch (error) {
       console.error(error)

--- a/src/modules/inspector/sagas.ts
+++ b/src/modules/inspector/sagas.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-import { put, race, select, take, takeEvery } from 'redux-saga/effects'
+import { call, put, race, select, take, takeEvery } from 'redux-saga/effects'
+import { future, IFuture } from 'fp-future'
+import { hashV1 } from '@dcl/hashing'
 import { LoginFailureAction, LoginSuccessAction, LOGIN_FAILURE, LOGIN_SUCCESS } from 'modules/identity/actions'
 import { isLoggingIn } from 'modules/identity/selectors'
 import { getProjectId } from 'modules/location/utils'
@@ -16,17 +18,53 @@ import {
   LOAD_PROJECT_SCENE_FAILURE,
   LOAD_PROJECT_SCENE_SUCCESS
 } from 'modules/project/actions'
-import { getData as getProjects, getLoading as getLoadingProjects } from 'modules/project/selectors'
-import { getData as getScenes } from 'modules/scene/selectors'
-import { ConnectInspectorAction, CONNECT_INSPECTOR, OpenInspectorAction, OPEN_INSPECTOR } from './actions'
+import { getCurrentProject, getData as getProjects, getLoading as getLoadingProjects } from 'modules/project/selectors'
+import { getCurrentScene } from 'modules/scene/selectors'
+import {
+  ConnectInspectorAction,
+  CONNECT_INSPECTOR,
+  OpenInspectorAction,
+  OPEN_INSPECTOR,
+  rpcFailure,
+  RPCFailureAction,
+  rpcRequest,
+  RPCRequestAction,
+  rpcSuccess,
+  RPCSuccessAction,
+  RPC_FAILURE,
+  RPC_REQUEST,
+  RPC_SUCCESS
+} from './actions'
 import { Project } from 'modules/project/types'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 import { IframeStorage, MessageTransport } from '@dcl/inspector'
 import { getParcels, toComposite, toMappings } from './utils'
+import { getContentsStorageUrl } from 'lib/api/builder'
+import { NO_CACHE_HEADERS } from 'lib/headers'
+import { store } from 'modules/common/store'
+import { Scene, SceneSDK7 } from 'modules/scene/types'
+import { updateScene } from 'modules/scene/actions'
+
+let nonces = 0
+const getNonce = () => nonces++
+const promises = new Map<number, IFuture<unknown>>()
+const handlers: Record<`${IframeStorage.Method}`, (params: any) => Generator> = {
+  read_file: handleReadFile,
+  exists: handleExists,
+  list: handleList,
+  write_file: handleWriteFile,
+  delete: handleDelete
+}
+
+// TODO: delete this, use builder-server
+const FILES = new Map<string, Buffer>()
 
 export function* inspectorSaga() {
   yield takeEvery(OPEN_INSPECTOR, handleOpenInspector)
   yield takeEvery(CONNECT_INSPECTOR, handleConnectInspector)
+  yield takeEvery(RPC_REQUEST, handleRpcRequest)
+  yield takeEvery(RPC_SUCCESS, handleRpcSuccess)
+  yield takeEvery(RPC_FAILURE, handleRpcFailure)
 }
 
 function* handleOpenInspector(_action: OpenInspectorAction) {
@@ -64,7 +102,7 @@ function* handleOpenInspector(_action: OpenInspectorAction) {
   }
 }
 
-function* handleConnectInspector(action: ConnectInspectorAction) {
+function handleConnectInspector(action: ConnectInspectorAction) {
   const { iframeId } = action.payload
 
   const iframe = document.getElementById(iframeId) as HTMLIFrameElement | null
@@ -72,98 +110,206 @@ function* handleConnectInspector(action: ConnectInspectorAction) {
     throw new Error(`Iframe with id="${iframeId}" not found`)
   }
 
-  const projectId = getProjectId()
-  if (!projectId) {
-    throw new Error(`Invalid projectId=${projectId}`)
-  }
-
-  const project: Project = yield getProject(projectId)
-  const scenes: ReturnType<typeof getScenes> = yield select(getScenes)
-  const scene = scenes[project.sceneId]
-
-  const composite = scene.sdk7 ? scene.sdk7.composite : toComposite(scene.sdk6, project)
-  const mappings = scene.sdk7 ? scene.sdk7.mappings : toMappings(scene.sdk6)
-
   const transport = new MessageTransport(window, iframe.contentWindow!, '*')
-  const server = new IframeStorage.Server(transport)
+  const storage = new IframeStorage.Server(transport)
 
-  function getFile(path: string) {
-    switch (path) {
-      case 'scene.json': {
-        return JSON.stringify({
-          scene: {
-            parcels: getParcels(project.layout).map($ => `${$.x},${$.y}`),
-            base: '0,0'
-          }
-        })
+  const methods = Object.keys(handlers) as (keyof typeof handlers)[]
+  for (const method of methods) {
+    storage.handle(method, params => {
+      const nonce = getNonce()
+      const action = rpcRequest(method, params, nonce)
+      const promise = future()
+      promises.set(nonce, promise)
+      store.dispatch(action)
+      return promise
+    })
+  }
+}
+
+function* handleRpcRequest(action: RPCRequestAction) {
+  const { method, params, nonce } = action.payload
+  try {
+    const handler = handlers[method]
+    const result: IframeStorage.Result[IframeStorage.Method] = yield handler(params)
+    yield put(rpcSuccess(method, result, nonce))
+  } catch (error) {
+    yield put(rpcFailure(method, error.message, nonce))
+  }
+}
+
+function handleRpcSuccess(action: RPCSuccessAction) {
+  const { result, nonce } = action.payload
+  const promise = promises.get(nonce)
+  if (promise) {
+    promise.resolve(result)
+  }
+}
+
+function handleRpcFailure(action: RPCFailureAction) {
+  const { error, nonce } = action.payload
+  const promise = promises.get(nonce)
+  if (promise) {
+    promise.reject(new Error(error))
+  }
+}
+
+// HANDLERS
+
+function* handleReadFile(params: IframeStorage.Params['read_file']) {
+  const { path } = params
+  console.log('read_file', path)
+
+  const scene: SceneSDK7 = yield getScene()
+
+  // TODO: this should be fetched from the builder-server
+  if (FILES.has(path)) {
+    console.log('loading file from memory')
+    return FILES.get(path)
+  }
+
+  if (path in scene.mappings) {
+    const hash = scene.mappings[path]
+    const response: Response = yield call(fetch, `https://builder-api.decentraland.org/v1/storage/contents/${hash}`)
+    const buffer: ArrayBuffer = yield call([response, 'arrayBuffer'])
+    return Buffer.from(buffer)
+  }
+
+  let file = ''
+  switch (path) {
+    case 'scene.json': {
+      const project: Project = yield select(getCurrentProject)
+      file = JSON.stringify({
+        scene: {
+          parcels: getParcels(project.layout).map($ => `${$.x},${$.y}`),
+          base: '0,0'
+        }
+      })
+      break
+    }
+    case 'assets/scene/main.composite': {
+      file = scene.composite
+      break
+    }
+    case 'inspector-preferences.json': {
+      file = JSON.stringify({
+        version: 1,
+        data: {
+          freeCameraInvertRotation: false,
+          autosaveEnabled: true
+        }
+      })
+      break
+    }
+  }
+  const buffer = Buffer.from(file, 'utf-8')
+  return buffer
+}
+
+function* handleExists(params: IframeStorage.Params['exists']) {
+  const { path } = params
+  switch (path) {
+    case 'scene.json':
+    case 'assets/scene/main.composite':
+    case 'inspector-preferences.json': {
+      return true
+    }
+    default: {
+      const scene: SceneSDK7 = yield getScene()
+      return path in scene.mappings
+    }
+  }
+}
+
+function* handleList(params: IframeStorage.Params['list']) {
+  const { path } = params
+
+  const scene: SceneSDK7 = yield getScene()
+  const paths = [...Object.keys(scene.mappings), 'assets/scene/main.composite']
+  const files: { name: string; isDirectory: boolean }[] = []
+
+  for (const _path of paths) {
+    if (!_path.startsWith(path)) continue
+
+    const fileName = _path.substring(path.length)
+    const slashPosition = fileName.indexOf('/')
+    if (slashPosition !== -1) {
+      const directoryName = fileName.substring(0, slashPosition)
+      if (!files.find(item => item.name === directoryName)) {
+        files.push({ name: directoryName, isDirectory: true })
       }
-      case 'assets/scene/main.composite': {
-        return JSON.stringify(composite)
-      }
-      case 'inspector-preferences.json': {
-        return JSON.stringify({
-          version: 1,
-          data: {
-            freeCameraInvertRotation: false,
-            autosaveEnabled: false
-          }
-        })
-      }
-      default: {
-        return ''
-      }
+    } else {
+      files.push({ name: fileName, isDirectory: false })
     }
   }
 
-  server.handle<IframeStorage.Method.READ_FILE>('read_file', async ({ path }) => {
-    console.log('read_file', path)
-
-    if (path in mappings) {
-      const hash = mappings[path]
-      const buffer = await (await fetch(`https://builder-api.decentraland.org/v1/storage/contents/${hash}`)).arrayBuffer()
-      return Buffer.from(buffer)
-    }
-    const file = getFile(path)
-    console.log('file', file)
-    const buffer = Buffer.from(file, 'utf-8')
-    console.log(buffer)
-    return buffer
-  })
-
-  server.handle<IframeStorage.Method.EXISTS>('exists', ({ path }) => {
-    console.log('exists', path)
-    return Promise.resolve(true)
-  })
-
-  server.handle<IframeStorage.Method.LIST>('list', ({ path }) => {
-    // const allPaths =
-    const paths = [...Object.keys(mappings), 'assets/scene/main.composite']
-
-    const files: { name: string; isDirectory: boolean }[] = []
-    for (const _path of paths) {
-      if (!_path.startsWith(path)) continue
-
-      const fileName = _path.substring(path.length)
-      const slashPosition = fileName.indexOf('/')
-      if (slashPosition !== -1) {
-        const directoryName = fileName.substring(0, slashPosition)
-        if (!files.find(item => item.name === directoryName)) {
-          files.push({ name: directoryName, isDirectory: true })
-        }
-      } else {
-        files.push({ name: fileName, isDirectory: false })
-      }
-    }
-
-    console.log('list', path, files)
-    return Promise.resolve(files)
-  })
-
-  server.handle<IframeStorage.Method.WRITE_FILE>('write_file', ({ path, content }) => {
-    console.log('write_file', path, new TextDecoder().decode(content))
-    return Promise.resolve()
-  })
+  return files
 }
+
+function* handleWriteFile(params: IframeStorage.Params['write_file']) {
+  const { path, content } = params
+
+  switch (path) {
+    case 'scene.json': {
+      // TODO: some changes to the scene.json might eventually end up in changes to the Project, like the name or the layout, but for now we can ignore it
+      break
+    }
+    case 'assets/scene/main.composite': {
+      const scene: SceneSDK7 = yield getScene()
+      const newScene: SceneSDK7 = {
+        ...scene,
+        composite: new TextDecoder().decode(content)
+      }
+      yield put(updateScene(newScene))
+      break
+    }
+    case 'inspector-preferences.json': {
+      break
+    }
+    default: {
+      const hash: string = yield call(hashV1, content)
+
+      const res: Response = yield call(fetch, getContentsStorageUrl(hash), { headers: NO_CACHE_HEADERS })
+      if (!res.ok) {
+        // TODO: remove this, use builder-server
+        FILES.set(path, content)
+      }
+
+      const scene: SceneSDK7 = yield getScene()
+      const newScene: SceneSDK7 = {
+        ...scene,
+        mappings: {
+          ...scene.mappings,
+          [path]: hash
+        }
+      }
+
+      yield put(updateScene(newScene))
+    }
+  }
+}
+
+function* handleDelete(params: IframeStorage.Params['delete']) {
+  const { path } = params
+  console.log('delete', path)
+
+  const scene: SceneSDK7 = yield getScene()
+
+  FILES.delete(path)
+
+  if (path in scene.mappings) {
+    const newMappings = { ...scene.mappings }
+    delete newMappings[path]
+    const newScene: SceneSDK7 = {
+      ...scene,
+      mappings: newMappings
+    }
+    yield put(updateScene(newScene))
+  }
+
+  return
+}
+
+// UTILS
 
 function* getProject(projectId: string): any {
   // grab projects from store
@@ -201,4 +347,33 @@ function* getProject(projectId: string): any {
     console.error(result.failure)
     throw new Error(`Could not load project`)
   }
+}
+
+function* getScene() {
+  const project: Project = yield select(getCurrentProject)
+
+  if (!project) {
+    throw new Error('Invalid project')
+  }
+
+  let scene: Scene | null = yield select(getCurrentScene)
+
+  if (!scene) {
+    throw new Error('Invalid scene')
+  }
+
+  if (!scene.sdk7) {
+    // TODO: remove automagic convertion into sdk7 once migration is possible via UI
+    console.log('SCENE IS NOT SDK7')
+    scene = {
+      sdk6: null,
+      sdk7: {
+        id: scene.sdk6.id,
+        composite: toComposite(scene.sdk6, project),
+        mappings: toMappings(scene.sdk6)
+      }
+    }
+  }
+
+  return scene.sdk7
 }

--- a/src/modules/inspector/sagas.ts
+++ b/src/modules/inspector/sagas.ts
@@ -133,7 +133,7 @@ function* handleRpcRequest(action: RPCRequestAction) {
     const result: IframeStorage.Result[IframeStorage.Method] = yield handler(params)
     yield put(rpcSuccess(method, result, nonce))
   } catch (error) {
-    yield put(rpcFailure(method, error.message, nonce))
+    yield put(rpcFailure(method, params, error.message, nonce))
   }
 }
 
@@ -157,13 +157,11 @@ function handleRpcFailure(action: RPCFailureAction) {
 
 function* handleReadFile(params: IframeStorage.Params['read_file']) {
   const { path } = params
-  console.log('read_file', path)
 
   const scene: SceneSDK7 = yield getScene()
 
   // TODO: this should be fetched from the builder-server
   if (FILES.has(path)) {
-    console.log('loading file from memory')
     return FILES.get(path)
   }
 
@@ -187,7 +185,7 @@ function* handleReadFile(params: IframeStorage.Params['read_file']) {
       break
     }
     case 'assets/scene/main.composite': {
-      file = scene.composite
+      file = JSON.stringify(scene.composite)
       break
     }
     case 'inspector-preferences.json': {
@@ -257,7 +255,7 @@ function* handleWriteFile(params: IframeStorage.Params['write_file']) {
       const scene: SceneSDK7 = yield getScene()
       const newScene: SceneSDK7 = {
         ...scene,
-        composite: new TextDecoder().decode(content)
+        composite: JSON.parse(new TextDecoder().decode(content))
       }
       yield put(updateScene(newScene))
       break
@@ -290,7 +288,6 @@ function* handleWriteFile(params: IframeStorage.Params['write_file']) {
 
 function* handleDelete(params: IframeStorage.Params['delete']) {
   const { path } = params
-  console.log('delete', path)
 
   const scene: SceneSDK7 = yield getScene()
 

--- a/src/modules/inspector/sagas.ts
+++ b/src/modules/inspector/sagas.ts
@@ -38,339 +38,329 @@ import {
 import { Project } from 'modules/project/types'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 import { IframeStorage, MessageTransport } from '@dcl/inspector'
-import { getParcels, toComposite, toMappings } from './utils'
+import { getParcels } from './utils'
 import { getContentsStorageUrl } from 'lib/api/builder'
 import { NO_CACHE_HEADERS } from 'lib/headers'
-import { store } from 'modules/common/store'
 import { Scene, SceneSDK7 } from 'modules/scene/types'
 import { updateScene } from 'modules/scene/actions'
+import { RootStore } from 'modules/common/types'
 
 let nonces = 0
 const getNonce = () => nonces++
 const promises = new Map<number, IFuture<unknown>>()
-const handlers: Record<`${IframeStorage.Method}`, (params: any) => Generator> = {
-  read_file: handleReadFile,
-  exists: handleExists,
-  list: handleList,
-  write_file: handleWriteFile,
-  delete: handleDelete
-}
 
 // TODO: delete this, use builder-server
 const FILES = new Map<string, Buffer>()
 
-export function* inspectorSaga() {
+export function* inspectorSaga(store: RootStore) {
   yield takeEvery(OPEN_INSPECTOR, handleOpenInspector)
   yield takeEvery(CONNECT_INSPECTOR, handleConnectInspector)
   yield takeEvery(RPC_REQUEST, handleRpcRequest)
   yield takeEvery(RPC_SUCCESS, handleRpcSuccess)
   yield takeEvery(RPC_FAILURE, handleRpcFailure)
-}
 
-function* handleOpenInspector(_action: OpenInspectorAction) {
-  try {
-    const projectId = getProjectId()
-    if (!projectId) {
-      throw new Error(`Invalid projectId=${projectId}`)
+  function* handleOpenInspector(_action: OpenInspectorAction) {
+    try {
+      const projectId = getProjectId()
+      if (!projectId) {
+        throw new Error(`Invalid projectId=${projectId}`)
+      }
+      const loggingIn: boolean = yield select(isLoggingIn)
+      if (loggingIn) {
+        const result: { success?: LoginSuccessAction; failure?: LoginFailureAction } = yield race({
+          success: take(LOGIN_SUCCESS),
+          failure: take(LOGIN_FAILURE)
+        })
+
+        if (result.failure) {
+          throw new Error('Could not load login')
+        }
+      }
+
+      const project: Project = yield getProject(projectId)
+
+      yield put(loadProjectSceneRequest(project))
+      {
+        const result: { success?: LoadProjectSceneSuccessAction; failure?: LoadProjectSceneFailureAction } = yield race({
+          success: take(LOAD_PROJECT_SCENE_SUCCESS),
+          failure: take(LOAD_PROJECT_SCENE_FAILURE)
+        })
+        if (result.failure) {
+          throw new Error('Could not load scene')
+        }
+      }
+    } catch (error) {
+      console.error(error)
     }
-    const loggingIn: boolean = yield select(isLoggingIn)
-    if (loggingIn) {
-      const result: { success?: LoginSuccessAction; failure?: LoginFailureAction } = yield race({
-        success: take(LOGIN_SUCCESS),
-        failure: take(LOGIN_FAILURE)
-      })
+  }
 
-      if (result.failure) {
-        throw new Error('Could not load login')
+  function handleConnectInspector(action: ConnectInspectorAction) {
+    const { iframeId } = action.payload
+
+    const iframe = document.getElementById(iframeId) as HTMLIFrameElement | null
+    if (iframe === null) {
+      throw new Error(`Iframe with id="${iframeId}" not found`)
+    }
+
+    const transport = new MessageTransport(window, iframe.contentWindow!, '*')
+    const storage = new IframeStorage.Server(transport)
+
+    const methods = Object.keys(handlers) as (keyof typeof handlers)[]
+    for (const method of methods) {
+      storage.handle(method, params => {
+        const nonce = getNonce()
+        const action = rpcRequest(method, params, nonce)
+        const promise = future()
+        promises.set(nonce, promise)
+        store.dispatch(action)
+        return promise
+      })
+    }
+  }
+
+  function* handleRpcRequest(action: RPCRequestAction) {
+    const { method, params, nonce } = action.payload
+    try {
+      const handler = handlers[method]
+      const result: IframeStorage.Result[IframeStorage.Method] = yield handler(params)
+      yield put(rpcSuccess(method, result, nonce))
+    } catch (error) {
+      yield put(rpcFailure(method, params, error.message, nonce))
+    }
+  }
+
+  function handleRpcSuccess(action: RPCSuccessAction) {
+    const { result, nonce } = action.payload
+    const promise = promises.get(nonce)
+    if (promise) {
+      promise.resolve(result)
+    }
+  }
+
+  function handleRpcFailure(action: RPCFailureAction) {
+    const { error, nonce } = action.payload
+    const promise = promises.get(nonce)
+    if (promise) {
+      promise.reject(new Error(error))
+    }
+  }
+
+  // HANDLERS
+
+  const handlers: Record<`${IframeStorage.Method}`, (params: any) => Generator> = {
+    read_file: handleReadFile,
+    exists: handleExists,
+    list: handleList,
+    write_file: handleWriteFile,
+    delete: handleDelete
+  }
+
+  function* handleReadFile(params: IframeStorage.Params['read_file']) {
+    const { path } = params
+
+    const scene: SceneSDK7 = yield getScene()
+
+    // TODO: this should be fetched from the builder-server
+    if (FILES.has(path)) {
+      return FILES.get(path)
+    }
+
+    if (path in scene.mappings) {
+      const hash = scene.mappings[path]
+      const response: Response = yield call(fetch, `https://builder-api.decentraland.org/v1/storage/contents/${hash}`)
+      const buffer: ArrayBuffer = yield call([response, 'arrayBuffer'])
+      return Buffer.from(buffer)
+    }
+
+    let file = ''
+    switch (path) {
+      case 'scene.json': {
+        const project: Project = yield select(getCurrentProject)
+        file = JSON.stringify({
+          scene: {
+            parcels: getParcels(project.layout).map($ => `${$.x},${$.y}`),
+            base: '0,0'
+          }
+        })
+        break
+      }
+      case 'assets/scene/main.composite': {
+        file = JSON.stringify(scene.composite)
+        break
+      }
+      case 'inspector-preferences.json': {
+        file = JSON.stringify({
+          version: 1,
+          data: {
+            freeCameraInvertRotation: false,
+            autosaveEnabled: true
+          }
+        })
+        break
+      }
+    }
+    const buffer = Buffer.from(file, 'utf-8')
+    return buffer
+  }
+
+  function* handleExists(params: IframeStorage.Params['exists']) {
+    const { path } = params
+    switch (path) {
+      case 'scene.json':
+      case 'assets/scene/main.composite':
+      case 'inspector-preferences.json': {
+        return true
+      }
+      default: {
+        const scene: SceneSDK7 = yield getScene()
+        return path in scene.mappings
+      }
+    }
+  }
+
+  function* handleList(params: IframeStorage.Params['list']) {
+    const { path } = params
+
+    const scene: SceneSDK7 = yield getScene()
+    const paths = [...Object.keys(scene.mappings), 'assets/scene/main.composite']
+    const files: { name: string; isDirectory: boolean }[] = []
+
+    for (const _path of paths) {
+      if (!_path.startsWith(path)) continue
+
+      const fileName = _path.substring(path.length)
+      const slashPosition = fileName.indexOf('/')
+      if (slashPosition !== -1) {
+        const directoryName = fileName.substring(0, slashPosition)
+        if (!files.find(item => item.name === directoryName)) {
+          files.push({ name: directoryName, isDirectory: true })
+        }
+      } else {
+        files.push({ name: fileName, isDirectory: false })
       }
     }
 
-    const project: Project = yield getProject(projectId)
+    return files
+  }
 
-    yield put(loadProjectSceneRequest(project))
-    {
-      const result: { success?: LoadProjectSceneSuccessAction; failure?: LoadProjectSceneFailureAction } = yield race({
-        success: take(LOAD_PROJECT_SCENE_SUCCESS),
-        failure: take(LOAD_PROJECT_SCENE_FAILURE)
-      })
-      if (result.failure) {
-        throw new Error('Could not load scene')
+  function* handleWriteFile(params: IframeStorage.Params['write_file']) {
+    const { path, content } = params
+
+    switch (path) {
+      case 'scene.json': {
+        // TODO: some changes to the scene.json might eventually end up in changes to the Project, like the name or the layout, but for now we can ignore it
+        break
+      }
+      case 'assets/scene/main.composite': {
+        const scene: SceneSDK7 = yield getScene()
+        const newScene: SceneSDK7 = {
+          ...scene,
+          composite: JSON.parse(new TextDecoder().decode(content))
+        }
+        yield put(updateScene(newScene))
+        break
+      }
+      case 'inspector-preferences.json': {
+        break
+      }
+      default: {
+        const hash: string = yield call(hashV1, content)
+
+        const res: Response = yield call(fetch, getContentsStorageUrl(hash), { headers: NO_CACHE_HEADERS })
+        if (!res.ok) {
+          // TODO: remove this, use builder-server
+          FILES.set(path, content)
+        }
+
+        const scene: SceneSDK7 = yield getScene()
+        const newScene: SceneSDK7 = {
+          ...scene,
+          mappings: {
+            ...scene.mappings,
+            [path]: hash
+          }
+        }
+
+        yield put(updateScene(newScene))
       }
     }
-  } catch (error) {
-    console.error(error)
-  }
-}
-
-function handleConnectInspector(action: ConnectInspectorAction) {
-  const { iframeId } = action.payload
-
-  const iframe = document.getElementById(iframeId) as HTMLIFrameElement | null
-  if (iframe === null) {
-    throw new Error(`Iframe with id="${iframeId}" not found`)
   }
 
-  const transport = new MessageTransport(window, iframe.contentWindow!, '*')
-  const storage = new IframeStorage.Server(transport)
+  function* handleDelete(params: IframeStorage.Params['delete']) {
+    const { path } = params
 
-  const methods = Object.keys(handlers) as (keyof typeof handlers)[]
-  for (const method of methods) {
-    storage.handle(method, params => {
-      const nonce = getNonce()
-      const action = rpcRequest(method, params, nonce)
-      const promise = future()
-      promises.set(nonce, promise)
-      store.dispatch(action)
-      return promise
+    const scene: SceneSDK7 = yield getScene()
+
+    FILES.delete(path)
+
+    if (path in scene.mappings) {
+      const newMappings = { ...scene.mappings }
+      delete newMappings[path]
+      const newScene: SceneSDK7 = {
+        ...scene,
+        mappings: newMappings
+      }
+      yield put(updateScene(newScene))
+    }
+  }
+
+  // UTILS
+
+  function* getProject(projectId: string): any {
+    // grab projects from store
+    const projects: Record<string, Project> = yield select(getProjects)
+    const project = projects[projectId]
+
+    // if project is found in store, return it
+    if (project) {
+      return project
+    }
+
+    // if project is not in the store, check if projects are being loaded
+    const projectsLoadingState: ReturnType<typeof getLoadingProjects> = yield select(getLoadingProjects)
+    const isLoading = isLoadingType(projectsLoadingState, LOAD_PROJECTS_REQUEST)
+
+    // if projects are not being loaded, then request them
+    if (!isLoading) {
+      yield put(loadProjectsRequest())
+    }
+
+    // wait for projects to be loaded
+    const result: { success?: LoadProjectsSuccessAction; failure?: LoadProjectsFailureAction } = yield race({
+      success: take(LOAD_PROJECTS_SUCCESS),
+      failure: take(LOAD_PROJECTS_FAILURE)
     })
-  }
-}
 
-function* handleRpcRequest(action: RPCRequestAction) {
-  const { method, params, nonce } = action.payload
-  try {
-    const handler = handlers[method]
-    const result: IframeStorage.Result[IframeStorage.Method] = yield handler(params)
-    yield put(rpcSuccess(method, result, nonce))
-  } catch (error) {
-    yield put(rpcFailure(method, params, error.message, nonce))
-  }
-}
-
-function handleRpcSuccess(action: RPCSuccessAction) {
-  const { result, nonce } = action.payload
-  const promise = promises.get(nonce)
-  if (promise) {
-    promise.resolve(result)
-  }
-}
-
-function handleRpcFailure(action: RPCFailureAction) {
-  const { error, nonce } = action.payload
-  const promise = promises.get(nonce)
-  if (promise) {
-    promise.reject(new Error(error))
-  }
-}
-
-// HANDLERS
-
-function* handleReadFile(params: IframeStorage.Params['read_file']) {
-  const { path } = params
-
-  const scene: SceneSDK7 = yield getScene()
-
-  // TODO: this should be fetched from the builder-server
-  if (FILES.has(path)) {
-    return FILES.get(path)
-  }
-
-  if (path in scene.mappings) {
-    const hash = scene.mappings[path]
-    const response: Response = yield call(fetch, `https://builder-api.decentraland.org/v1/storage/contents/${hash}`)
-    const buffer: ArrayBuffer = yield call([response, 'arrayBuffer'])
-    return Buffer.from(buffer)
-  }
-
-  let file = ''
-  switch (path) {
-    case 'scene.json': {
-      const project: Project = yield select(getCurrentProject)
-      file = JSON.stringify({
-        scene: {
-          parcels: getParcels(project.layout).map($ => `${$.x},${$.y}`),
-          base: '0,0'
-        }
-      })
-      break
+    // if load is successful try getting the project again
+    if (result.success) {
+      const _project: Project = yield getProject(projectId)
+      return _project
     }
-    case 'assets/scene/main.composite': {
-      file = JSON.stringify(scene.composite)
-      break
-    }
-    case 'inspector-preferences.json': {
-      file = JSON.stringify({
-        version: 1,
-        data: {
-          freeCameraInvertRotation: false,
-          autosaveEnabled: true
-        }
-      })
-      break
-    }
-  }
-  const buffer = Buffer.from(file, 'utf-8')
-  return buffer
-}
 
-function* handleExists(params: IframeStorage.Params['exists']) {
-  const { path } = params
-  switch (path) {
-    case 'scene.json':
-    case 'assets/scene/main.composite':
-    case 'inspector-preferences.json': {
-      return true
-    }
-    default: {
-      const scene: SceneSDK7 = yield getScene()
-      return path in scene.mappings
-    }
-  }
-}
-
-function* handleList(params: IframeStorage.Params['list']) {
-  const { path } = params
-
-  const scene: SceneSDK7 = yield getScene()
-  const paths = [...Object.keys(scene.mappings), 'assets/scene/main.composite']
-  const files: { name: string; isDirectory: boolean }[] = []
-
-  for (const _path of paths) {
-    if (!_path.startsWith(path)) continue
-
-    const fileName = _path.substring(path.length)
-    const slashPosition = fileName.indexOf('/')
-    if (slashPosition !== -1) {
-      const directoryName = fileName.substring(0, slashPosition)
-      if (!files.find(item => item.name === directoryName)) {
-        files.push({ name: directoryName, isDirectory: true })
-      }
-    } else {
-      files.push({ name: fileName, isDirectory: false })
+    // if load fails then throw
+    if (result.failure) {
+      console.error(result.failure)
+      throw new Error(`Could not load project`)
     }
   }
 
-  return files
-}
+  function* getScene() {
+    const project: Project = yield select(getCurrentProject)
 
-function* handleWriteFile(params: IframeStorage.Params['write_file']) {
-  const { path, content } = params
-
-  switch (path) {
-    case 'scene.json': {
-      // TODO: some changes to the scene.json might eventually end up in changes to the Project, like the name or the layout, but for now we can ignore it
-      break
+    if (!project) {
+      throw new Error('Invalid project')
     }
-    case 'assets/scene/main.composite': {
-      const scene: SceneSDK7 = yield getScene()
-      const newScene: SceneSDK7 = {
-        ...scene,
-        composite: JSON.parse(new TextDecoder().decode(content))
-      }
-      yield put(updateScene(newScene))
-      break
+
+    const scene: Scene | null = yield select(getCurrentScene)
+
+    if (!scene) {
+      throw new Error('Invalid scene')
     }
-    case 'inspector-preferences.json': {
-      break
+
+    if (!scene.sdk7) {
+      throw new Error('Scene must be SDK7')
     }
-    default: {
-      const hash: string = yield call(hashV1, content)
 
-      const res: Response = yield call(fetch, getContentsStorageUrl(hash), { headers: NO_CACHE_HEADERS })
-      if (!res.ok) {
-        // TODO: remove this, use builder-server
-        FILES.set(path, content)
-      }
-
-      const scene: SceneSDK7 = yield getScene()
-      const newScene: SceneSDK7 = {
-        ...scene,
-        mappings: {
-          ...scene.mappings,
-          [path]: hash
-        }
-      }
-
-      yield put(updateScene(newScene))
-    }
+    return scene.sdk7
   }
-}
-
-function* handleDelete(params: IframeStorage.Params['delete']) {
-  const { path } = params
-
-  const scene: SceneSDK7 = yield getScene()
-
-  FILES.delete(path)
-
-  if (path in scene.mappings) {
-    const newMappings = { ...scene.mappings }
-    delete newMappings[path]
-    const newScene: SceneSDK7 = {
-      ...scene,
-      mappings: newMappings
-    }
-    yield put(updateScene(newScene))
-  }
-
-  return
-}
-
-// UTILS
-
-function* getProject(projectId: string): any {
-  // grab projects from store
-  const projects: Record<string, Project> = yield select(getProjects)
-  const project = projects[projectId]
-
-  // if project is found in store, return it
-  if (project) {
-    return project
-  }
-
-  // if project is not in the store, check if projects are being loaded
-  const projectsLoadingState: ReturnType<typeof getLoadingProjects> = yield select(getLoadingProjects)
-  const isLoading = isLoadingType(projectsLoadingState, LOAD_PROJECTS_REQUEST)
-
-  // if projects are not being loaded, then request them
-  if (!isLoading) {
-    yield put(loadProjectsRequest())
-  }
-
-  // wait for projects to be loaded
-  const result: { success?: LoadProjectsSuccessAction; failure?: LoadProjectsFailureAction } = yield race({
-    success: take(LOAD_PROJECTS_SUCCESS),
-    failure: take(LOAD_PROJECTS_FAILURE)
-  })
-
-  // if load is successful try getting the project again
-  if (result.success) {
-    const _project: Project = yield getProject(projectId)
-    return _project
-  }
-
-  // if load fails then throw
-  if (result.failure) {
-    console.error(result.failure)
-    throw new Error(`Could not load project`)
-  }
-}
-
-function* getScene() {
-  const project: Project = yield select(getCurrentProject)
-
-  if (!project) {
-    throw new Error('Invalid project')
-  }
-
-  let scene: Scene | null = yield select(getCurrentScene)
-
-  if (!scene) {
-    throw new Error('Invalid scene')
-  }
-
-  if (!scene.sdk7) {
-    // TODO: remove automagic convertion into sdk7 once migration is possible via UI
-    console.log('SCENE IS NOT SDK7')
-    scene = {
-      sdk6: null,
-      sdk7: {
-        id: scene.sdk6.id,
-        composite: toComposite(scene.sdk6, project),
-        mappings: toMappings(scene.sdk6)
-      }
-    }
-  }
-
-  return scene.sdk7
 }

--- a/src/modules/inspector/utils.ts
+++ b/src/modules/inspector/utils.ts
@@ -52,7 +52,7 @@ export function toComposite(scene: SceneSDK6, project?: Project) {
   })
 
   const composite = dumpEngineToComposite(engine as any, 'json')
-  return Composite.toJson(composite) as string
+  return JSON.stringify(Composite.toJson(composite))
 }
 
 export function toMappings(scene: SceneSDK6): Record<string, string> {

--- a/src/modules/inspector/utils.ts
+++ b/src/modules/inspector/utils.ts
@@ -1,4 +1,4 @@
-import { Composite } from '@dcl/ecs'
+import { Composite, CompositeDefinition } from '@dcl/ecs'
 import { createEngineContext, dumpEngineToComposite } from '@dcl/inspector'
 import { Layout, Project } from 'modules/project/types'
 import { ComponentData, ComponentType, SceneSDK6 } from 'modules/scene/types'
@@ -52,7 +52,7 @@ export function toComposite(scene: SceneSDK6, project?: Project) {
   })
 
   const composite = dumpEngineToComposite(engine as any, 'json')
-  return JSON.stringify(Composite.toJson(composite))
+  return Composite.toJson(composite) as CompositeDefinition
 }
 
 export function toMappings(scene: SceneSDK6): Record<string, string> {

--- a/src/modules/scene/actions.ts
+++ b/src/modules/scene/actions.ts
@@ -1,6 +1,6 @@
 import { action } from 'typesafe-actions'
 import { Asset, AssetParameterValues } from 'modules/asset/types'
-import { Scene, ComponentType, ComponentData, SceneSDK6 } from './types'
+import { Scene, ComponentType, ComponentData, SceneSDK6, SceneSDK7 } from './types'
 import { ModelMetrics, Vector3 } from 'modules/models/types'
 import { Project } from 'modules/project/types'
 
@@ -133,3 +133,10 @@ export const SET_SCRIPT_VALUES = 'Set Script Values'
 export const setScriptValues = (entityId: string, values: AssetParameterValues) => action(SET_SCRIPT_VALUES, { entityId, values })
 
 export type SetScriptValuesAction = ReturnType<typeof setScriptValues>
+
+// Update Scene
+export const UPDATE_SCENE = 'Update scene'
+
+export const updateScene = (scene: SceneSDK7) => action(UPDATE_SCENE, { scene })
+
+export type UpdateSceneAction = ReturnType<typeof updateScene>

--- a/src/modules/scene/reducer.ts
+++ b/src/modules/scene/reducer.ts
@@ -12,7 +12,9 @@ import {
   FixLegacyNamespacesSuccessAction,
   FIX_LEGACY_NAMESPACES_SUCCESS,
   SYNC_SCENE_ASSETS_SUCCESS,
-  SyncSceneAssetsSuccessAction
+  SyncSceneAssetsSuccessAction,
+  UPDATE_SCENE,
+  UpdateSceneAction
 } from 'modules/scene/actions'
 import {
   DeleteProjectAction,
@@ -38,6 +40,7 @@ export type SceneReducerAction =
   | FixLegacyNamespacesSuccessAction
   | SyncSceneAssetsSuccessAction
   | LoadProjectSceneSuccessAction
+  | UpdateSceneAction
 
 const INITIAL_STATE: SceneState = {
   data: {},
@@ -67,6 +70,22 @@ const baseSceneReducer = (state: SceneState = INITIAL_STATE, action: SceneReduce
           data: {
             ...state.data,
             [scene.sdk7.id]: { ...scene }
+          }
+        }
+      }
+    }
+    case UPDATE_SCENE: {
+      const { scene } = action.payload
+      return {
+        ...state,
+        data: {
+          ...state.data,
+          [scene.id]: {
+            ...state.data[scene.id],
+            sdk6: null,
+            sdk7: {
+              ...scene
+            }
           }
         }
       }

--- a/src/modules/scene/types.ts
+++ b/src/modules/scene/types.ts
@@ -1,3 +1,4 @@
+import { CompositeDefinition } from '@dcl/ecs'
 import { Asset, AssetParameterValues } from 'modules/asset/types'
 import { ModelMetrics, Vector3, Quaternion } from 'modules/models/types'
 
@@ -75,6 +76,6 @@ export type SceneSDK6 = {
 
 export type SceneSDK7 = {
   id: string
-  composite: string
+  composite: CompositeDefinition
   mappings: Record<string, string>
 }

--- a/src/modules/sync/sagas.ts
+++ b/src/modules/sync/sagas.ts
@@ -14,7 +14,7 @@ import {
   EDIT_PROJECT_THUMBNAIL,
   EditProjectThumbnailAction
 } from 'modules/project/actions'
-import { PROVISION_SCENE, ProvisionSceneAction } from 'modules/scene/actions'
+import { PROVISION_SCENE, ProvisionSceneAction, UpdateSceneAction, UPDATE_SCENE } from 'modules/scene/actions'
 
 import {
   SAVE_PROJECT_REQUEST,
@@ -52,6 +52,7 @@ export function* syncSaga(builder: BuilderAPI) {
   yield takeLatest(DELETE_PROJECT, handleDeleteProject)
   yield takeLatest(PROVISION_SCENE, handleProvisionScene)
   yield takeLatest(SAVE_PROJECT_SUCCESS, handleSaveProjectSuccess)
+  yield takeLatest(UPDATE_SCENE, handleUpdateScene)
 
   function* handleLoginSuccess(_action: LoginSuccessAction) {
     yield put(sync())
@@ -136,6 +137,16 @@ export function* syncSaga(builder: BuilderAPI) {
 
   function* handleProvisionScene(action: ProvisionSceneAction) {
     if (action.payload.init) return
+    const isLoggedInResult: boolean = yield select(isLoggedIn)
+    if (isLoggedInResult) {
+      const project: Project | null = yield select(getCurrentProject)
+      if (project) {
+        yield put(saveProjectRequest(project))
+      }
+    }
+  }
+
+  function* handleUpdateScene(_action: UpdateSceneAction) {
     const isLoggedInResult: boolean = yield select(isLoggedIn)
     if (isLoggedInResult) {
       const project: Project | null = yield select(getCurrentProject)


### PR DESCRIPTION
This PR refactor all the server handlers into generators, so we can use redux (using selector, dispatching actions, using sagas' flow control) from within them (before they were async function without connection to redux).

It also adds the ability to save scenes. There is one thing that is not implemented yet which is the upload of assets, that will require a new endpoint, for now it is implemented in memory storing the assets in a map.