### PR TITLE
feat: serve bin/index.js

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,7 @@ REACT_APP_FF_BUILDER_DCL_CONTROLLER_V2=
 
 ; Local development of @dcl/inspector
 REACT_APP_INSPECTOR_PORT=
+
+; Local development of @dcl/asset-packs
+REACT_APP_BIN_INDEX_JS_DEV_PORT=
+REACT_APP_BIN_INDEX_JS_DEV_PATH=

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ yarn-error.log*
 src/ecsScene/scene.js
 /public/editor.js
 /public/inspector*
+/public/bin
 /src/ecsScene/ecs.js.raw

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/hashing": "^3.0.4",
         "@dcl/mini-rpc": "^1.0.7",
         "@dcl/schemas": "^9.4.1",
-        "@dcl/sdk": "7.3.10",
+        "@dcl/sdk": "^7.3.13-6114564127.commit-51030fe",
         "@dcl/single-sign-on-client": "^0.0.12",
         "@dcl/ui-env": "^1.2.0",
         "@sentry/react": "^7.64.0",
@@ -2266,37 +2266,19 @@
       }
     },
     "node_modules/@dcl/crypto": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.4.3.tgz",
-      "integrity": "sha512-biG8PqImY3jtVM5bPizgAD0P6X9/7VMxKuD2hxiEEeZClfB1Zi76Qk8pHaLpJ5pU3B+NogwZ8xoREhq0Po+gXQ==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.4.5.tgz",
+      "integrity": "sha512-uneyjOAOx7pi5kabZsLmPm9kSLkCk4Cok8FUsvT+6k8RquqkjKqocvkGVOMaoWsfU6S3mkLOyaeqEKmOy4ErxA==",
       "dependencies": {
-        "@dcl/schemas": "^8.2.0",
+        "@dcl/schemas": "^9.2.0",
         "eth-connect": "^6.0.3",
         "ethereum-cryptography": "^1.0.3"
       }
     },
-    "node_modules/@dcl/crypto/node_modules/@dcl/schemas": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-8.2.2.tgz",
-      "integrity": "sha512-IZqcT1YOKxw5XWs6LW6Uw+7Ue5vHCVERPMwefAdt26jW1OTH818od0rBc1tQzzfBTwsrAvbgFJvpbZedieu00g==",
-      "dependencies": {
-        "ajv": "^8.11.0",
-        "ajv-errors": "^3.0.0",
-        "ajv-keywords": "^5.1.0"
-      }
-    },
-    "node_modules/@dcl/crypto/node_modules/ajv-errors": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
-      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
-      "peerDependencies": {
-        "ajv": "^8.0.1"
-      }
-    },
     "node_modules/@dcl/ecs": {
-      "version": "7.3.10",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.10.tgz",
-      "integrity": "sha512-FWvjc4sF8sVHrXWX3nYTUn7m+0rla6vl8dQSNEqSEnvCZ8lnZxZtgVBRqY6BQnsypniyp9mnljWq+EIiDO42PQ=="
+      "version": "7.3.13-6114564127.commit-51030fe",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.13-6114564127.commit-51030fe.tgz",
+      "integrity": "sha512-ub/Pz/vE9GRn2INWYqLXEvCvtV+B4ucuuYq9wlhnITQgUfoYYy0g5WOM53s1DP2oNSNT8qKbcrIWSWtXLQ9BLg=="
     },
     "node_modules/@dcl/ecs-math": {
       "version": "2.0.2",
@@ -2304,9 +2286,9 @@
       "integrity": "sha512-w01+a3mpHvxGPHepu0hAAX8OfpBSQEqBbC1+U8o+5SBSQVXHiRwt3P4cK20yM8QCgZe3enPttmpqePnjTliTig=="
     },
     "node_modules/@dcl/explorer": {
-      "version": "1.0.139428-20230817134048.commit-4c182e2",
-      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.139428-20230817134048.commit-4c182e2.tgz",
-      "integrity": "sha512-6b8CbIp06DQKkN5G1kX7JMGLUyIvBueEKSHIu/a80TVxgT/JUqG7CSnEql/fnGZrn8npfpsSx8lP8AODnsFYNQ=="
+      "version": "1.0.141942-20230828173247.commit-e060db1",
+      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.141942-20230828173247.commit-e060db1.tgz",
+      "integrity": "sha512-sRDMuDAzmQTALcxW6MflWIqBj1AbOagTCGqhnjPytPogrO0lKu6a+ok1LOlaH6ZzJxXuV/GVTZlsUF5ZBt2ZXA=="
     },
     "node_modules/@dcl/hashing": {
       "version": "3.0.4",
@@ -2314,14 +2296,14 @@
       "integrity": "sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg=="
     },
     "node_modules/@dcl/inspector": {
-      "version": "7.3.10",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.10.tgz",
-      "integrity": "sha512-aq5ShMD06NDVCj87uzfhA7QCnInJcsLfd8vOzJdDrBlogCBk7pnnmWLKTWPsGR9/inK8xESgAJkxkxK/HOuzDQ=="
+      "version": "7.3.13-6114564127.commit-51030fe",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.13-6114564127.commit-51030fe.tgz",
+      "integrity": "sha512-iUcaHtTpfZw0Yo1OGYRSRiQ6X4rJ9rY9wT+HX/t/4M2mZuCAniJdXXfGTDyGvfZGRfDOMe+mKHok4s33IhJ3Iw=="
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.3.10",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.10.tgz",
-      "integrity": "sha512-SX9O6GQXIKoLe3nzPC8y2Qs/B31yzftt7HPISMhXglph+QCgjvIZkMAG8m3xR2Maq4+ardeD5mVR+Pr/ewO4Qw=="
+      "version": "7.3.13-6114564127.commit-51030fe",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.13-6114564127.commit-51030fe.tgz",
+      "integrity": "sha512-5rXHoGdOCogciiWazIkocKYurFxIiyrZ7guJKfpnULQErV82VVYA6rbPWWuSt11M3yGj4qHZCw9A/heuPrx00w=="
     },
     "node_modules/@dcl/kernel": {
       "version": "1.0.0-2505075507.commit-6af9c3b",
@@ -2329,9 +2311,9 @@
       "integrity": "sha512-i4pzhHdv6AXC7jHKQzWNvmf5xXFg8LY2EzToaHDtyJcFdW2uW2O7dYeJKpF1EMwzD/Q8J7VfGcnSql0B1OiOEA=="
     },
     "node_modules/@dcl/linker-dapp": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.9.1.tgz",
-      "integrity": "sha512-Ji/dDrtHq1LVgkDG16kpe2ss/Ee2wKGLFmPaKAQF4TFg40LepSXnHQzPLhZVqzlNm2iyQxlkYStxJai+bMMSog=="
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.10.1.tgz",
+      "integrity": "sha512-61H3Xy4Ft1+rljtmqgAYobIKALDVta4UEj9VRxYqll2jy5Z/tv6h/brEAKyOgMQYJKRG0f8ki5B+GfnJgEHWTw=="
     },
     "node_modules/@dcl/mini-comms": {
       "version": "1.0.1-20230216163137.commit-a4c75be",
@@ -2379,9 +2361,9 @@
       }
     },
     "node_modules/@dcl/mini-comms/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.0.tgz",
+      "integrity": "sha512-WR0RJE9Ehsio6U4TuM+LmunEsjQ5ncHlw4sn9ihD6RoJKZrVyH9FWV3dmnwu8B2aNib1OvG2X6adUCyFpQyWcg==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -2421,11 +2403,11 @@
       }
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.3.10",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.10.tgz",
-      "integrity": "sha512-z/JVDkPWGM8WJmIO7RWLhhrGzbCcSDAtqDPPoSjtUGAz8r8kdXdPl0sYmiaGrc7wC7uBaDqgFHZtCBi+R5k8+A==",
+      "version": "7.3.13-6114564127.commit-51030fe",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.13-6114564127.commit-51030fe.tgz",
+      "integrity": "sha512-aLud5vyd8GJNpJ0wyTvnxIwhVMyPdrMDitw6DCVnFS/aehaesLbW0dGjQSU+PpA+3fspcpeCarv58hNDq8IJkQ==",
       "dependencies": {
-        "@dcl/ecs": "7.3.10",
+        "@dcl/ecs": "7.3.13-6114564127.commit-51030fe",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -2492,27 +2474,28 @@
       }
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.3.10",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.10.tgz",
-      "integrity": "sha512-f4o8nFzHI0xPZbmWwYVdX7SgEyDPynNclfK0oEgZ9qPe2IsztYWAOVkd4gsOFr85w/u3wuwouA8Br6Cy759iFA==",
+      "version": "7.3.13-6114564127.commit-51030fe",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.13-6114564127.commit-51030fe.tgz",
+      "integrity": "sha512-EcIB8qoIRhEJq2sw/17/xQteyBL3m7f8UfUiUtPeZ8gGo10lG6rDwY0eeDsYr/gXefIK+HorksisuZ9XZhaHjA==",
       "dependencies": {
-        "@dcl/ecs": "7.3.10",
+        "@dcl/ecs": "7.3.13-6114564127.commit-51030fe",
         "@dcl/ecs-math": "2.0.2",
-        "@dcl/explorer": "1.0.139428-20230817134048.commit-4c182e2",
-        "@dcl/js-runtime": "7.3.10",
-        "@dcl/react-ecs": "7.3.10",
-        "@dcl/sdk-commands": "7.3.10"
+        "@dcl/explorer": "1.0.141942-20230828173247.commit-e060db1",
+        "@dcl/js-runtime": "7.3.13-6114564127.commit-51030fe",
+        "@dcl/react-ecs": "7.3.13-6114564127.commit-51030fe",
+        "@dcl/sdk-commands": "7.3.13-6114564127.commit-51030fe"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.3.10",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.10.tgz",
-      "integrity": "sha512-ykYzM5VjNY+cBuXIa1btB40zt+7jUpcCf6+95bA8YH5MWziFN9/TniLgeymFU8puyRgPgBMxtwoh+R+BlsGtyg==",
+      "version": "7.3.13-6114564127.commit-51030fe",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.13-6114564127.commit-51030fe.tgz",
+      "integrity": "sha512-J5HdBnIfioKTmko9324o4GtYJjA11Xcftxy3lVpFKcWgtfh6MN9/i7bWGIk2oDdF4w1e568Gtsoxv+KV75xzZw==",
       "dependencies": {
-        "@dcl/ecs": "7.3.10",
+        "@dcl/crypto": "^3.4.4",
+        "@dcl/ecs": "7.3.13-6114564127.commit-51030fe",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.3.10",
-        "@dcl/linker-dapp": "0.9.1",
+        "@dcl/inspector": "7.3.13-6114564127.commit-51030fe",
+        "@dcl/linker-dapp": "0.10.1",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-5812097343.commit-8025576",
         "@dcl/rpc": "^1.1.1",
@@ -2536,6 +2519,7 @@
         "node-fetch": "^2.6.8",
         "open": "^8.4.0",
         "portfinder": "^1.0.32",
+        "prompts": "^2.4.2",
         "typescript": "^5.0.2",
         "undici": "^5.19.1",
         "uuid": "^9.0.0"
@@ -2620,9 +2604,9 @@
       }
     },
     "node_modules/@dcl/sdk-commands/node_modules/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -2654,15 +2638,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@dcl/sdk-commands/node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@dcl/sdk-commands/node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/@dcl/sdk-commands/node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6230,9 +6226,9 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
     },
     "node_modules/@types/object-hash": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-3.0.3.tgz",
-      "integrity": "sha512-Mb0SDIhjhBAz4/rDNU0cYcQR4lSJIwy+kFlm0whXLkx+o0pXwEszwyrWD6gXWumxVbAS6XZ9gXK82LR+Uk+cKQ=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-3.0.4.tgz",
+      "integrity": "sha512-w4fEy2suq1bepUxHoJRCBHJz0vS5DPAYpSbcgNwOahljxwyJsiKmi8qyes2/TJc+4Avd7fsgP+ZgUuXZjPvdug=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -8381,9 +8377,9 @@
       }
     },
     "node_modules/@well-known-components/http-server/node_modules/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -11634,9 +11630,9 @@
       }
     },
     "node_modules/compress-commons": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.1.tgz",
-      "integrity": "sha512-QLdDLCKNV2dtoTorqgxngQCMA+gWXkM/Nwu7FpeBhk/RdkzimqC3jueb/FDmaZeXh+uby1jkBqE3xArsLBE5wQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
       "dependencies": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -12086,9 +12082,9 @@
       }
     },
     "node_modules/crc32-stream": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.2.tgz",
-      "integrity": "sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
@@ -32335,9 +32331,9 @@
       }
     },
     "node_modules/ts-proto": {
-      "version": "1.156.7",
-      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.156.7.tgz",
-      "integrity": "sha512-vuSby+Mx0CniXscbHx9ieKCEErGBuie12RmduPA67p27Io5C0gkzlMnyN/j3vKWAJrP/h6+mbAoo6WrlalOt7w==",
+      "version": "1.157.0",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.157.0.tgz",
+      "integrity": "sha512-0f9rvHb+1aLG66UpFHh1QbZ5SMvKqV5EudUerHRF+C47g2wd8ZYXiVrK3VmsmLcNxmMrdi4vWgFNCH6qRg1SrA==",
       "dependencies": {
         "case-anything": "^2.1.13",
         "protobufjs": "^7.2.4",
@@ -35536,12 +35532,32 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/zip-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.0.tgz",
-      "integrity": "sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
       "dependencies": {
-        "archiver-utils": "^2.1.0",
-        "compress-commons": "^4.1.0",
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
         "readable-stream": "^3.6.0"
       },
       "engines": {
@@ -37055,37 +37071,19 @@
       }
     },
     "@dcl/crypto": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.4.3.tgz",
-      "integrity": "sha512-biG8PqImY3jtVM5bPizgAD0P6X9/7VMxKuD2hxiEEeZClfB1Zi76Qk8pHaLpJ5pU3B+NogwZ8xoREhq0Po+gXQ==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.4.5.tgz",
+      "integrity": "sha512-uneyjOAOx7pi5kabZsLmPm9kSLkCk4Cok8FUsvT+6k8RquqkjKqocvkGVOMaoWsfU6S3mkLOyaeqEKmOy4ErxA==",
       "requires": {
-        "@dcl/schemas": "^8.2.0",
+        "@dcl/schemas": "^9.2.0",
         "eth-connect": "^6.0.3",
         "ethereum-cryptography": "^1.0.3"
-      },
-      "dependencies": {
-        "@dcl/schemas": {
-          "version": "8.2.2",
-          "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-8.2.2.tgz",
-          "integrity": "sha512-IZqcT1YOKxw5XWs6LW6Uw+7Ue5vHCVERPMwefAdt26jW1OTH818od0rBc1tQzzfBTwsrAvbgFJvpbZedieu00g==",
-          "requires": {
-            "ajv": "^8.11.0",
-            "ajv-errors": "^3.0.0",
-            "ajv-keywords": "^5.1.0"
-          }
-        },
-        "ajv-errors": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
-          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
-          "requires": {}
-        }
       }
     },
     "@dcl/ecs": {
-      "version": "7.3.10",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.10.tgz",
-      "integrity": "sha512-FWvjc4sF8sVHrXWX3nYTUn7m+0rla6vl8dQSNEqSEnvCZ8lnZxZtgVBRqY6BQnsypniyp9mnljWq+EIiDO42PQ=="
+      "version": "7.3.13-6114564127.commit-51030fe",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.13-6114564127.commit-51030fe.tgz",
+      "integrity": "sha512-ub/Pz/vE9GRn2INWYqLXEvCvtV+B4ucuuYq9wlhnITQgUfoYYy0g5WOM53s1DP2oNSNT8qKbcrIWSWtXLQ9BLg=="
     },
     "@dcl/ecs-math": {
       "version": "2.0.2",
@@ -37093,9 +37091,9 @@
       "integrity": "sha512-w01+a3mpHvxGPHepu0hAAX8OfpBSQEqBbC1+U8o+5SBSQVXHiRwt3P4cK20yM8QCgZe3enPttmpqePnjTliTig=="
     },
     "@dcl/explorer": {
-      "version": "1.0.139428-20230817134048.commit-4c182e2",
-      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.139428-20230817134048.commit-4c182e2.tgz",
-      "integrity": "sha512-6b8CbIp06DQKkN5G1kX7JMGLUyIvBueEKSHIu/a80TVxgT/JUqG7CSnEql/fnGZrn8npfpsSx8lP8AODnsFYNQ=="
+      "version": "1.0.141942-20230828173247.commit-e060db1",
+      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.141942-20230828173247.commit-e060db1.tgz",
+      "integrity": "sha512-sRDMuDAzmQTALcxW6MflWIqBj1AbOagTCGqhnjPytPogrO0lKu6a+ok1LOlaH6ZzJxXuV/GVTZlsUF5ZBt2ZXA=="
     },
     "@dcl/hashing": {
       "version": "3.0.4",
@@ -37103,14 +37101,14 @@
       "integrity": "sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg=="
     },
     "@dcl/inspector": {
-      "version": "7.3.10",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.10.tgz",
-      "integrity": "sha512-aq5ShMD06NDVCj87uzfhA7QCnInJcsLfd8vOzJdDrBlogCBk7pnnmWLKTWPsGR9/inK8xESgAJkxkxK/HOuzDQ=="
+      "version": "7.3.13-6114564127.commit-51030fe",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.13-6114564127.commit-51030fe.tgz",
+      "integrity": "sha512-iUcaHtTpfZw0Yo1OGYRSRiQ6X4rJ9rY9wT+HX/t/4M2mZuCAniJdXXfGTDyGvfZGRfDOMe+mKHok4s33IhJ3Iw=="
     },
     "@dcl/js-runtime": {
-      "version": "7.3.10",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.10.tgz",
-      "integrity": "sha512-SX9O6GQXIKoLe3nzPC8y2Qs/B31yzftt7HPISMhXglph+QCgjvIZkMAG8m3xR2Maq4+ardeD5mVR+Pr/ewO4Qw=="
+      "version": "7.3.13-6114564127.commit-51030fe",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.13-6114564127.commit-51030fe.tgz",
+      "integrity": "sha512-5rXHoGdOCogciiWazIkocKYurFxIiyrZ7guJKfpnULQErV82VVYA6rbPWWuSt11M3yGj4qHZCw9A/heuPrx00w=="
     },
     "@dcl/kernel": {
       "version": "1.0.0-2505075507.commit-6af9c3b",
@@ -37118,9 +37116,9 @@
       "integrity": "sha512-i4pzhHdv6AXC7jHKQzWNvmf5xXFg8LY2EzToaHDtyJcFdW2uW2O7dYeJKpF1EMwzD/Q8J7VfGcnSql0B1OiOEA=="
     },
     "@dcl/linker-dapp": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.9.1.tgz",
-      "integrity": "sha512-Ji/dDrtHq1LVgkDG16kpe2ss/Ee2wKGLFmPaKAQF4TFg40LepSXnHQzPLhZVqzlNm2iyQxlkYStxJai+bMMSog=="
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.10.1.tgz",
+      "integrity": "sha512-61H3Xy4Ft1+rljtmqgAYobIKALDVta4UEj9VRxYqll2jy5Z/tv6h/brEAKyOgMQYJKRG0f8ki5B+GfnJgEHWTw=="
     },
     "@dcl/mini-comms": {
       "version": "1.0.1-20230216163137.commit-a4c75be",
@@ -37166,9 +37164,9 @@
           "requires": {}
         },
         "ws": {
-          "version": "8.13.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+          "version": "8.14.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.0.tgz",
+          "integrity": "sha512-WR0RJE9Ehsio6U4TuM+LmunEsjQ5ncHlw4sn9ihD6RoJKZrVyH9FWV3dmnwu8B2aNib1OvG2X6adUCyFpQyWcg==",
           "requires": {}
         }
       }
@@ -37196,11 +37194,11 @@
       }
     },
     "@dcl/react-ecs": {
-      "version": "7.3.10",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.10.tgz",
-      "integrity": "sha512-z/JVDkPWGM8WJmIO7RWLhhrGzbCcSDAtqDPPoSjtUGAz8r8kdXdPl0sYmiaGrc7wC7uBaDqgFHZtCBi+R5k8+A==",
+      "version": "7.3.13-6114564127.commit-51030fe",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.13-6114564127.commit-51030fe.tgz",
+      "integrity": "sha512-aLud5vyd8GJNpJ0wyTvnxIwhVMyPdrMDitw6DCVnFS/aehaesLbW0dGjQSU+PpA+3fspcpeCarv58hNDq8IJkQ==",
       "requires": {
-        "@dcl/ecs": "7.3.10",
+        "@dcl/ecs": "7.3.13-6114564127.commit-51030fe",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       },
@@ -37260,27 +37258,28 @@
       }
     },
     "@dcl/sdk": {
-      "version": "7.3.10",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.10.tgz",
-      "integrity": "sha512-f4o8nFzHI0xPZbmWwYVdX7SgEyDPynNclfK0oEgZ9qPe2IsztYWAOVkd4gsOFr85w/u3wuwouA8Br6Cy759iFA==",
+      "version": "7.3.13-6114564127.commit-51030fe",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.13-6114564127.commit-51030fe.tgz",
+      "integrity": "sha512-EcIB8qoIRhEJq2sw/17/xQteyBL3m7f8UfUiUtPeZ8gGo10lG6rDwY0eeDsYr/gXefIK+HorksisuZ9XZhaHjA==",
       "requires": {
-        "@dcl/ecs": "7.3.10",
+        "@dcl/ecs": "7.3.13-6114564127.commit-51030fe",
         "@dcl/ecs-math": "2.0.2",
-        "@dcl/explorer": "1.0.139428-20230817134048.commit-4c182e2",
-        "@dcl/js-runtime": "7.3.10",
-        "@dcl/react-ecs": "7.3.10",
-        "@dcl/sdk-commands": "7.3.10"
+        "@dcl/explorer": "1.0.141942-20230828173247.commit-e060db1",
+        "@dcl/js-runtime": "7.3.13-6114564127.commit-51030fe",
+        "@dcl/react-ecs": "7.3.13-6114564127.commit-51030fe",
+        "@dcl/sdk-commands": "7.3.13-6114564127.commit-51030fe"
       }
     },
     "@dcl/sdk-commands": {
-      "version": "7.3.10",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.10.tgz",
-      "integrity": "sha512-ykYzM5VjNY+cBuXIa1btB40zt+7jUpcCf6+95bA8YH5MWziFN9/TniLgeymFU8puyRgPgBMxtwoh+R+BlsGtyg==",
+      "version": "7.3.13-6114564127.commit-51030fe",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.13-6114564127.commit-51030fe.tgz",
+      "integrity": "sha512-J5HdBnIfioKTmko9324o4GtYJjA11Xcftxy3lVpFKcWgtfh6MN9/i7bWGIk2oDdF4w1e568Gtsoxv+KV75xzZw==",
       "requires": {
-        "@dcl/ecs": "7.3.10",
+        "@dcl/crypto": "^3.4.4",
+        "@dcl/ecs": "7.3.13-6114564127.commit-51030fe",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.3.10",
-        "@dcl/linker-dapp": "0.9.1",
+        "@dcl/inspector": "7.3.13-6114564127.commit-51030fe",
+        "@dcl/linker-dapp": "0.10.1",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-5812097343.commit-8025576",
         "@dcl/rpc": "^1.1.1",
@@ -37304,6 +37303,7 @@
         "node-fetch": "^2.6.8",
         "open": "^8.4.0",
         "portfinder": "^1.0.32",
+        "prompts": "^2.4.2",
         "typescript": "^5.0.2",
         "undici": "^5.19.1",
         "uuid": "^9.0.0"
@@ -37368,9 +37368,9 @@
           "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ=="
         },
         "node-fetch": {
-          "version": "2.6.13",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
-          "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
           "requires": {
             "whatwg-url": "^5.0.0"
           }
@@ -37385,15 +37385,24 @@
             "is-wsl": "^2.2.0"
           }
         },
+        "prompts": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+          "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+          "requires": {
+            "kleur": "^3.0.3",
+            "sisteransi": "^1.0.5"
+          }
+        },
         "tr46": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
         "typescript": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-          "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA=="
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
         },
         "uuid": {
           "version": "9.0.0",
@@ -39959,9 +39968,9 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
     },
     "@types/object-hash": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-3.0.3.tgz",
-      "integrity": "sha512-Mb0SDIhjhBAz4/rDNU0cYcQR4lSJIwy+kFlm0whXLkx+o0pXwEszwyrWD6gXWumxVbAS6XZ9gXK82LR+Uk+cKQ=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-3.0.4.tgz",
+      "integrity": "sha512-w4fEy2suq1bepUxHoJRCBHJz0vS5DPAYpSbcgNwOahljxwyJsiKmi8qyes2/TJc+4Avd7fsgP+ZgUuXZjPvdug=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -41809,9 +41818,9 @@
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.6.13",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
-          "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
           "requires": {
             "whatwg-url": "^5.0.0"
           }
@@ -44422,9 +44431,9 @@
       }
     },
     "compress-commons": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.1.tgz",
-      "integrity": "sha512-QLdDLCKNV2dtoTorqgxngQCMA+gWXkM/Nwu7FpeBhk/RdkzimqC3jueb/FDmaZeXh+uby1jkBqE3xArsLBE5wQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
       "requires": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -44775,9 +44784,9 @@
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="
     },
     "crc32-stream": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.2.tgz",
-      "integrity": "sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
       "requires": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
@@ -60868,9 +60877,9 @@
       }
     },
     "ts-proto": {
-      "version": "1.156.7",
-      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.156.7.tgz",
-      "integrity": "sha512-vuSby+Mx0CniXscbHx9ieKCEErGBuie12RmduPA67p27Io5C0gkzlMnyN/j3vKWAJrP/h6+mbAoo6WrlalOt7w==",
+      "version": "1.157.0",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.157.0.tgz",
+      "integrity": "sha512-0f9rvHb+1aLG66UpFHh1QbZ5SMvKqV5EudUerHRF+C47g2wd8ZYXiVrK3VmsmLcNxmMrdi4vWgFNCH6qRg1SrA==",
       "requires": {
         "case-anything": "^2.1.13",
         "protobufjs": "^7.2.4",
@@ -63513,13 +63522,32 @@
       }
     },
     "zip-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.0.tgz",
-      "integrity": "sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
       "requires": {
-        "archiver-utils": "^2.1.0",
-        "compress-commons": "^4.1.0",
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
         "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "archiver-utils": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+          "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+          "requires": {
+            "glob": "^7.2.3",
+            "graceful-fs": "^4.2.0",
+            "lazystream": "^1.0.0",
+            "lodash.defaults": "^4.2.0",
+            "lodash.difference": "^4.5.0",
+            "lodash.flatten": "^4.4.0",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.union": "^4.6.0",
+            "normalize-path": "^3.0.0",
+            "readable-stream": "^3.6.0"
+          }
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@dcl/hashing": "^3.0.4",
     "@dcl/mini-rpc": "^1.0.7",
     "@dcl/schemas": "^9.4.1",
-    "@dcl/sdk": "7.3.10",
+    "@dcl/sdk": "^7.3.13-6114564127.commit-51030fe",
     "@dcl/single-sign-on-client": "^0.0.12",
     "@dcl/ui-env": "^1.2.0",
     "@sentry/react": "^7.64.0",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -33,9 +33,11 @@ const publicPath = path.resolve(__dirname, '../public')
 console.log('Public folder:', publicPath)
 for (const file of files) {
   const source = path.resolve(inspectorAssetsPath, file)
-  const target = path.resolve(publicPath, `inspector-${file}`)
-  console.log(`> Copying ${file} as inspector-${file}...`)
-  fs.copyFileSync(source, target)
+  const isDirectory = fs.statSync(source).isDirectory()
+  const targetFile = isDirectory ? file : `inspector-${file}`
+  const target = path.resolve(publicPath, targetFile)
+  console.log(`> Copying ${file} as ${targetFile}...`)
+  fs.cpSync(source, target, { recursive: true })
 }
 console.log(`> Add "inspector-" prefix to files in inspector-index.html`)
 const htmlPath = path.resolve(publicPath, `inspector-index.html`)

--- a/src/components/InspectorPage/InspectorPage.tsx
+++ b/src/components/InspectorPage/InspectorPage.tsx
@@ -41,6 +41,21 @@ export default class InspectorPage extends React.PureComponent<Props, State> {
       return <SignInRequired />
     }
 
+    let htmlUrl = `${PUBLIC_URL}/inspector-index.html`
+    let binIndexJsUrl = `${PUBLIC_URL}/bin/index.js`
+
+    // use the local @dcl/inspector running on your machine
+    if (process.env.REACT_APP_INSPECTOR_PORT) {
+      htmlUrl = `http://localhost:${process.env.REACT_APP_INSPECTOR_PORT}`
+      binIndexJsUrl = `http://localhost:${process.env.REACT_APP_INSPECTOR_PORT}/bin/index.js`
+    }
+
+    // use the local bin/index.js being watched an served on your machine
+    if (process.env.REACT_APP_BIN_INDEX_JS_DEV_PORT && process.env.REACT_APP_BIN_INDEX_JS_DEV_PATH) {
+      const b64 = btoa(process.env.REACT_APP_BIN_INDEX_JS_DEV_PATH)
+      binIndexJsUrl = `http://localhost:${process.env.REACT_APP_BIN_INDEX_JS_DEV_PORT}/content/contents/b64-${b64}`
+    }
+
     return (
       <div className="InspectorPage">
         {(!this.state.isLoaded || isReloading) && <Loader active />}
@@ -51,11 +66,7 @@ export default class InspectorPage extends React.PureComponent<Props, State> {
               ref={this.refIframe}
               title="inspector"
               id="inspector"
-              src={`${
-                process.env.REACT_APP_INSPECTOR_PORT
-                  ? `http://localhost:${process.env.REACT_APP_INSPECTOR_PORT}`
-                  : `${PUBLIC_URL}/inspector-index.html`
-              }?parent=${window.location.origin}`}
+              src={`${htmlUrl}?dataLayerRpcParentUrl=${window.location.origin}&binIndexJsUrl=${binIndexJsUrl}`}
             />
           </>
         )}

--- a/src/components/InspectorPage/InspectorPage.tsx
+++ b/src/components/InspectorPage/InspectorPage.tsx
@@ -47,7 +47,7 @@ export default class InspectorPage extends React.PureComponent<Props, State> {
     // use the local @dcl/inspector running on your machine
     if (process.env.REACT_APP_INSPECTOR_PORT) {
       htmlUrl = `http://localhost:${process.env.REACT_APP_INSPECTOR_PORT}`
-      binIndexJsUrl = `http://localhost:${process.env.REACT_APP_INSPECTOR_PORT}/bin/index.js`
+      binIndexJsUrl = `${htmlUrl}/bin/index.js`
     }
 
     // use the local bin/index.js being watched an served on your machine

--- a/src/modules/inspector/sagas.ts
+++ b/src/modules/inspector/sagas.ts
@@ -409,7 +409,11 @@ function* getScene() {
 
 function* isContentUploaded(path: string, hash: string) {
   if (assets.has(path)) {
-    return true
+    const currentContent = assets.get(path)!
+    const currentHash: string = yield call(hashV1, currentContent)
+    if (hash === currentHash) {
+      return true
+    }
   }
   try {
     const res: Response = yield call(fetch, `${getContentsStorageUrl(hash)}/exists`, { headers: NO_CACHE_HEADERS })


### PR DESCRIPTION
This PR makes the builder serve the `bin/index.js` file so it does not rely anymore on the builder server. This also makes deployments to land/worlds start working.

I also added a few env vars to setup the env to develop the `@dcl/asset-packs` repo from here.