### PR TITLE
feat: Add NameTabs component

### DIFF
--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/NameTabs/NameTabs.container.ts
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/NameTabs/NameTabs.container.ts
@@ -1,0 +1,12 @@
+import { connect } from 'react-redux'
+import { push } from 'connected-react-router'
+import NameTabs from './NameTabs'
+import { MapDispatch, MapDispatchProps } from './NameTabs.types'
+
+const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => {
+  return {
+    onNavigate: to => dispatch(push(to))
+  }
+}
+
+export default connect(null, mapDispatch)(NameTabs)

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/NameTabs/NameTabs.spec.tsx
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/NameTabs/NameTabs.spec.tsx
@@ -1,0 +1,114 @@
+import { ReactNode } from 'react'
+import { useLocation } from 'react-router'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { Mobile, NotMobile } from 'decentraland-ui/dist/components/Media/Media'
+import NameTabs, { TAB_QUERY_PARAM_KEY } from './NameTabs'
+import { TabType } from './NameTabs.types'
+
+jest.mock('react-router')
+jest.mock('decentraland-ui/dist/components/Media/Media')
+
+const mockUseLocation = useLocation as jest.Mock
+const mockMobile = Mobile as jest.Mock
+const mockNotMobile = NotMobile as jest.Mock
+
+describe('when rendering the name tabs component', () => {
+  let location: Location
+  let onNavigate: jest.Mock
+
+  beforeEach(() => {
+    location = {
+      pathname: '/pathname'
+    } as Location
+
+    mockUseLocation.mockReturnValueOnce(location)
+
+    onNavigate = jest.fn()
+  })
+
+  describe('when the tab param is not found in the location.search property', () => {
+    beforeEach(() => {
+      location.search = '?foo=bar'
+    })
+
+    it('should call the on navigate prop with the current pathname + current query params + the tab query param with dcl as value', () => {
+      render(<NameTabs onNavigate={onNavigate} />)
+      expect(onNavigate).toHaveBeenCalledWith(`${location.pathname}${location.search}&${TAB_QUERY_PARAM_KEY}=${TabType.DCL}`)
+    })
+  })
+
+  describe('when the tab param is found in the location.search property but is not ens or dcl', () => {
+    beforeEach(() => {
+      location.search = `?foo=bar&${TAB_QUERY_PARAM_KEY}=invalid-tab`
+    })
+
+    it('should call the on navigate prop with the current pathname + current query params + the tab query param with dcl as value instead of the invalid value', () => {
+      render(<NameTabs onNavigate={onNavigate} />)
+      expect(onNavigate).toHaveBeenCalledWith(`${location.pathname}?foo=bar&${TAB_QUERY_PARAM_KEY}=${TabType.DCL}`)
+    })
+  })
+
+  describe('when the tab param is found in location.search and is ens or dcl', () => {
+    let dclTabText: string
+    let ensTabText: string
+
+    beforeEach(() => {
+      location.search = `?${TAB_QUERY_PARAM_KEY}=${TabType.ENS}`
+      dclTabText = 'Decentraland names'
+      ensTabText = 'ENS names'
+
+      mockMobile.mockImplementation(({ children }) => children as ReactNode)
+      mockNotMobile.mockImplementation(() => null)
+    })
+
+    it('should render both the ens and dcl tabs name tabs', () => {
+      render(<NameTabs onNavigate={onNavigate} />)
+
+      expect(screen.getByText(dclTabText)).toBeInTheDocument()
+      expect(screen.getByText(ensTabText)).toBeInTheDocument()
+    })
+
+    describe('when the tab param is ens', () => {
+      it('should add the active css class to the ens tab', () => {
+        render(<NameTabs onNavigate={onNavigate} />)
+
+        expect(screen.getByText(ensTabText)).toHaveClass('active')
+        expect(screen.getByText(dclTabText)).not.toHaveClass('active')
+      })
+    })
+
+    describe('when the tab param is dcl', () => {
+      beforeEach(() => {
+        location.search = `?${TAB_QUERY_PARAM_KEY}=${TabType.DCL}`
+      })
+
+      it('should add the active css class to the dcl tab', () => {
+        render(<NameTabs onNavigate={onNavigate} />)
+
+        expect(screen.getByText(ensTabText)).not.toHaveClass('active')
+        expect(screen.getByText(dclTabText)).toHaveClass('active')
+      })
+    })
+
+    describe('when the dcl tab is clicked', () => {
+      it('should call the on navigate prop with the current pathname + the tab query param with dcl as value', () => {
+        render(<NameTabs onNavigate={onNavigate} />)
+
+        screen.getByText(dclTabText).click()
+
+        expect(onNavigate).toHaveBeenCalledWith(`${location.pathname}?${TAB_QUERY_PARAM_KEY}=${TabType.DCL}`)
+      })
+    })
+
+    describe('when the ens tab is clicked', () => {
+      it('should call the on navigate prop with the current pathname + the tab query param with ens as value', () => {
+        render(<NameTabs onNavigate={onNavigate} />)
+
+        screen.getByText(ensTabText).click()
+
+        expect(onNavigate).toHaveBeenCalledWith(`${location.pathname}?${TAB_QUERY_PARAM_KEY}=${TabType.ENS}`)
+      })
+    })
+  })
+})

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/NameTabs/NameTabs.tsx
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/NameTabs/NameTabs.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { useLocation } from 'react-router'
-import { Tabs } from 'decentraland-ui'
+import { Tabs } from 'decentraland-ui/dist/components/Tabs/Tabs'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Props, TabType } from './NameTabs.types'
 
-const TAB_QUERY_PARAM_KEY = 'tab'
+export const TAB_QUERY_PARAM_KEY = 'tab'
 
 const NameTabs = ({ onNavigate }: Props) => {
   const location = useLocation()

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/NameTabs/NameTabs.tsx
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/NameTabs/NameTabs.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { useLocation } from 'react-router'
+import { Tabs } from 'decentraland-ui'
+import { t } from 'decentraland-dapps/dist/modules/translation/utils'
+import { Props, TabType } from './NameTabs.types'
+
+const TAB_QUERY_PARAM_KEY = 'tab'
+
+const NameTabs = ({ onNavigate }: Props) => {
+  const location = useLocation()
+
+  const urlSearchParams = new URLSearchParams(location.search)
+  const tab = urlSearchParams.get(TAB_QUERY_PARAM_KEY)
+
+  const navigateToTab = (tab: TabType) => {
+    urlSearchParams.set(TAB_QUERY_PARAM_KEY, tab)
+    onNavigate(`${location.pathname}?${urlSearchParams.toString()}`)
+  }
+
+  if (tab !== TabType.DCL && tab !== TabType.ENS) {
+    navigateToTab(TabType.DCL)
+    return null
+  }
+
+  return (
+    <Tabs>
+      <Tabs.Tab active={tab === TabType.DCL} onClick={() => navigateToTab(TabType.DCL)}>
+        {t('worlds_list_page.name_tabs.dcl_names')}
+      </Tabs.Tab>
+      <Tabs.Tab active={tab === TabType.ENS} onClick={() => navigateToTab(TabType.ENS)}>
+        {t('worlds_list_page.name_tabs.ens_names')}
+      </Tabs.Tab>
+    </Tabs>
+  )
+}
+
+export default React.memo(NameTabs)

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/NameTabs/NameTabs.types.ts
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/NameTabs/NameTabs.types.ts
@@ -1,0 +1,14 @@
+import { CallHistoryMethodAction } from 'connected-react-router'
+import { Dispatch } from 'react'
+
+export enum TabType {
+  DCL = 'dcl',
+  ENS = 'ens'
+}
+
+export type Props = {
+  onNavigate: (to: string) => void
+}
+
+export type MapDispatchProps = Pick<Props, 'onNavigate'>
+export type MapDispatch = Dispatch<CallHistoryMethodAction>

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/NameTabs/index.ts
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/NameTabs/index.ts
@@ -1,0 +1,2 @@
+import NameTabs from './NameTabs.container'
+export default NameTabs

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldListPage.tsx
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldListPage.tsx
@@ -23,6 +23,7 @@ import Icon from 'components/Icon'
 import LoggedInDetailPage from 'components/LoggedInDetailPage'
 import { NavigationTab } from 'components/Navigation/Navigation.types'
 import { Props, SortBy } from './WorldListPage.types'
+import NameTabs from './NameTabs'
 import './WorldListPage.css'
 
 const EXPLORER_URL = config.get('EXPLORER_URL', '')
@@ -239,6 +240,8 @@ const WorldListPage: React.FC<Props> = props => {
       isLoading={isLoading}
       isPageFullscreen={true}
     >
+      <h1>Worlds</h1>
+      <NameTabs />
       {ensList.length > 0 ? renderEnsList() : renderEmptyPage()}
     </LoggedInDetailPage>
   )

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -607,6 +607,10 @@
       "title": "Get a free World when you own a NAME",
       "description": "Each NAME grants you access to one World, <b>your own 3D space in the metaverse</b> where you can shape the space however you like and invite up to 100 people to visit.",
       "cta": "Claim Name"
+    },
+    "name_tabs": {
+      "dcl_names": "Decentraland names",
+      "ens_names": "ENS names"
     }
   },
   "error_page": {

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -609,6 +609,10 @@
       "title": "Obtenga un mundo gratis cuando tenga un nombre",
       "description": "Cada nombre le otorga acceso a un Mundo, <b>su espacio 3D personal en el metaverso</b> donde le puede dar forma como quiera e invitar hasta 100 personas a visitar su espacio.",
       "cta": "Reclamar un nuevo Nombre"
+    },
+    "name_tabs": {
+      "dcl_names": "Nombres de Decentraland",
+      "ens_names": "Nombre de ENS"
     }
   },
   "error_page": {

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -611,6 +611,10 @@
       "title": "当您拥有一个名字时获得一个自由的世界",
       "description": "每个名称都授予您访问一个世界的权限，<b>您自己在 metaverse 中的 3D 空间</b>，您可以在其中随心所欲地塑造空间并邀请多达 100 人参观。",
       "cta": "索赔名称"
+    },
+    "name_tabs": {
+      "dcl_names": "Decentraland 名称",
+      "ens_names": "ENS 名称"
     }
   },
   "estate_editor": {


### PR DESCRIPTION
- Integrates it inside WorldListPage just to check it out. The page will be completely overhauled.
- The selected tab depends on the `tab` query param
- Defaults to dcl tab query param if the provided one is invalid

Closes #2910 

<img width="739" alt="image" src="https://github.com/decentraland/builder/assets/24811313/aa70fae9-fd51-4b11-83c3-4868c4454709">

<img width="814" alt="image" src="https://github.com/decentraland/builder/assets/24811313/5cefeec1-3f33-4528-b804-b641b7018f39">

Based but not exact to figma given that it is not the final design.

<img width="719" alt="image" src="https://github.com/decentraland/builder/assets/24811313/2f58360f-930a-4090-b78e-476d7a2c700e">
