### PR TITLE
feat: Upload video back takes the previous view into account

### DIFF
--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
@@ -722,7 +722,6 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
     const keys = Object.keys(this.state)
     const { fromView } = this.state
 
-    console.log('fromView', fromView)
 
     if (fromView) {
       this.setState({ view: fromView })

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
@@ -450,7 +450,6 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
   handleVideoDropAccepted = (acceptedFileProps: AcceptedFileProps) => {
     this.setState({
       isLoading: true,
-      fromView: undefined,
       ...acceptedFileProps
     })
   }
@@ -722,6 +721,8 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
   handleUploadVideoGoBack = () => {
     const keys = Object.keys(this.state)
     const { fromView } = this.state
+
+    console.log('fromView', fromView)
 
     if (fromView) {
       this.setState({ view: fromView })

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
@@ -450,12 +450,14 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
   handleVideoDropAccepted = (acceptedFileProps: AcceptedFileProps) => {
     this.setState({
       isLoading: true,
+      fromView: undefined,
       ...acceptedFileProps
     })
   }
 
   handleSaveVideo = () => {
     this.setState({
+      fromView: undefined,
       view: CreateItemView.DETAILS
     })
   }
@@ -528,7 +530,7 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
   }
 
   handleOpenVideoDialog = () => {
-    this.setState({ view: CreateItemView.UPLOAD_VIDEO })
+    this.setState({ view: CreateItemView.UPLOAD_VIDEO, fromView: CreateItemView.DETAILS })
   }
 
   handleYes = () => this.setState({ isRepresentation: true })
@@ -719,6 +721,13 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
 
   handleUploadVideoGoBack = () => {
     const keys = Object.keys(this.state)
+    const { fromView } = this.state
+
+    if (fromView) {
+      this.setState({ view: fromView })
+      return
+    }
+
     const stateReset = keys.reduce((acc, v) => ({ ...acc, [v]: undefined }), {})
     this.setState({ ...stateReset, ...this.getInitialState() })
   }

--- a/src/components/Modals/CreateSingleItemModal/UploadVideoStep/UploadVideoStep.tsx
+++ b/src/components/Modals/CreateSingleItemModal/UploadVideoStep/UploadVideoStep.tsx
@@ -117,7 +117,7 @@ export default class UploadVideoStep extends React.PureComponent<Props, State> {
 
     return (
       <>
-        <ModalNavigation title={title} onBack={onBack} onClose={onClose} />
+        <ModalNavigation title={title} onBack={video ? this.handleGoBack : onBack} onClose={onClose} />
         <Modal.Content>
           {(!video || id) && (
             <FileImport


### PR DESCRIPTION
It considers the previous view to navigate using the back button in the header.

When the user is viewing the item's details and wants to modify the video, if the user clicks the back button, the component will consider that the previous view was the Item Details and render that again.