### PR TITLE
fix: install older version of catalyst client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "cids": "^0.7.2",
         "connected-react-router": "^6.9.2",
         "date-fns": "^2.28.0",
+        "dcl-catalyst-client": "^21.5.3",
         "dcl-scene-writer": "^1.1.2",
         "decentraland": "^3.3.0",
         "decentraland-builder-scripts": "^0.24.0",
@@ -12756,13 +12757,13 @@
       }
     },
     "node_modules/dcl-catalyst-client": {
-      "version": "21.5.4",
-      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-21.5.4.tgz",
-      "integrity": "sha512-jnRfQS6ZJ/PKQZyXQpAXZKkayVKdzSXkdcVcACO0hdEUfECE9QHlwP7sJ9Eczp32vp7lb3T7np63cUA6o8NU6g==",
+      "version": "21.5.3",
+      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-21.5.3.tgz",
+      "integrity": "sha512-wsMGYyUmeorglPyh4bwiqpRTX5Db6JSnUq9M052b9da0n4SRnsKygdf76GTOCasQllgAiZCAZsAFxezBfCsziw==",
       "dependencies": {
         "@dcl/catalyst-contracts": "^4.0.2",
         "@dcl/crypto": "^3.4.0",
-        "@dcl/hashing": "^3.0.0",
+        "@dcl/hashing": "^2.0.0",
         "@dcl/schemas": "^8.1.0",
         "@well-known-components/fetch-component": "^2.0.0",
         "cookie": "^0.5.0",
@@ -12771,9 +12772,14 @@
       }
     },
     "node_modules/dcl-catalyst-client/node_modules/@dcl/hashing": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@dcl/hashing/-/hashing-3.0.3.tgz",
-      "integrity": "sha512-fz643arBiTcotaC/mW2kSVBQFwELi2wkqAs6eJ6nsivqBEMP1FDdqRAL3x4iS3pk1aQntzQ5NebGmZTZaVK9IA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dcl/hashing/-/hashing-2.0.0.tgz",
+      "integrity": "sha512-Wver/KQScNhoobAOT9u09THMReCIkuK2VQ2GtB891uHKYh31IxCYJW+dcBkynWUZQA4HTRa3DOtEDt/ZyImaHQ==",
+      "dependencies": {
+        "ethereum-cryptography": "^1.0.3",
+        "ipfs-unixfs-importer": "^7.0.3",
+        "multiformats": "^9.6.3"
+      }
     },
     "node_modules/dcl-catalyst-client/node_modules/form-data": {
       "version": "4.0.0",
@@ -45510,13 +45516,13 @@
       }
     },
     "dcl-catalyst-client": {
-      "version": "21.5.4",
-      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-21.5.4.tgz",
-      "integrity": "sha512-jnRfQS6ZJ/PKQZyXQpAXZKkayVKdzSXkdcVcACO0hdEUfECE9QHlwP7sJ9Eczp32vp7lb3T7np63cUA6o8NU6g==",
+      "version": "21.5.3",
+      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-21.5.3.tgz",
+      "integrity": "sha512-wsMGYyUmeorglPyh4bwiqpRTX5Db6JSnUq9M052b9da0n4SRnsKygdf76GTOCasQllgAiZCAZsAFxezBfCsziw==",
       "requires": {
         "@dcl/catalyst-contracts": "^4.0.2",
         "@dcl/crypto": "^3.4.0",
-        "@dcl/hashing": "^3.0.0",
+        "@dcl/hashing": "^2.0.0",
         "@dcl/schemas": "^8.1.0",
         "@well-known-components/fetch-component": "^2.0.0",
         "cookie": "^0.5.0",
@@ -45525,9 +45531,14 @@
       },
       "dependencies": {
         "@dcl/hashing": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@dcl/hashing/-/hashing-3.0.3.tgz",
-          "integrity": "sha512-fz643arBiTcotaC/mW2kSVBQFwELi2wkqAs6eJ6nsivqBEMP1FDdqRAL3x4iS3pk1aQntzQ5NebGmZTZaVK9IA=="
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@dcl/hashing/-/hashing-2.0.0.tgz",
+          "integrity": "sha512-Wver/KQScNhoobAOT9u09THMReCIkuK2VQ2GtB891uHKYh31IxCYJW+dcBkynWUZQA4HTRa3DOtEDt/ZyImaHQ==",
+          "requires": {
+            "ethereum-cryptography": "^1.0.3",
+            "ipfs-unixfs-importer": "^7.0.3",
+            "multiformats": "^9.6.3"
+          }
         },
         "form-data": {
           "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "cids": "^0.7.2",
     "connected-react-router": "^6.9.2",
     "date-fns": "^2.28.0",
+    "dcl-catalyst-client": "21.5.3",
     "dcl-scene-writer": "^1.1.2",
     "decentraland": "^3.3.0",
     "decentraland-builder-scripts": "^0.24.0",


### PR DESCRIPTION
The latest version of `catalyst-client` throws when using the util `buildEntity` with a `(0, r.hashV1) is not a function`. 

It seems that it has to do with some of the changes from version `v3.0.0` to `v.3.0.3` of `@dcl/hashing`: https://github.com/decentraland/catalyst-client/releases/tag/21.5.4