### PR TITLE
fix: SW contents

### DIFF
--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
@@ -30,7 +30,6 @@ import {
   WearableRepresentation,
   ItemType,
   EmotePlayMode,
-  SCENE_PATH,
   VIDEO_PATH,
   WearableData
 } from 'modules/item/types'
@@ -143,7 +142,7 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
   prefixContents(bodyShape: BodyShapeType, contents: Record<string, Blob>): Record<string, Blob> {
     return Object.keys(contents).reduce((newContents: Record<string, Blob>, key: string) => {
       // Do not include the thumbnail, scenes, and video in each of the body shapes
-      if ([THUMBNAIL_PATH, SCENE_PATH, VIDEO_PATH].includes(key)) {
+      if ([THUMBNAIL_PATH, VIDEO_PATH].includes(key)) {
         return newContents
       }
       newContents[this.prefixContentName(bodyShape, key)] = contents[key]
@@ -167,7 +166,6 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
 
     const all = {
       [THUMBNAIL_PATH]: contents[THUMBNAIL_PATH],
-      [SCENE_PATH]: contents[SCENE_PATH],
       [VIDEO_PATH]: contents[VIDEO_PATH],
       ...male,
       ...female
@@ -188,7 +186,6 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
     }
     const all = {
       [THUMBNAIL_PATH]: contents[THUMBNAIL_PATH],
-      [SCENE_PATH]: contents[SCENE_PATH],
       ...male,
       ...female
     }

--- a/src/modules/deployment/contentUtils.ts
+++ b/src/modules/deployment/contentUtils.ts
@@ -1,17 +1,14 @@
 import { hashV1 } from '@dcl/hashing'
-import { VIDEO_PATH } from 'modules/item/types'
 import { getContentsStorageUrl } from 'lib/api/builder'
 import { NO_CACHE_HEADERS } from 'lib/headers'
 import { default as toBuffer } from 'blob-to-buffer'
 
-export const FILE_NAME_BLACKLIST = ['.dclignore', 'Dockerfile', 'builder.json', 'src/game.ts', VIDEO_PATH]
+export const FILE_NAME_BLACKLIST = ['.dclignore', 'Dockerfile', 'builder.json', 'src/game.ts']
 
 export async function computeHashes(contents: Record<string, Blob>): Promise<Record<string, string>> {
   const contentsAsHashes: Record<string, string> = {}
   for (const path in contents) {
     const blob = contents[path]
-    const isEmpty = blob.size === 0 // skip empty blobs, it breaks the catalyst
-    if (FILE_NAME_BLACKLIST.includes(path) || isEmpty) continue
     const blobBuffer = await blob.arrayBuffer()
     contentsAsHashes[path] = await hashV1(new Uint8Array(blobBuffer))
   }


### PR DESCRIPTION
This PR updates the `SW` data representation to contain the `scene.json`. 

Also, it fixes sending the video content to the builder-server, removed previously in [[this PR]](https://github.com/decentraland/builder/pull/2785/files#diff-6e44a8ab5281e24e1251f5bee8340d324289f9b25dfbf8f77aba93077b4c71b5R539).