### PR TITLE
fix: Expand collection item first column

### DIFF
--- a/src/components/CollectionDetailPage/CollectionItem/CollectionItem.tsx
+++ b/src/components/CollectionDetailPage/CollectionItem/CollectionItem.tsx
@@ -18,6 +18,8 @@ import { Props } from './CollectionItem.types'
 import ResetItemButton from './ResetItemButton'
 import styles from './CollectionItem.module.css'
 
+const LENGTH_LIMIT = 25
+
 export default class CollectionItem extends React.PureComponent<Props> {
   handleEditPriceAndBeneficiary = () => {
     const { onOpenModal, item } = this.props
@@ -149,7 +151,7 @@ export default class CollectionItem extends React.PureComponent<Props> {
 
     return (
       <Table.Row className={`CollectionItem ${styles.row}`}>
-        <Table.Cell className={`${styles.avatarColumn}`} width={6}>
+        <Table.Cell className={`${styles.avatarColumn}`} width={item.name.length > LENGTH_LIMIT ? 6 : 5}>
           <Link to={locations.itemDetail(item.id)} className="CollectionItem">
             <div className={styles.avatarContainer}>
               <ItemImage className={styles.itemImage} item={item} />

--- a/src/components/CollectionDetailPage/CollectionItem/CollectionItem.tsx
+++ b/src/components/CollectionDetailPage/CollectionItem/CollectionItem.tsx
@@ -149,7 +149,7 @@ export default class CollectionItem extends React.PureComponent<Props> {
 
     return (
       <Table.Row className={`CollectionItem ${styles.row}`}>
-        <Table.Cell className={`${styles.avatarColumn}`} width={5}>
+        <Table.Cell className={`${styles.avatarColumn}`} width={6}>
           <Link to={locations.itemDetail(item.id)} className="CollectionItem">
             <div className={styles.avatarContainer}>
               <ItemImage className={styles.itemImage} item={item} />


### PR DESCRIPTION
Expand the first column when necessary to avoid collisions between the name, the smart badge, and the Rarity badge.

<img width="1040" alt="image" src="https://github.com/decentraland/builder/assets/31735779/b417eb2c-5452-424e-bb8b-af73faefdfaa">
