### PR TITLE
feat: Update CreateSingleItem modal

### DIFF
--- a/src/components/ItemDetailPage/ItemDetailPage.css
+++ b/src/components/ItemDetailPage/ItemDetailPage.css
@@ -169,6 +169,21 @@
 
 .ItemDetailPage .data {
   display: flex;
+  line-height: 30px;
+}
+
+.ItemDetailPage .data:not(:last-child) {
+  margin-bottom: 24px;
+}
+
+.ItemDetailPage .data.tags-container {
+  margin-top: 12px;
+}
+
+.ItemDetailPage .data.tags-container .tag {
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 18px;
 }
 
 .ItemDetailPage .card .dcl.section.medium {
@@ -196,6 +211,11 @@
 .ItemDetailPage .title-card-container .title,
 .ItemDetailPage .title-card-container .actions {
   flex: 1;
+}
+
+.ItemDetailPage .title-card-container .actions {
+  display: flex;
+  justify-content: flex-end;
 }
 
 .ItemDetailPage .title-card-container .actions .edit {

--- a/src/components/ItemDetailPage/ItemDetailPage.tsx
+++ b/src/components/ItemDetailPage/ItemDetailPage.tsx
@@ -296,7 +296,24 @@ export default class ItemDetailPage extends React.PureComponent<Props, State> {
                     ) : null}
                   </div>
                 </div>
-                <div className="data">{item.description}</div>
+                {item.description && (
+                  <>
+                    <div className="subtitle">{t('global.description')}</div>
+                    <div className="data">{item.description}</div>
+                  </>
+                )}
+                {item.data.tags.length ? (
+                  <>
+                    <div className="subtitle">{t('item_detail_page.tags.title')}</div>
+                    <div className="data tags-container">
+                      {item.data.tags.map(tag => (
+                        <span className="tag" key={tag}>
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  </>
+                ) : null}
               </div>
 
               <div className="card">
@@ -364,21 +381,6 @@ export default class ItemDetailPage extends React.PureComponent<Props, State> {
                   </div>
                   <div className="data">
                     <ItemRequiredPermission requiredPermissions={item.data.requiredPermissions} basic />
-                  </div>
-                </div>
-              ) : null}
-
-              {item.data.tags.length ? (
-                <div className="card">
-                  <div className="title">{t('item_detail_page.tags.title')}</div>
-                  <div className="data">
-                    <div className="tags-container">
-                      {item.data.tags.map(tag => (
-                        <span className="tag" key={tag}>
-                          {tag}
-                        </span>
-                      ))}
-                    </div>
                   </div>
                 </div>
               ) : null}

--- a/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import equal from 'fast-deep-equal'
-import { Loader, Dropdown, Button, Modal, ModalNavigation } from 'decentraland-ui'
+import { Loader, Dropdown, Button } from 'decentraland-ui'
 import { BodyPartCategory, EmoteCategory, EmoteDataADR74, HideableWearableCategory, Network, WearableCategory } from '@dcl/schemas'
 import { NetworkButton } from 'decentraland-dapps/dist/containers'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
@@ -16,8 +16,7 @@ import {
   getEmotePlayModes,
   getHideableBodyPartCategories,
   getHideableWearableCategories,
-  isSmart,
-  getVideoURL
+  isSmart
 } from 'modules/item/utils'
 import { isLocked } from 'modules/collection/utils'
 import { computeHashes } from 'modules/deployment/contentUtils'
@@ -43,7 +42,6 @@ import ItemImage from 'components/ItemImage'
 import ItemProvider from 'components/ItemProvider'
 import ItemVideo from 'components/ItemVideo'
 import ItemRequiredPermission from 'components/ItemRequiredPermission'
-import { EditVideoView } from 'components/Modals/EditVideoModal/EditVideoModal.types'
 import Input from './Input'
 import Select from './Select'
 import MultiSelect from './MultiSelect'
@@ -112,8 +110,7 @@ export default class RightPanel extends React.PureComponent<Props, State> {
       contents: {},
       data: undefined,
       hasItem: false,
-      isDirty: false,
-      showVideoShowCase: false
+      isDirty: false
     }
   }
 
@@ -134,14 +131,8 @@ export default class RightPanel extends React.PureComponent<Props, State> {
   }
 
   handleOpenVideoDialog = () => {
-    this.setState({ showVideoShowCase: true })
-  }
-
-  handleChangeVideoFile = () => {
     const { selectedItem, onOpenModal } = this.props
-    this.setState({ showVideoShowCase: false }, () => {
-      onOpenModal('EditVideoModal', { item: selectedItem, view: EditVideoView.UPLOAD_VIDEO, onSaveVideo: this.handleSaveVideo })
-    })
+    onOpenModal('EditVideoModal', { item: selectedItem, onSaveVideo: this.handleSaveVideo })
   }
 
   handleSaveVideo = (video: Blob) => {
@@ -540,7 +531,7 @@ export default class RightPanel extends React.PureComponent<Props, State> {
       <div className="details">
         {canEditItemMetadata ? (
           <>
-            <Icon name="edit" className="edit-item-file" onClick={this.handleChangeVideoFile} />
+            <Icon name="edit" className="edit-item-file" onClick={this.handleOpenVideoDialog} />
             <Icon name="play" className="play-video-button" onClick={this.handleOpenVideoDialog} />
             <ItemVideo item={item} src={this.state.video} showMetrics />
           </>
@@ -555,28 +546,9 @@ export default class RightPanel extends React.PureComponent<Props, State> {
     return <ItemRequiredPermission requiredPermissions={item.data.requiredPermissions} />
   }
 
-  renderVideoShowcase(item: Item) {
-    const handleClose = () => this.setState({ showVideoShowCase: false })
-
-    return (
-      <Modal open={this.state.showVideoShowCase} size="small" className="VideoShowcaseModal" onClose={handleClose}>
-        <ModalNavigation title={t('video_showcase_modal.title')} onClose={handleClose} />
-        <Modal.Content>
-          <video
-            src={getVideoURL(item)}
-            preload="auto"
-            controls
-            controlsList="nodownload noremoteplayback noplaybackrate"
-            disablePictureInPicture
-          />
-        </Modal.Content>
-      </Modal>
-    )
-  }
-
   render() {
     const { selectedItemId, address, isConnected, error, isCampaignEnabled, isHandsCategoryEnabled } = this.props
-    const { name, description, rarity, data, isDirty, hasItem, showVideoShowCase } = this.state
+    const { name, description, rarity, data, isDirty, hasItem } = this.state
     const rarities = getRarities()
     const playModes = getEmotePlayModes()
 
@@ -731,7 +703,6 @@ export default class RightPanel extends React.PureComponent<Props, State> {
                         {t('global.error_ocurred')}: {error}
                       </p>
                     ) : null}
-                    {item && showVideoShowCase ? this.renderVideoShowcase(item) : null}
                   </div>
                 </>
               ) : null

--- a/src/components/ItemEditorPage/RightPanel/RightPanel.types.ts
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.types.ts
@@ -43,7 +43,6 @@ export type State = {
   data?: WearableData | EmoteDataADR74
   hasItem: boolean
   isDirty: boolean
-  showVideoShowCase: boolean
 }
 
 export type MapStateProps = Pick<

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
@@ -196,7 +196,7 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
   }
 
   createItem = async (sortedContents: SortedContent, representations: WearableRepresentation[]) => {
-    const { address, collection, isHandsCategoryEnabled, onSave } = this.props
+    const { address, collection, isHandsCategoryEnabled } = this.props
     const { id, name, description, type, metrics, collectionId, category, playMode, rarity, hasScreenshotTaken, requiredPermissions } = this
       .state as StateData
 
@@ -260,17 +260,12 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
       updatedAt: +new Date()
     }
 
-    // The Emote will be saved on the set price step
-    if (type === ItemType.EMOTE) {
-      this.setState({
-        item: { ...(item as Item) },
-        itemSortedContents: sortedContents.all,
-        view: hasScreenshotTaken ? CreateItemView.SET_PRICE : CreateItemView.THUMBNAIL,
-        fromView: CreateItemView.THUMBNAIL
-      })
-    } else {
-      onSave(item as Item, sortedContents.all)
-    }
+    this.setState({
+      item: { ...(item as Item) },
+      itemSortedContents: sortedContents.all,
+      view: hasScreenshotTaken || type !== ItemType.EMOTE ? CreateItemView.SET_PRICE : CreateItemView.THUMBNAIL,
+      fromView: CreateItemView.THUMBNAIL
+    })
   }
 
   addItemRepresentation = async (sortedContents: SortedContent, representations: WearableRepresentation[]) => {
@@ -722,7 +717,6 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
     const keys = Object.keys(this.state)
     const { fromView } = this.state
 
-
     if (fromView) {
       this.setState({ view: fromView })
       return
@@ -1090,11 +1084,7 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
                 ) : null}
                 <Column align="right">
                   <Button primary disabled={isDisabled} loading={isLoading}>
-                    {(metadata && metadata.changeItemFile) || isRepresentation
-                      ? t('global.save')
-                      : type === ItemType.EMOTE
-                      ? t('global.next')
-                      : t('global.create')}
+                    {(metadata && metadata.changeItemFile) || isRepresentation ? t('global.save') : t('global.next')}
                   </Button>
                 </Column>
               </Row>

--- a/src/themes/theme.css
+++ b/src/themes/theme.css
@@ -69,3 +69,7 @@
 .ui.popup.modal-tooltip {
   z-index: 999999999999999;
 }
+
+html {
+  overflow: hidden;
+}


### PR DESCRIPTION
This PR updates the CreateSingleItem modal to include the `EditPrice` step in the flow for all items.

Video Showcase:
https://github.com/decentraland/builder/assets/3170051/61c60385-c2de-415b-9a39-719fa1a91dfe

Also, updates the Item details design:
<img width="1018" alt="image" src="https://github.com/decentraland/builder/assets/3170051/5914225e-a6eb-4827-9b77-6d4045d56e86">
