### PR TITLE
fix: download scene sdk6

### DIFF
--- a/src/modules/project/export.ts
+++ b/src/modules/project/export.ts
@@ -10,6 +10,7 @@ import { Scene, ComponentType, ComponentDefinition, SceneSDK6 } from 'modules/sc
 import { getContentsStorageUrl } from 'lib/api/builder'
 import { AssetParameterValues } from 'modules/asset/types'
 import { migrations } from 'modules/migrations/manifest'
+import { wrapSdk6 } from 'modules/migrations/utils'
 import { reHashContent } from 'modules/deployment/contentUtils'
 import { NO_CACHE_HEADERS } from 'lib/headers'
 import { getParcelOrientation } from './utils'
@@ -422,7 +423,7 @@ export function createDynamicFiles(args: {
     [EXPORT_PATH.MANIFEST_FILE]: JSON.stringify({
       version: MANIFEST_FILE_VERSION,
       project,
-      scene
+      scene: wrapSdk6(scene)
     }),
     [EXPORT_PATH.PACKAGE_FILE]: JSON.stringify(
       {


### PR DESCRIPTION
Fix download scenes in sdk6. Version was taking MAX values (migration 11) but the scene wasn't wrapped in sdk6 object