### PR TITLE
feat: enable resize scene sdk7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/hashing": "^3.0.4",
         "@dcl/mini-rpc": "^1.0.6",
         "@dcl/schemas": "^8.2.2",
-        "@dcl/sdk": "^7.3.6",
+        "@dcl/sdk": "^7.3.9",
         "@dcl/single-sign-on-client": "^0.0.12",
         "@dcl/ui-env": "^1.2.0",
         "@testing-library/jest-dom": "^5.16.4",
@@ -2286,9 +2286,9 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.6.tgz",
-      "integrity": "sha512-yxc/XXGWILDLvU8UJorKM0n97n+uqrv6puSx9i4nSQ2P1e4Wrw8ukcr4QE9azyvdi9jOB9GP5a5JOhDBJbzUfQ=="
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.9.tgz",
+      "integrity": "sha512-4iN30TEiefm0To6U0IB9fDY2dcTJxQWaLvKzuxHBBNp1G9SVX8SMqk5iVZoglsORkKyvonyFs8+isTGAOtgTSQ=="
     },
     "node_modules/@dcl/ecs-math": {
       "version": "2.0.2",
@@ -2296,9 +2296,9 @@
       "integrity": "sha512-w01+a3mpHvxGPHepu0hAAX8OfpBSQEqBbC1+U8o+5SBSQVXHiRwt3P4cK20yM8QCgZe3enPttmpqePnjTliTig=="
     },
     "node_modules/@dcl/explorer": {
-      "version": "1.0.132930-20230725144125.commit-5991944",
-      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.132930-20230725144125.commit-5991944.tgz",
-      "integrity": "sha512-IGt5ZiPfXN3tvV2EVboOmCActq6PzZCLCgntiEHugWiDkKjWS7Vflr4Z0UrB53d2Kcjeh06sm3GN2QXdOFTyew=="
+      "version": "1.0.139428-20230817134048.commit-4c182e2",
+      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.139428-20230817134048.commit-4c182e2.tgz",
+      "integrity": "sha512-6b8CbIp06DQKkN5G1kX7JMGLUyIvBueEKSHIu/a80TVxgT/JUqG7CSnEql/fnGZrn8npfpsSx8lP8AODnsFYNQ=="
     },
     "node_modules/@dcl/hashing": {
       "version": "3.0.4",
@@ -2306,14 +2306,14 @@
       "integrity": "sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg=="
     },
     "node_modules/@dcl/inspector": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.6.tgz",
-      "integrity": "sha512-17foKuR+FAYuXCZArnqKQZtLKIm/s2ooCpsgFKpWY6lgdYodcYHu7qtNy7VMa9j+U5GO1qQxkX9ET4F3GmrJHw=="
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.9.tgz",
+      "integrity": "sha512-/nokEbDOo95SUSvpxk5dL1tARHqdkkbQ28jHzogknofOf7HtiVhVl6LyXvl+YmcRobNsFhbNZ73xBgfV4UOToQ=="
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.6.tgz",
-      "integrity": "sha512-n15VTV5wmilxjgeUJq1dMLfcBr3EW/+85Ngz+10RJUbXK0VubHZcqha/STQ8B6N0MkZk75QCAGIb8MxvYzSTrg=="
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.9.tgz",
+      "integrity": "sha512-2/+I578A3B2F2Cuhv4Uhjd6CdlfxTJbJNDuTt0lhfquxyFpGzpSqcGe/o4OXW3FyOFtBpx1okJXNNZyosw/+3Q=="
     },
     "node_modules/@dcl/kernel": {
       "version": "1.0.0-2505075507.commit-6af9c3b",
@@ -2405,19 +2405,19 @@
       "integrity": "sha512-Z0zpNr2HAxn2cLWUadWGlzaG48Z+N3hg2bI20UH+OT8NJtvCJnAwVBshAG83iAn4BTC+CsUsk4A394jrlv2ZIQ=="
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-5623934099.commit-07e0626",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-5623934099.commit-07e0626.tgz",
-      "integrity": "sha512-OTa7l4HwHIaj/GgMwvy2+u3fHhyq5EvyO8XRXBbaWOdQTTxa8QdNCINzoT4W36kWwZ3nidoyj0vODR/EyEu+RA==",
+      "version": "1.0.0-5812097343.commit-8025576",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-5812097343.commit-8025576.tgz",
+      "integrity": "sha512-ZqgITIayuZVZYPlbuZhEiZt1DVo3a9TFmRDN0pJp3BB7ymg9X/7W/joxEsgP++dCtEJ3DZ1HjzlB0SEX2nyrmg==",
       "dependencies": {
-        "@dcl/ts-proto": "1.153.0"
+        "@dcl/ts-proto": "1.154.0"
       }
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.6.tgz",
-      "integrity": "sha512-PJ77UvtKF/HQNV8Qt0cetzkzcw1KOEWqP6FvM3vjCpxz34OhaYmJPAb14pOTZG4UXsaY24pvyka84fsbzbamtA==",
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.9.tgz",
+      "integrity": "sha512-6g2HP7ybUaHgJqf5A63wQEHs1wcGWBSDuZXj5N3xINX/TH3l0ILRE8/Bg7nUcxB98K8Jz2VRZvWeh4iisSYRXQ==",
       "dependencies": {
-        "@dcl/ecs": "7.3.6",
+        "@dcl/ecs": "7.3.9",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -2484,29 +2484,29 @@
       }
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.6.tgz",
-      "integrity": "sha512-G/rP+VuHl9qjDsPLzEZx2p8m70EJ6x56wNcxi57ZpelC6W+4J7a4Yu2kwQ9a01JU6vSkA3ImYv9XfkfV5PFM5g==",
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.9.tgz",
+      "integrity": "sha512-Mx0lOrV4jXxBGrSpoJXuk8+fTbR8NCkNHUcU9qscoUhqef42Eit+iT73FYJtAWKYETgca1vVwep1ML81fi8jtA==",
       "dependencies": {
-        "@dcl/ecs": "7.3.6",
+        "@dcl/ecs": "7.3.9",
         "@dcl/ecs-math": "2.0.2",
-        "@dcl/explorer": "1.0.132930-20230725144125.commit-5991944",
-        "@dcl/js-runtime": "7.3.6",
-        "@dcl/react-ecs": "7.3.6",
-        "@dcl/sdk-commands": "7.3.6"
+        "@dcl/explorer": "1.0.139428-20230817134048.commit-4c182e2",
+        "@dcl/js-runtime": "7.3.9",
+        "@dcl/react-ecs": "7.3.9",
+        "@dcl/sdk-commands": "7.3.9"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.6.tgz",
-      "integrity": "sha512-+aBelHoJrFNNEBqSUEgGhk4CFB5I/uE9NLvXX1vp884+xsIdBSrmSHJ38DT9VUtaNkFBNnbznBVqksi6tzOcGw==",
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.9.tgz",
+      "integrity": "sha512-nzq4n2X/C95Y8sBDtdavAakWXXtQRK1J18Ez0h+fuS2adZGZJyLFoEWiecrcRnAtJD2infNUOk8WPuNdHOhH2Q==",
       "dependencies": {
-        "@dcl/ecs": "7.3.6",
+        "@dcl/ecs": "7.3.9",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.3.6",
+        "@dcl/inspector": "7.3.9",
         "@dcl/linker-dapp": "0.9.1",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-5623934099.commit-07e0626",
+        "@dcl/protocol": "1.0.0-5812097343.commit-8025576",
         "@dcl/rpc": "^1.1.1",
         "@dcl/schemas": "^8.2.3-20230718182824.commit-356025c",
         "@segment/analytics-node": "^1.0.0-beta.22",
@@ -2694,9 +2694,9 @@
       }
     },
     "node_modules/@dcl/ts-proto": {
-      "version": "1.153.0",
-      "resolved": "https://registry.npmjs.org/@dcl/ts-proto/-/ts-proto-1.153.0.tgz",
-      "integrity": "sha512-jmoK+/mxSyhxIswar1SRPcEp/N1/QYShbuAHc4FEPls843m0kbPUUKJYCwtFCd+Fwu3pT8j8O30cq9iJ80gaZQ==",
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@dcl/ts-proto/-/ts-proto-1.154.0.tgz",
+      "integrity": "sha512-2S5AKMMPVZrVfa/1WRy4/h0niikcbu3Yf6dCoudh7ScG7BsyKAPC3CMg6IJKHzrmWS593UZClq7YJof6Vt4O+w==",
       "dependencies": {
         "@types/object-hash": "^3.0.2",
         "case-anything": "^2.1.10",
@@ -2704,7 +2704,7 @@
         "object-hash": "^3.0.0",
         "protobufjs": "^7.2.4",
         "ts-poet": "^6.4.1",
-        "ts-proto-descriptors": "1.9.0"
+        "ts-proto-descriptors": "^1.15.0"
       },
       "bin": {
         "protoc-gen-dcl_ts_proto": "protoc-gen-dcl_ts_proto"
@@ -2749,9 +2749,9 @@
       "integrity": "sha512-cy3+dN6Exm4bd2cpMAx7aHyqztfuRhKOr9Bny0irJi79y1nnnGVeOxc6pPSDcO4uR3JFmZit9B5SifT1AxXHiw=="
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.17.tgz",
-      "integrity": "sha512-wHsmJG/dnL3OkpAcwbgoBTTMHVi4Uyou3F5mf58ZtmUyIKfcdA7TROav/6tCzET4A3QW2Q2FC+eFneMU+iyOxg==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
       "cpu": [
         "arm"
       ],
@@ -2764,9 +2764,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.17.tgz",
-      "integrity": "sha512-9np+YYdNDed5+Jgr1TdWBsozZ85U1Oa3xW0c7TWqH0y2aGghXtZsuT8nYRbzOMcl0bXZXjOGbksoTtVOlWrRZg==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
       "cpu": [
         "arm64"
       ],
@@ -2779,9 +2779,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.17.tgz",
-      "integrity": "sha512-O+FeWB/+xya0aLg23hHEM2E3hbfwZzjqumKMSIqcHbNvDa+dza2D0yLuymRBQQnC34CWrsJUXyH2MG5VnLd6uw==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
       "cpu": [
         "x64"
       ],
@@ -2794,9 +2794,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.17.tgz",
-      "integrity": "sha512-M9uJ9VSB1oli2BE/dJs3zVr9kcCBBsE883prage1NWz6pBS++1oNn/7soPNS3+1DGj0FrkSvnED4Bmlu1VAE9g==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
       "cpu": [
         "arm64"
       ],
@@ -2809,9 +2809,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.17.tgz",
-      "integrity": "sha512-XDre+J5YeIJDMfp3n0279DFNrGCXlxOuGsWIkRb1NThMZ0BsrWXoTg23Jer7fEXQ9Ye5QjrvXpxnhzl3bHtk0g==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
       "cpu": [
         "x64"
       ],
@@ -2824,9 +2824,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.17.tgz",
-      "integrity": "sha512-cjTzGa3QlNfERa0+ptykyxs5A6FEUQQF0MuilYXYBGdBxD3vxJcKnzDlhDCa1VAJCmAxed6mYhA2KaJIbtiNuQ==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
       "cpu": [
         "arm64"
       ],
@@ -2839,9 +2839,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.17.tgz",
-      "integrity": "sha512-sOxEvR8d7V7Kw8QqzxWc7bFfnWnGdaFBut1dRUYtu+EIRXefBc/eIsiUiShnW0hM3FmQ5Zf27suDuHsKgZ5QrA==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
       "cpu": [
         "x64"
       ],
@@ -2854,9 +2854,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.17.tgz",
-      "integrity": "sha512-2d3Lw6wkwgSLC2fIvXKoMNGVaeY8qdN0IC3rfuVxJp89CRfA3e3VqWifGDfuakPmp90+ZirmTfye1n4ncjv2lg==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
       "cpu": [
         "arm"
       ],
@@ -2869,9 +2869,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.17.tgz",
-      "integrity": "sha512-c9w3tE7qA3CYWjT+M3BMbwMt+0JYOp3vCMKgVBrCl1nwjAlOMYzEo+gG7QaZ9AtqZFj5MbUc885wuBBmu6aADQ==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
       "cpu": [
         "arm64"
       ],
@@ -2884,9 +2884,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.17.tgz",
-      "integrity": "sha512-1DS9F966pn5pPnqXYz16dQqWIB0dmDfAQZd6jSSpiT9eX1NzKh07J6VKR3AoXXXEk6CqZMojiVDSZi1SlmKVdg==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
       "cpu": [
         "ia32"
       ],
@@ -2899,9 +2899,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.17.tgz",
-      "integrity": "sha512-EvLsxCk6ZF0fpCB6w6eOI2Fc8KW5N6sHlIovNe8uOFObL2O+Mr0bflPHyHwLT6rwMg9r77WOAWb2FqCQrVnwFg==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
       "cpu": [
         "loong64"
       ],
@@ -2914,9 +2914,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.17.tgz",
-      "integrity": "sha512-e0bIdHA5p6l+lwqTE36NAW5hHtw2tNRmHlGBygZC14QObsA3bD4C6sXLJjvnDIjSKhW1/0S3eDy+QmX/uZWEYQ==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
       "cpu": [
         "mips64el"
       ],
@@ -2929,9 +2929,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.17.tgz",
-      "integrity": "sha512-BAAilJ0M5O2uMxHYGjFKn4nJKF6fNCdP1E0o5t5fvMYYzeIqy2JdAP88Az5LHt9qBoUa4tDaRpfWt21ep5/WqQ==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
       "cpu": [
         "ppc64"
       ],
@@ -2944,9 +2944,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.17.tgz",
-      "integrity": "sha512-Wh/HW2MPnC3b8BqRSIme/9Zhab36PPH+3zam5pqGRH4pE+4xTrVLx2+XdGp6fVS3L2x+DrsIcsbMleex8fbE6g==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
       "cpu": [
         "riscv64"
       ],
@@ -2959,9 +2959,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.17.tgz",
-      "integrity": "sha512-j/34jAl3ul3PNcK3pfI0NSlBANduT2UO5kZ7FCaK33XFv3chDhICLY8wJJWIhiQ+YNdQ9dxqQctRg2bvrMlYgg==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
       "cpu": [
         "s390x"
       ],
@@ -2974,9 +2974,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.17.tgz",
-      "integrity": "sha512-QM50vJ/y+8I60qEmFxMoxIx4de03pGo2HwxdBeFd4nMh364X6TIBZ6VQ5UQmPbQWUVWHWws5MmJXlHAXvJEmpQ==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
       "cpu": [
         "x64"
       ],
@@ -2989,9 +2989,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.17.tgz",
-      "integrity": "sha512-/jGlhWR7Sj9JPZHzXyyMZ1RFMkNPjC6QIAan0sDOtIo2TYk3tZn5UDrkE0XgsTQCxWTTOcMPf9p6Rh2hXtl5TQ==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
       "cpu": [
         "x64"
       ],
@@ -3004,9 +3004,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.17.tgz",
-      "integrity": "sha512-rSEeYaGgyGGf4qZM2NonMhMOP/5EHp4u9ehFiBrg7stH6BYEEjlkVREuDEcQ0LfIl53OXLxNbfuIj7mr5m29TA==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
       "cpu": [
         "x64"
       ],
@@ -3019,9 +3019,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.17.tgz",
-      "integrity": "sha512-Y7ZBbkLqlSgn4+zot4KUNYst0bFoO68tRgI6mY2FIM+b7ZbyNVtNbDP5y8qlu4/knZZ73fgJDlXID+ohY5zt5g==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
       "cpu": [
         "x64"
       ],
@@ -3034,9 +3034,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.17.tgz",
-      "integrity": "sha512-bwPmTJsEQcbZk26oYpc4c/8PvTY3J5/QK8jM19DVlEsAB41M39aWovWoHtNm78sd6ip6prilxeHosPADXtEJFw==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
       "cpu": [
         "arm64"
       ],
@@ -3049,9 +3049,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.17.tgz",
-      "integrity": "sha512-H/XaPtPKli2MhW+3CQueo6Ni3Avggi6hP/YvgkEe1aSaxw+AeO8MFjq8DlgfTd9Iz4Yih3QCZI6YLMoyccnPRg==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
       "cpu": [
         "ia32"
       ],
@@ -3064,9 +3064,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.17.tgz",
-      "integrity": "sha512-fGEb8f2BSA3CW7riJVurug65ACLuQAzKq0SSqkY2b2yHHH0MzDfbLyKIGzHwOI/gkHcxM/leuSW6D5w/LMNitA==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
       "cpu": [
         "x64"
       ],
@@ -6177,9 +6177,9 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
     },
     "node_modules/@types/object-hash": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-3.0.2.tgz",
-      "integrity": "sha512-tfyXl1JPCf2hzIDK29gO7qGqJjThKBzg/Cn3bA68R9NmWdOx+f7k5mm4to/n43BHspCwcoUC6FU4NpUoK/h9bQ=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-3.0.3.tgz",
+      "integrity": "sha512-Mb0SDIhjhBAz4/rDNU0cYcQR4lSJIwy+kFlm0whXLkx+o0pXwEszwyrWD6gXWumxVbAS6XZ9gXK82LR+Uk+cKQ=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -8413,9 +8413,9 @@
       "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg=="
     },
     "node_modules/@well-known-components/logger": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@well-known-components/logger/-/logger-3.1.2.tgz",
-      "integrity": "sha512-nT2ULsvtxcaehnUPcmRfVWIspVq6iYTPTzs5D9lBxqE3Pt+j5StzPfo814IqSo4xhN9cJhJAQ/EggMmKuYMaZg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@well-known-components/logger/-/logger-3.1.3.tgz",
+      "integrity": "sha512-tTjD27CdfU4SVe+kPfjRbPSqdrw0Crg+M31RNejinCuMEBtEGbhYLtB1M4gn+PSTy2Oi3cI3iOdeQ1xVhMSerQ==",
       "peerDependencies": {
         "@well-known-components/interfaces": "^1.0.0"
       }
@@ -8932,15 +8932,15 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "node_modules/archiver": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.1.tgz",
-      "integrity": "sha512-8KyabkmbYrH+9ibcTScQ1xCJC/CGcugdVIwB+53f5sZziXgwUh3iXlAlANMxcZyDEfTHMe6+Z5FofV8nopXP7w==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
       "dependencies": {
         "archiver-utils": "^2.1.0",
-        "async": "^3.2.3",
+        "async": "^3.2.4",
         "buffer-crc32": "^0.2.1",
         "readable-stream": "^3.6.0",
-        "readdir-glob": "^1.0.0",
+        "readdir-glob": "^1.1.2",
         "tar-stream": "^2.2.0",
         "zip-stream": "^4.1.0"
       },
@@ -14611,9 +14611,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.17.tgz",
-      "integrity": "sha512-1GJtYnUxsJreHYA0Y+iQz2UEykonY66HNWOb0yXYZi9/kNrORUEHVg87eQsCtqh59PEJ5YVZJO98JHznMJSWjg==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -14622,28 +14622,28 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.17",
-        "@esbuild/android-arm64": "0.18.17",
-        "@esbuild/android-x64": "0.18.17",
-        "@esbuild/darwin-arm64": "0.18.17",
-        "@esbuild/darwin-x64": "0.18.17",
-        "@esbuild/freebsd-arm64": "0.18.17",
-        "@esbuild/freebsd-x64": "0.18.17",
-        "@esbuild/linux-arm": "0.18.17",
-        "@esbuild/linux-arm64": "0.18.17",
-        "@esbuild/linux-ia32": "0.18.17",
-        "@esbuild/linux-loong64": "0.18.17",
-        "@esbuild/linux-mips64el": "0.18.17",
-        "@esbuild/linux-ppc64": "0.18.17",
-        "@esbuild/linux-riscv64": "0.18.17",
-        "@esbuild/linux-s390x": "0.18.17",
-        "@esbuild/linux-x64": "0.18.17",
-        "@esbuild/netbsd-x64": "0.18.17",
-        "@esbuild/openbsd-x64": "0.18.17",
-        "@esbuild/sunos-x64": "0.18.17",
-        "@esbuild/win32-arm64": "0.18.17",
-        "@esbuild/win32-ia32": "0.18.17",
-        "@esbuild/win32-x64": "0.18.17"
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
       }
     },
     "node_modules/escalade": {
@@ -25035,17 +25035,17 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
-      "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
       "engines": {
         "node": "14 || >=16.14"
       }
     },
     "node_modules/path-scurry/node_modules/minipass": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.2.tgz",
-      "integrity": "sha512-eL79dXrE1q9dBbDCLg7xfn/vl7MS4F1gvJAgjJrQli/jbQWdUttuVawphqpffoIYfRdq78LHx6GP4bU/EQ2ATA==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+      "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -32418,9 +32418,9 @@
       }
     },
     "node_modules/ts-proto": {
-      "version": "1.156.2",
-      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.156.2.tgz",
-      "integrity": "sha512-0ZAbGmfvB2R79QJfpTIk56T8xM4k9ZS+z77517HDpuFZFizCMceCIE3IhdYQWbmP1oSYLzw0AeVbVHi2PIigKQ==",
+      "version": "1.156.7",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.156.7.tgz",
+      "integrity": "sha512-vuSby+Mx0CniXscbHx9ieKCEErGBuie12RmduPA67p27Io5C0gkzlMnyN/j3vKWAJrP/h6+mbAoo6WrlalOt7w==",
       "dependencies": {
         "case-anything": "^2.1.13",
         "protobufjs": "^7.2.4",
@@ -32432,12 +32432,40 @@
       }
     },
     "node_modules/ts-proto-descriptors": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-1.9.0.tgz",
-      "integrity": "sha512-Ui8zA5Q4Jnq6JIGRraUWvECrqixxtwwin8GkhIkvwCpR+JcSPsxWe8HfTj5eHfyruGYI6Zjf96XlC87hTakHfQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-1.15.0.tgz",
+      "integrity": "sha512-TYyJ7+H+7Jsqawdv+mfsEpZPTIj9siDHS6EMCzG/z3b/PZiphsX+mWtqFfFVe5/N0Th6V3elK9lQqjnrgTOfrg==",
       "dependencies": {
-        "long": "^4.0.0",
-        "protobufjs": "^6.8.8"
+        "long": "^5.2.3",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/ts-proto-descriptors/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
+    "node_modules/ts-proto-descriptors/node_modules/protobufjs": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
+      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/ts-proto/node_modules/long": {
@@ -32466,15 +32494,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/ts-proto/node_modules/ts-proto-descriptors": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-1.15.0.tgz",
-      "integrity": "sha512-TYyJ7+H+7Jsqawdv+mfsEpZPTIj9siDHS6EMCzG/z3b/PZiphsX+mWtqFfFVe5/N0Th6V3elK9lQqjnrgTOfrg==",
-      "dependencies": {
-        "long": "^5.2.3",
-        "protobufjs": "^7.2.4"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -37343,9 +37362,9 @@
       }
     },
     "@dcl/ecs": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.6.tgz",
-      "integrity": "sha512-yxc/XXGWILDLvU8UJorKM0n97n+uqrv6puSx9i4nSQ2P1e4Wrw8ukcr4QE9azyvdi9jOB9GP5a5JOhDBJbzUfQ=="
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.9.tgz",
+      "integrity": "sha512-4iN30TEiefm0To6U0IB9fDY2dcTJxQWaLvKzuxHBBNp1G9SVX8SMqk5iVZoglsORkKyvonyFs8+isTGAOtgTSQ=="
     },
     "@dcl/ecs-math": {
       "version": "2.0.2",
@@ -37353,9 +37372,9 @@
       "integrity": "sha512-w01+a3mpHvxGPHepu0hAAX8OfpBSQEqBbC1+U8o+5SBSQVXHiRwt3P4cK20yM8QCgZe3enPttmpqePnjTliTig=="
     },
     "@dcl/explorer": {
-      "version": "1.0.132930-20230725144125.commit-5991944",
-      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.132930-20230725144125.commit-5991944.tgz",
-      "integrity": "sha512-IGt5ZiPfXN3tvV2EVboOmCActq6PzZCLCgntiEHugWiDkKjWS7Vflr4Z0UrB53d2Kcjeh06sm3GN2QXdOFTyew=="
+      "version": "1.0.139428-20230817134048.commit-4c182e2",
+      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.139428-20230817134048.commit-4c182e2.tgz",
+      "integrity": "sha512-6b8CbIp06DQKkN5G1kX7JMGLUyIvBueEKSHIu/a80TVxgT/JUqG7CSnEql/fnGZrn8npfpsSx8lP8AODnsFYNQ=="
     },
     "@dcl/hashing": {
       "version": "3.0.4",
@@ -37363,14 +37382,14 @@
       "integrity": "sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg=="
     },
     "@dcl/inspector": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.6.tgz",
-      "integrity": "sha512-17foKuR+FAYuXCZArnqKQZtLKIm/s2ooCpsgFKpWY6lgdYodcYHu7qtNy7VMa9j+U5GO1qQxkX9ET4F3GmrJHw=="
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.9.tgz",
+      "integrity": "sha512-/nokEbDOo95SUSvpxk5dL1tARHqdkkbQ28jHzogknofOf7HtiVhVl6LyXvl+YmcRobNsFhbNZ73xBgfV4UOToQ=="
     },
     "@dcl/js-runtime": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.6.tgz",
-      "integrity": "sha512-n15VTV5wmilxjgeUJq1dMLfcBr3EW/+85Ngz+10RJUbXK0VubHZcqha/STQ8B6N0MkZk75QCAGIb8MxvYzSTrg=="
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.9.tgz",
+      "integrity": "sha512-2/+I578A3B2F2Cuhv4Uhjd6CdlfxTJbJNDuTt0lhfquxyFpGzpSqcGe/o4OXW3FyOFtBpx1okJXNNZyosw/+3Q=="
     },
     "@dcl/kernel": {
       "version": "1.0.0-2505075507.commit-6af9c3b",
@@ -37448,19 +37467,19 @@
       "integrity": "sha512-Z0zpNr2HAxn2cLWUadWGlzaG48Z+N3hg2bI20UH+OT8NJtvCJnAwVBshAG83iAn4BTC+CsUsk4A394jrlv2ZIQ=="
     },
     "@dcl/protocol": {
-      "version": "1.0.0-5623934099.commit-07e0626",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-5623934099.commit-07e0626.tgz",
-      "integrity": "sha512-OTa7l4HwHIaj/GgMwvy2+u3fHhyq5EvyO8XRXBbaWOdQTTxa8QdNCINzoT4W36kWwZ3nidoyj0vODR/EyEu+RA==",
+      "version": "1.0.0-5812097343.commit-8025576",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-5812097343.commit-8025576.tgz",
+      "integrity": "sha512-ZqgITIayuZVZYPlbuZhEiZt1DVo3a9TFmRDN0pJp3BB7ymg9X/7W/joxEsgP++dCtEJ3DZ1HjzlB0SEX2nyrmg==",
       "requires": {
-        "@dcl/ts-proto": "1.153.0"
+        "@dcl/ts-proto": "1.154.0"
       }
     },
     "@dcl/react-ecs": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.6.tgz",
-      "integrity": "sha512-PJ77UvtKF/HQNV8Qt0cetzkzcw1KOEWqP6FvM3vjCpxz34OhaYmJPAb14pOTZG4UXsaY24pvyka84fsbzbamtA==",
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.9.tgz",
+      "integrity": "sha512-6g2HP7ybUaHgJqf5A63wQEHs1wcGWBSDuZXj5N3xINX/TH3l0ILRE8/Bg7nUcxB98K8Jz2VRZvWeh4iisSYRXQ==",
       "requires": {
-        "@dcl/ecs": "7.3.6",
+        "@dcl/ecs": "7.3.9",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       },
@@ -37520,29 +37539,29 @@
       }
     },
     "@dcl/sdk": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.6.tgz",
-      "integrity": "sha512-G/rP+VuHl9qjDsPLzEZx2p8m70EJ6x56wNcxi57ZpelC6W+4J7a4Yu2kwQ9a01JU6vSkA3ImYv9XfkfV5PFM5g==",
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.9.tgz",
+      "integrity": "sha512-Mx0lOrV4jXxBGrSpoJXuk8+fTbR8NCkNHUcU9qscoUhqef42Eit+iT73FYJtAWKYETgca1vVwep1ML81fi8jtA==",
       "requires": {
-        "@dcl/ecs": "7.3.6",
+        "@dcl/ecs": "7.3.9",
         "@dcl/ecs-math": "2.0.2",
-        "@dcl/explorer": "1.0.132930-20230725144125.commit-5991944",
-        "@dcl/js-runtime": "7.3.6",
-        "@dcl/react-ecs": "7.3.6",
-        "@dcl/sdk-commands": "7.3.6"
+        "@dcl/explorer": "1.0.139428-20230817134048.commit-4c182e2",
+        "@dcl/js-runtime": "7.3.9",
+        "@dcl/react-ecs": "7.3.9",
+        "@dcl/sdk-commands": "7.3.9"
       }
     },
     "@dcl/sdk-commands": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.6.tgz",
-      "integrity": "sha512-+aBelHoJrFNNEBqSUEgGhk4CFB5I/uE9NLvXX1vp884+xsIdBSrmSHJ38DT9VUtaNkFBNnbznBVqksi6tzOcGw==",
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.9.tgz",
+      "integrity": "sha512-nzq4n2X/C95Y8sBDtdavAakWXXtQRK1J18Ez0h+fuS2adZGZJyLFoEWiecrcRnAtJD2infNUOk8WPuNdHOhH2Q==",
       "requires": {
-        "@dcl/ecs": "7.3.6",
+        "@dcl/ecs": "7.3.9",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.3.6",
+        "@dcl/inspector": "7.3.9",
         "@dcl/linker-dapp": "0.9.1",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-5623934099.commit-07e0626",
+        "@dcl/protocol": "1.0.0-5812097343.commit-8025576",
         "@dcl/rpc": "^1.1.1",
         "@dcl/schemas": "^8.2.3-20230718182824.commit-356025c",
         "@segment/analytics-node": "^1.0.0-beta.22",
@@ -37685,9 +37704,9 @@
       }
     },
     "@dcl/ts-proto": {
-      "version": "1.153.0",
-      "resolved": "https://registry.npmjs.org/@dcl/ts-proto/-/ts-proto-1.153.0.tgz",
-      "integrity": "sha512-jmoK+/mxSyhxIswar1SRPcEp/N1/QYShbuAHc4FEPls843m0kbPUUKJYCwtFCd+Fwu3pT8j8O30cq9iJ80gaZQ==",
+      "version": "1.154.0",
+      "resolved": "https://registry.npmjs.org/@dcl/ts-proto/-/ts-proto-1.154.0.tgz",
+      "integrity": "sha512-2S5AKMMPVZrVfa/1WRy4/h0niikcbu3Yf6dCoudh7ScG7BsyKAPC3CMg6IJKHzrmWS593UZClq7YJof6Vt4O+w==",
       "requires": {
         "@types/object-hash": "^3.0.2",
         "case-anything": "^2.1.10",
@@ -37695,7 +37714,7 @@
         "object-hash": "^3.0.0",
         "protobufjs": "^7.2.4",
         "ts-poet": "^6.4.1",
-        "ts-proto-descriptors": "1.9.0"
+        "ts-proto-descriptors": "^1.15.0"
       },
       "dependencies": {
         "long": {
@@ -37735,135 +37754,135 @@
       "integrity": "sha512-cy3+dN6Exm4bd2cpMAx7aHyqztfuRhKOr9Bny0irJi79y1nnnGVeOxc6pPSDcO4uR3JFmZit9B5SifT1AxXHiw=="
     },
     "@esbuild/android-arm": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.17.tgz",
-      "integrity": "sha512-wHsmJG/dnL3OkpAcwbgoBTTMHVi4Uyou3F5mf58ZtmUyIKfcdA7TROav/6tCzET4A3QW2Q2FC+eFneMU+iyOxg==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
       "optional": true
     },
     "@esbuild/android-arm64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.17.tgz",
-      "integrity": "sha512-9np+YYdNDed5+Jgr1TdWBsozZ85U1Oa3xW0c7TWqH0y2aGghXtZsuT8nYRbzOMcl0bXZXjOGbksoTtVOlWrRZg==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
       "optional": true
     },
     "@esbuild/android-x64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.17.tgz",
-      "integrity": "sha512-O+FeWB/+xya0aLg23hHEM2E3hbfwZzjqumKMSIqcHbNvDa+dza2D0yLuymRBQQnC34CWrsJUXyH2MG5VnLd6uw==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
       "optional": true
     },
     "@esbuild/darwin-arm64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.17.tgz",
-      "integrity": "sha512-M9uJ9VSB1oli2BE/dJs3zVr9kcCBBsE883prage1NWz6pBS++1oNn/7soPNS3+1DGj0FrkSvnED4Bmlu1VAE9g==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
       "optional": true
     },
     "@esbuild/darwin-x64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.17.tgz",
-      "integrity": "sha512-XDre+J5YeIJDMfp3n0279DFNrGCXlxOuGsWIkRb1NThMZ0BsrWXoTg23Jer7fEXQ9Ye5QjrvXpxnhzl3bHtk0g==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
       "optional": true
     },
     "@esbuild/freebsd-arm64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.17.tgz",
-      "integrity": "sha512-cjTzGa3QlNfERa0+ptykyxs5A6FEUQQF0MuilYXYBGdBxD3vxJcKnzDlhDCa1VAJCmAxed6mYhA2KaJIbtiNuQ==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
       "optional": true
     },
     "@esbuild/freebsd-x64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.17.tgz",
-      "integrity": "sha512-sOxEvR8d7V7Kw8QqzxWc7bFfnWnGdaFBut1dRUYtu+EIRXefBc/eIsiUiShnW0hM3FmQ5Zf27suDuHsKgZ5QrA==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
       "optional": true
     },
     "@esbuild/linux-arm": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.17.tgz",
-      "integrity": "sha512-2d3Lw6wkwgSLC2fIvXKoMNGVaeY8qdN0IC3rfuVxJp89CRfA3e3VqWifGDfuakPmp90+ZirmTfye1n4ncjv2lg==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
       "optional": true
     },
     "@esbuild/linux-arm64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.17.tgz",
-      "integrity": "sha512-c9w3tE7qA3CYWjT+M3BMbwMt+0JYOp3vCMKgVBrCl1nwjAlOMYzEo+gG7QaZ9AtqZFj5MbUc885wuBBmu6aADQ==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
       "optional": true
     },
     "@esbuild/linux-ia32": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.17.tgz",
-      "integrity": "sha512-1DS9F966pn5pPnqXYz16dQqWIB0dmDfAQZd6jSSpiT9eX1NzKh07J6VKR3AoXXXEk6CqZMojiVDSZi1SlmKVdg==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
       "optional": true
     },
     "@esbuild/linux-loong64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.17.tgz",
-      "integrity": "sha512-EvLsxCk6ZF0fpCB6w6eOI2Fc8KW5N6sHlIovNe8uOFObL2O+Mr0bflPHyHwLT6rwMg9r77WOAWb2FqCQrVnwFg==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
       "optional": true
     },
     "@esbuild/linux-mips64el": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.17.tgz",
-      "integrity": "sha512-e0bIdHA5p6l+lwqTE36NAW5hHtw2tNRmHlGBygZC14QObsA3bD4C6sXLJjvnDIjSKhW1/0S3eDy+QmX/uZWEYQ==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
       "optional": true
     },
     "@esbuild/linux-ppc64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.17.tgz",
-      "integrity": "sha512-BAAilJ0M5O2uMxHYGjFKn4nJKF6fNCdP1E0o5t5fvMYYzeIqy2JdAP88Az5LHt9qBoUa4tDaRpfWt21ep5/WqQ==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
       "optional": true
     },
     "@esbuild/linux-riscv64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.17.tgz",
-      "integrity": "sha512-Wh/HW2MPnC3b8BqRSIme/9Zhab36PPH+3zam5pqGRH4pE+4xTrVLx2+XdGp6fVS3L2x+DrsIcsbMleex8fbE6g==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
       "optional": true
     },
     "@esbuild/linux-s390x": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.17.tgz",
-      "integrity": "sha512-j/34jAl3ul3PNcK3pfI0NSlBANduT2UO5kZ7FCaK33XFv3chDhICLY8wJJWIhiQ+YNdQ9dxqQctRg2bvrMlYgg==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
       "optional": true
     },
     "@esbuild/linux-x64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.17.tgz",
-      "integrity": "sha512-QM50vJ/y+8I60qEmFxMoxIx4de03pGo2HwxdBeFd4nMh364X6TIBZ6VQ5UQmPbQWUVWHWws5MmJXlHAXvJEmpQ==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
       "optional": true
     },
     "@esbuild/netbsd-x64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.17.tgz",
-      "integrity": "sha512-/jGlhWR7Sj9JPZHzXyyMZ1RFMkNPjC6QIAan0sDOtIo2TYk3tZn5UDrkE0XgsTQCxWTTOcMPf9p6Rh2hXtl5TQ==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
       "optional": true
     },
     "@esbuild/openbsd-x64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.17.tgz",
-      "integrity": "sha512-rSEeYaGgyGGf4qZM2NonMhMOP/5EHp4u9ehFiBrg7stH6BYEEjlkVREuDEcQ0LfIl53OXLxNbfuIj7mr5m29TA==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
       "optional": true
     },
     "@esbuild/sunos-x64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.17.tgz",
-      "integrity": "sha512-Y7ZBbkLqlSgn4+zot4KUNYst0bFoO68tRgI6mY2FIM+b7ZbyNVtNbDP5y8qlu4/knZZ73fgJDlXID+ohY5zt5g==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
       "optional": true
     },
     "@esbuild/win32-arm64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.17.tgz",
-      "integrity": "sha512-bwPmTJsEQcbZk26oYpc4c/8PvTY3J5/QK8jM19DVlEsAB41M39aWovWoHtNm78sd6ip6prilxeHosPADXtEJFw==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
       "optional": true
     },
     "@esbuild/win32-ia32": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.17.tgz",
-      "integrity": "sha512-H/XaPtPKli2MhW+3CQueo6Ni3Avggi6hP/YvgkEe1aSaxw+AeO8MFjq8DlgfTd9Iz4Yih3QCZI6YLMoyccnPRg==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
       "optional": true
     },
     "@esbuild/win32-x64": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.17.tgz",
-      "integrity": "sha512-fGEb8f2BSA3CW7riJVurug65ACLuQAzKq0SSqkY2b2yHHH0MzDfbLyKIGzHwOI/gkHcxM/leuSW6D5w/LMNitA==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
       "optional": true
     },
     "@eslint/eslintrc": {
@@ -40193,9 +40212,9 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
     },
     "@types/object-hash": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-3.0.2.tgz",
-      "integrity": "sha512-tfyXl1JPCf2hzIDK29gO7qGqJjThKBzg/Cn3bA68R9NmWdOx+f7k5mm4to/n43BHspCwcoUC6FU4NpUoK/h9bQ=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-3.0.3.tgz",
+      "integrity": "sha512-Mb0SDIhjhBAz4/rDNU0cYcQR4lSJIwy+kFlm0whXLkx+o0pXwEszwyrWD6gXWumxVbAS6XZ9gXK82LR+Uk+cKQ=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -42109,9 +42128,9 @@
       }
     },
     "@well-known-components/logger": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@well-known-components/logger/-/logger-3.1.2.tgz",
-      "integrity": "sha512-nT2ULsvtxcaehnUPcmRfVWIspVq6iYTPTzs5D9lBxqE3Pt+j5StzPfo814IqSo4xhN9cJhJAQ/EggMmKuYMaZg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@well-known-components/logger/-/logger-3.1.3.tgz",
+      "integrity": "sha512-tTjD27CdfU4SVe+kPfjRbPSqdrw0Crg+M31RNejinCuMEBtEGbhYLtB1M4gn+PSTy2Oi3cI3iOdeQ1xVhMSerQ==",
       "requires": {}
     },
     "@well-known-components/metrics": {
@@ -42543,15 +42562,15 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "archiver": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.1.tgz",
-      "integrity": "sha512-8KyabkmbYrH+9ibcTScQ1xCJC/CGcugdVIwB+53f5sZziXgwUh3iXlAlANMxcZyDEfTHMe6+Z5FofV8nopXP7w==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
       "requires": {
         "archiver-utils": "^2.1.0",
-        "async": "^3.2.3",
+        "async": "^3.2.4",
         "buffer-crc32": "^0.2.1",
         "readable-stream": "^3.6.0",
-        "readdir-glob": "^1.0.0",
+        "readdir-glob": "^1.1.2",
         "tar-stream": "^2.2.0",
         "zip-stream": "^4.1.0"
       },
@@ -47061,32 +47080,32 @@
       }
     },
     "esbuild": {
-      "version": "0.18.17",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.17.tgz",
-      "integrity": "sha512-1GJtYnUxsJreHYA0Y+iQz2UEykonY66HNWOb0yXYZi9/kNrORUEHVg87eQsCtqh59PEJ5YVZJO98JHznMJSWjg==",
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
       "requires": {
-        "@esbuild/android-arm": "0.18.17",
-        "@esbuild/android-arm64": "0.18.17",
-        "@esbuild/android-x64": "0.18.17",
-        "@esbuild/darwin-arm64": "0.18.17",
-        "@esbuild/darwin-x64": "0.18.17",
-        "@esbuild/freebsd-arm64": "0.18.17",
-        "@esbuild/freebsd-x64": "0.18.17",
-        "@esbuild/linux-arm": "0.18.17",
-        "@esbuild/linux-arm64": "0.18.17",
-        "@esbuild/linux-ia32": "0.18.17",
-        "@esbuild/linux-loong64": "0.18.17",
-        "@esbuild/linux-mips64el": "0.18.17",
-        "@esbuild/linux-ppc64": "0.18.17",
-        "@esbuild/linux-riscv64": "0.18.17",
-        "@esbuild/linux-s390x": "0.18.17",
-        "@esbuild/linux-x64": "0.18.17",
-        "@esbuild/netbsd-x64": "0.18.17",
-        "@esbuild/openbsd-x64": "0.18.17",
-        "@esbuild/sunos-x64": "0.18.17",
-        "@esbuild/win32-arm64": "0.18.17",
-        "@esbuild/win32-ia32": "0.18.17",
-        "@esbuild/win32-x64": "0.18.17"
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
       }
     },
     "escalade": {
@@ -55273,14 +55292,14 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
-          "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw=="
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+          "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g=="
         },
         "minipass": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.2.tgz",
-          "integrity": "sha512-eL79dXrE1q9dBbDCLg7xfn/vl7MS4F1gvJAgjJrQli/jbQWdUttuVawphqpffoIYfRdq78LHx6GP4bU/EQ2ATA=="
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+          "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg=="
         }
       }
     },
@@ -61206,9 +61225,9 @@
       }
     },
     "ts-proto": {
-      "version": "1.156.2",
-      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.156.2.tgz",
-      "integrity": "sha512-0ZAbGmfvB2R79QJfpTIk56T8xM4k9ZS+z77517HDpuFZFizCMceCIE3IhdYQWbmP1oSYLzw0AeVbVHi2PIigKQ==",
+      "version": "1.156.7",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.156.7.tgz",
+      "integrity": "sha512-vuSby+Mx0CniXscbHx9ieKCEErGBuie12RmduPA67p27Io5C0gkzlMnyN/j3vKWAJrP/h6+mbAoo6WrlalOt7w==",
       "requires": {
         "case-anything": "^2.1.13",
         "protobufjs": "^7.2.4",
@@ -61239,25 +61258,42 @@
             "@types/node": ">=13.7.0",
             "long": "^5.0.0"
           }
-        },
-        "ts-proto-descriptors": {
-          "version": "1.15.0",
-          "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-1.15.0.tgz",
-          "integrity": "sha512-TYyJ7+H+7Jsqawdv+mfsEpZPTIj9siDHS6EMCzG/z3b/PZiphsX+mWtqFfFVe5/N0Th6V3elK9lQqjnrgTOfrg==",
-          "requires": {
-            "long": "^5.2.3",
-            "protobufjs": "^7.2.4"
-          }
         }
       }
     },
     "ts-proto-descriptors": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-1.9.0.tgz",
-      "integrity": "sha512-Ui8zA5Q4Jnq6JIGRraUWvECrqixxtwwin8GkhIkvwCpR+JcSPsxWe8HfTj5eHfyruGYI6Zjf96XlC87hTakHfQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-1.15.0.tgz",
+      "integrity": "sha512-TYyJ7+H+7Jsqawdv+mfsEpZPTIj9siDHS6EMCzG/z3b/PZiphsX+mWtqFfFVe5/N0Th6V3elK9lQqjnrgTOfrg==",
       "requires": {
-        "long": "^4.0.0",
-        "protobufjs": "^6.8.8"
+        "long": "^5.2.3",
+        "protobufjs": "^7.2.4"
+      },
+      "dependencies": {
+        "long": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+          "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+        },
+        "protobufjs": {
+          "version": "7.2.4",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
+          "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/node": ">=13.7.0",
+            "long": "^5.0.0"
+          }
+        }
       }
     },
     "tsconfig-paths": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@dcl/hashing": "^3.0.4",
     "@dcl/mini-rpc": "^1.0.6",
     "@dcl/schemas": "^8.2.2",
-    "@dcl/sdk": "^7.3.6",
+    "@dcl/sdk": "^7.3.9",
     "@dcl/single-sign-on-client": "^0.0.12",
     "@dcl/ui-env": "^1.2.0",
     "@testing-library/jest-dom": "^5.16.4",

--- a/src/components/InspectorPage/InspectorPage.container.ts
+++ b/src/components/InspectorPage/InspectorPage.container.ts
@@ -3,6 +3,7 @@ import { RootState } from 'modules/common/types'
 import { isLoggedIn } from 'modules/identity/selectors'
 import { getCurrentScene } from 'modules/scene/selectors'
 import { connectInspector, openInspector } from 'modules/inspector/actions'
+import { isReloading } from 'modules/inspector/selectors'
 import { getIsInspectorEnabled } from 'modules/features/selectors'
 import { MapStateProps, MapDispatch, MapDispatchProps } from './InspectorPage.types'
 import EditorPage from './InspectorPage'
@@ -11,7 +12,8 @@ const mapState = (state: RootState): MapStateProps => {
   return {
     isLoggedIn: isLoggedIn(state),
     scene: getCurrentScene(state),
-    isInspectorEnabled: getIsInspectorEnabled(state)
+    isInspectorEnabled: getIsInspectorEnabled(state),
+    isReloading: isReloading(state)
   }
 }
 

--- a/src/components/InspectorPage/InspectorPage.tsx
+++ b/src/components/InspectorPage/InspectorPage.tsx
@@ -31,7 +31,7 @@ export default class InspectorPage extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const { scene, isLoggedIn, isInspectorEnabled } = this.props
+    const { scene, isLoggedIn, isInspectorEnabled, isReloading } = this.props
 
     if (!isInspectorEnabled) {
       return <NotFoundPage />
@@ -43,8 +43,8 @@ export default class InspectorPage extends React.PureComponent<Props, State> {
 
     return (
       <div className="InspectorPage">
-        {!this.state.isLoaded && <Loader active />}
-        {scene && (
+        {(!this.state.isLoaded || isReloading) && <Loader active />}
+        {scene && !isReloading && (
           <>
             <TopBar />
             <iframe

--- a/src/components/InspectorPage/InspectorPage.types.ts
+++ b/src/components/InspectorPage/InspectorPage.types.ts
@@ -6,6 +6,7 @@ export type Props = {
   scene: Scene | null
   isLoggedIn: boolean
   isInspectorEnabled: boolean
+  isReloading: boolean
   onOpen: typeof openInspector
   onConnect: typeof connectInspector
 }
@@ -14,6 +15,6 @@ export type State = {
   isLoaded: boolean
 }
 
-export type MapStateProps = Pick<Props, 'isLoggedIn' | 'scene' | 'isInspectorEnabled'>
+export type MapStateProps = Pick<Props, 'isLoggedIn' | 'scene' | 'isInspectorEnabled' | 'isReloading'>
 export type MapDispatchProps = Pick<Props, 'onOpen' | 'onConnect'>
 export type MapDispatch = Dispatch<OpenInspectorAction | ConnectInspectorAction>

--- a/src/components/Modals/EditProjectModal/EditProjectModal.tsx
+++ b/src/components/Modals/EditProjectModal/EditProjectModal.tsx
@@ -65,7 +65,7 @@ export default class EditProjectModal extends React.PureComponent<Props, State> 
   }
 
   render() {
-    const { name, deploymentStatus, currentScene, onClose } = this.props
+    const { name, deploymentStatus, onClose } = this.props
     const { title, description, rows, cols, hasError } = this.state
     const isSubmitDisabled = hasError || deploymentStatus !== DeploymentStatus.UNPUBLISHED
 
@@ -77,14 +77,12 @@ export default class EditProjectModal extends React.PureComponent<Props, State> 
             <div className="details">
               <ProjectFields.Title value={title} onChange={this.handleTitleChange} required icon="asterisk" />
               <ProjectFields.Description value={description} onChange={this.handleDescriptionChange} />
-              {currentScene.sdk6 && (
-                <div className="picker">
-                  <Header sub className="picker-label">
-                    {t('edit_project_modal.custom_layout_label')}
-                  </Header>
-                  <ProjectLayoutPicker rows={rows} cols={cols} onChange={this.handleLayoutChange} />
-                </div>
-              )}
+              <div className="picker">
+                <Header sub className="picker-label">
+                  {t('edit_project_modal.custom_layout_label')}
+                </Header>
+                <ProjectLayoutPicker rows={rows} cols={cols} onChange={this.handleLayoutChange} />
+              </div>
             </div>
             <div className="error">{deploymentStatus !== DeploymentStatus.UNPUBLISHED && t('edit_project_modal.unpublish_needed')}</div>
           </Modal.Content>

--- a/src/modules/inspector/actions.ts
+++ b/src/modules/inspector/actions.ts
@@ -31,3 +31,7 @@ export type RPCFailureAction = ReturnType<typeof rpcFailure>
 export const TOGGLE_SCREENSHOT = 'Toggle Screenshot'
 export const toggleScreenshot = (enabled: boolean) => action(TOGGLE_SCREENSHOT, { enabled })
 export type ToggleScreenshotAction = ReturnType<typeof toggleScreenshot>
+
+export const SET_INSPECTOR_RELOADING = 'Set Inspector Reloading'
+export const setInspectorReloading = (value: boolean) => action(SET_INSPECTOR_RELOADING, { value })
+export type SetInspectorReloadingAction = ReturnType<typeof setInspectorReloading>

--- a/src/modules/inspector/reducer.ts
+++ b/src/modules/inspector/reducer.ts
@@ -1,21 +1,29 @@
-import { ToggleScreenshotAction, TOGGLE_SCREENSHOT } from './actions'
+import { SetInspectorReloadingAction, SET_INSPECTOR_RELOADING, ToggleScreenshotAction, TOGGLE_SCREENSHOT } from './actions'
 
 export type InspectorState = {
   screenshotEnabled: boolean
+  isReloading: boolean
 }
 
 const INITIAL_STATE: InspectorState = {
-  screenshotEnabled: true
+  screenshotEnabled: true,
+  isReloading: false
 }
 
-type InspectorReducerAction = ToggleScreenshotAction
+type InspectorReducerAction = ToggleScreenshotAction | SetInspectorReloadingAction
 
-export function inspectorReducer(state = INITIAL_STATE, action: InspectorReducerAction) {
+export function inspectorReducer(state = INITIAL_STATE, action: InspectorReducerAction): InspectorState {
   switch (action.type) {
     case TOGGLE_SCREENSHOT: {
       return {
         ...state,
         screenshotEnabled: action.payload.enabled
+      }
+    }
+    case SET_INSPECTOR_RELOADING: {
+      return {
+        ...state,
+        isReloading: action.payload.value
       }
     }
     default:

--- a/src/modules/inspector/sagas.ts
+++ b/src/modules/inspector/sagas.ts
@@ -38,7 +38,7 @@ import {
 } from './actions'
 import { Project } from 'modules/project/types'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
-import { IframeStorage } from '@dcl/inspector'
+import { IframeStorage, UiClient } from '@dcl/inspector'
 import { MessageTransport } from '@dcl/mini-rpc'
 import { getParcels } from './utils'
 import { BuilderAPI, getContentsStorageUrl } from 'lib/api/builder'
@@ -122,6 +122,11 @@ export function* inspectorSaga(builder: BuilderAPI, store: RootStore) {
         return promise
       })
     }
+
+    // configure UI
+    const ui = new UiClient(transport)
+    yield call([ui, 'selectAssetsTab'], 'AssetsPack')
+    yield call([ui, 'toggleComponent'], 'inspector::Scene', false)
 
     // wait for RPC to be idle (3 seconds)
     yield waitForRpcIdle(3000)

--- a/src/modules/inspector/selectors.ts
+++ b/src/modules/inspector/selectors.ts
@@ -2,3 +2,4 @@ import { RootState } from 'modules/common/types'
 
 export const getState = (state: RootState) => state.inspector
 export const isScreenshotEnabled = (state: RootState) => getState(state).screenshotEnabled
+export const isReloading = (state: RootState) => getState(state).isReloading

--- a/src/modules/inspector/utils.ts
+++ b/src/modules/inspector/utils.ts
@@ -1,7 +1,7 @@
 import { Composite, CompositeDefinition } from '@dcl/ecs'
 import { createEngineContext, dumpEngineToComposite, dumpEngineToCrdtCommands } from '@dcl/inspector'
 import { Layout, Project } from 'modules/project/types'
-import { ComponentData, ComponentType, SceneSDK6 } from 'modules/scene/types'
+import { ComponentData, ComponentType, SceneSDK6, SceneSDK7 } from 'modules/scene/types'
 
 export function getParcels(layout: Layout) {
   const parcels: { x: number; y: number }[] = []
@@ -73,4 +73,37 @@ export function toMappings(scene: SceneSDK6): Record<string, string> {
 export function toCrdt(scene: SceneSDK6, project?: Project) {
   const engine = getEngine(scene, project)
   return dumpEngineToCrdtCommands(engine as any)
+}
+
+export function changeLayout(scene: SceneSDK7, layout: Layout) {
+  const sceneComponent = scene.composite.components.find(component => component.name === 'inspector::Scene')!
+  const newData = {
+    ...sceneComponent.data
+  } as any
+
+  newData[0] = {
+    ...newData[0],
+    json: {
+      ...newData[0].json,
+      layout: {
+        ...newData[0].json.layout,
+        parcels: getParcels(layout)
+      }
+    }
+  }
+
+  const newScene: SceneSDK7 = {
+    ...scene,
+    composite: {
+      ...scene.composite,
+      components: [
+        ...scene.composite.components.filter(component => component.name !== 'inspector::Scene'),
+        {
+          ...sceneComponent,
+          data: newData
+        }
+      ]
+    }
+  }
+  return newScene
 }


### PR DESCRIPTION
This PR enabled resizing the SDK7 scenes using the `EditProjectModal`, same way as the SDK6 scenes.

It also disables the `Scene` component in the inspector because resizing the scene from there would not impact in the deployed scene.

It also changes the initial selected tab to be the `AssetPacks` tab.