### PR TITLE
fix: Missing identity causes double sign in

### DIFF
--- a/src/modules/identity/sagas.ts
+++ b/src/modules/identity/sagas.ts
@@ -179,9 +179,12 @@ function* handleConnectWalletSuccess(action: ConnectWalletSuccessAction) {
   const identity: AuthIdentity | null = yield call(getIdentity, address)
 
   // If an identity is found, store it and proceed with the login so the state acknowledges that the user is connected.
+  // If not, proceed with the login in order to retrieve user's signature.
   if (identity) {
     yield put(generateIdentitySuccess(address, identity))
     yield put(loginRequest(providerType, true))
+  } else {
+    yield put(loginRequest(providerType))
   }
 }
 
@@ -193,9 +196,12 @@ function* handleChangeAccount(action: ChangeAccountAction) {
   const identity: AuthIdentity | null = yield call(getIdentity, address)
 
   // If an identity is found, store it and proceed with the login so the state acknowledges that the user is connected.
+  // If not, proceed with the login in order to retrieve user's signature.
   if (identity) {
     yield put(generateIdentitySuccess(address, identity))
     yield put(loginRequest(providerType, true))
+  } else {
+    yield put(loginRequest(providerType))
   }
 
   yield put(clearAssetPacks())


### PR DESCRIPTION
Dispatch the `loginRequest` in order to get the user's signature if the identity is missing.