### PR TITLE
feat: Worlds Storage component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "apollo-link-http": "^1.5.17",
         "blob-to-buffer": "^1.2.9",
         "cids": "^0.7.2",
+        "classnames": "^2.3.2",
         "connected-react-router": "^6.9.2",
         "date-fns": "^2.28.0",
         "dcl-catalyst-client": "^21.5.5",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "apollo-link-http": "^1.5.17",
     "blob-to-buffer": "^1.2.9",
     "cids": "^0.7.2",
+    "classnames": "^2.3.2",
     "connected-react-router": "^6.9.2",
     "date-fns": "^2.28.0",
     "dcl-catalyst-client": "^21.5.5",

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldListPage.tsx
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldListPage.tsx
@@ -24,8 +24,8 @@ import LoggedInDetailPage from 'components/LoggedInDetailPage'
 import { NavigationTab } from 'components/Navigation/Navigation.types'
 import { Props, SortBy } from './WorldListPage.types'
 import NameTabs from './NameTabs'
+import WorldsStorage from './WorldsStorage'
 import './WorldListPage.css'
-import WorldsStorage from './WorldsStorage/WorldsStorage'
 
 const EXPLORER_URL = config.get('EXPLORER_URL', '')
 const WORLDS_CONTENT_SERVER_URL = config.get('WORLDS_CONTENT_SERVER', '')

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldListPage.tsx
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldListPage.tsx
@@ -25,6 +25,7 @@ import { NavigationTab } from 'components/Navigation/Navigation.types'
 import { Props, SortBy } from './WorldListPage.types'
 import NameTabs from './NameTabs'
 import './WorldListPage.css'
+import WorldsStorage from './WorldsStorage/WorldsStorage'
 
 const EXPLORER_URL = config.get('EXPLORER_URL', '')
 const WORLDS_CONTENT_SERVER_URL = config.get('WORLDS_CONTENT_SERVER', '')
@@ -240,8 +241,19 @@ const WorldListPage: React.FC<Props> = props => {
       isLoading={isLoading}
       isPageFullscreen={true}
     >
-      <h1>Worlds</h1>
-      <NameTabs />
+      {/** The following elements are just for show until the feature is complete, disregard the layout, just preview the components */}
+      <Container>
+        <h1>Worlds</h1>
+        <NameTabs />
+        <div
+          style={{
+            marginBottom: '1rem'
+          }}
+        >
+          <WorldsStorage maxBytes="100000000" currentBytes="75000000" />
+        </div>
+      </Container>
+      {/** Old ens list which will be removed or replaced with the new worlds for ens owners feature */}
       {ensList.length > 0 ? renderEnsList() : renderEmptyPage()}
     </LoggedInDetailPage>
   )

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldListPage.tsx
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldListPage.tsx
@@ -250,7 +250,7 @@ const WorldListPage: React.FC<Props> = props => {
             marginBottom: '1rem'
           }}
         >
-          <WorldsStorage maxBytes="100000000" currentBytes="75000000" />
+          <WorldsStorage maxBytes={100000000} currentBytes={75000000} />
         </div>
       </Container>
       {/** Old ens list which will be removed or replaced with the new worlds for ens owners feature */}

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.module.css
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.module.css
@@ -14,28 +14,13 @@
   font-size: 1.5rem;
 }
 
-.barContainer {
-  position: relative;
-  width: 100%;
-  height: 10px;
-  margin-bottom: 1rem;
-}
-
 .bar {
-  position: absolute;
-  height: 10px;
-  border-radius: 200px;
+  margin-bottom: 1rem !important;
+  background-color: #a09ba8 !important;
 }
 
-.barBehind {
-  background-color: #a09ba8;
-  width: 100%;
-}
-
-.barFront {
-  position: absolute;
+.bar:global(.ui.progress .bar) {
   background-color: #ff2d55;
-  width: 0px;
 }
 
 .viewDetails {

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.module.css
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.module.css
@@ -1,0 +1,45 @@
+.worldsStorage {
+  background-color: var(--dark-two);
+  border-radius: 10px;
+  padding: 22px;
+}
+
+.spaceContainer {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.currentMbs {
+  font-size: 1.5rem;
+}
+
+.barContainer {
+  position: relative;
+  width: 100%;
+  height: 10px;
+  margin-bottom: 1rem;
+}
+
+.bar {
+  position: absolute;
+  height: 10px;
+  border-radius: 200px;
+}
+
+.barBehind {
+  background-color: #a09ba8;
+  width: 100%;
+}
+
+.barFront {
+  position: absolute;
+  background-color: #ff2d55;
+  width: 0px;
+}
+
+.viewDetails {
+  text-align: right;
+  cursor: pointer;
+  text-decoration: underline;
+}

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.spec.tsx
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import WorldsStorage, { BAR_FRONT_TEST_ID, CURRENT_MBS_TEST_ID } from './WorldsStorage'
+import WorldsStorage, { CURRENT_MBS_TEST_ID, PROGRESS_TEST_ID } from './WorldsStorage'
 
 describe('when rendering the worlds storage component', () => {
   describe('when the provided current bytes is 50550000 and the max bytes is 100000000', () => {
@@ -12,7 +12,7 @@ describe('when rendering the worlds storage component', () => {
     })
 
     it('should render the storage front bar with 50%', () => {
-      expect(screen.getByTestId(BAR_FRONT_TEST_ID).style.width).toEqual('50%')
+      expect(screen.getByTestId(PROGRESS_TEST_ID).children[0].getAttribute('style')).toEqual('width: 50%;')
     })
   })
 })

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.spec.tsx
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.spec.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react'
+import WorldsStorage, { BAR_FRONT_TEST_ID, CURRENT_MBS_TEST_ID } from './WorldsStorage'
+
+describe('when rendering the worlds storage component', () => {
+  describe('when the provided current bytes is 75000000 and the max bytes is 100000000', () => {
+    beforeEach(() => {
+      render(<WorldsStorage currentBytes="75000000" maxBytes="100000000" />)
+    })
+
+    it('should render 75/100mb', () => {
+      expect(screen.getByTestId(CURRENT_MBS_TEST_ID).textContent).toEqual('75 / 100 mb')
+    })
+
+    it('should render the storage front bar with 75%', () => {
+      expect(screen.getByTestId(BAR_FRONT_TEST_ID).style.width).toEqual('75%')
+    })
+  })
+})

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.spec.tsx
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.spec.tsx
@@ -2,17 +2,17 @@ import { render, screen } from '@testing-library/react'
 import WorldsStorage, { BAR_FRONT_TEST_ID, CURRENT_MBS_TEST_ID } from './WorldsStorage'
 
 describe('when rendering the worlds storage component', () => {
-  describe('when the provided current bytes is 75000000 and the max bytes is 100000000', () => {
+  describe('when the provided current bytes is 50550000 and the max bytes is 100000000', () => {
     beforeEach(() => {
-      render(<WorldsStorage currentBytes="75000000" maxBytes="100000000" />)
+      render(<WorldsStorage currentBytes={50550000} maxBytes={100000000} />)
     })
 
-    it('should render 75/100mb', () => {
-      expect(screen.getByTestId(CURRENT_MBS_TEST_ID).textContent).toEqual('75 / 100 mb')
+    it('should render 50.55/100.00mb', () => {
+      expect(screen.getByTestId(CURRENT_MBS_TEST_ID).textContent).toEqual('50.55 / 100.00 mb')
     })
 
-    it('should render the storage front bar with 75%', () => {
-      expect(screen.getByTestId(BAR_FRONT_TEST_ID).style.width).toEqual('75%')
+    it('should render the storage front bar with 50%', () => {
+      expect(screen.getByTestId(BAR_FRONT_TEST_ID).style.width).toEqual('50%')
     })
   })
 })

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.tsx
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { Props } from './WorldsStorage.types'
+import styles from './WorldsStorage.module.css'
+import classNames from 'classnames'
+
+const WorldsStorage = ({ maxBytes, currentBytes: currentBytes }: Props) => {
+  const maxMbs = BigInt(maxBytes) / BigInt(1000000)
+  const currentMbs = BigInt(currentBytes) / BigInt(1000000)
+  const usedPercentage = (currentMbs * BigInt(100)) / maxMbs
+
+  return (
+    <div className={styles.worldsStorage}>
+      <div className={styles.spaceContainer}>
+        <span>Space used</span>
+        <div>
+          <span className={styles.currentMbs}>{currentMbs.toString()}</span> / {maxMbs.toString()} mb
+        </div>
+      </div>
+      <div className={styles.barContainer}>
+        <div className={classNames(styles.bar, styles.barBehind)} />
+        <div
+          style={{
+            width: `${usedPercentage}%`
+          }}
+          className={classNames(styles.bar, styles.barFront)}
+        />
+      </div>
+      <div className={styles.viewDetails}>view details</div>
+    </div>
+  )
+}
+
+export default React.memo(WorldsStorage)

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.tsx
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.tsx
@@ -4,6 +4,9 @@ import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Props } from './WorldsStorage.types'
 import styles from './WorldsStorage.module.css'
 
+export const CURRENT_MBS_TEST_ID = 'worlds-storage-current-mbs'
+export const BAR_FRONT_TEST_ID = 'worlds-storage-bar-front'
+
 const WorldsStorage = ({ maxBytes, currentBytes }: Props) => {
   const maxMbs = Number(BigInt(maxBytes) / BigInt(1000000))
   const currentMbs = Number(BigInt(currentBytes) / BigInt(1000000))
@@ -13,13 +16,14 @@ const WorldsStorage = ({ maxBytes, currentBytes }: Props) => {
     <div className={styles.worldsStorage}>
       <div className={styles.spaceContainer}>
         <span>{t('worlds_list_page.worlds_storage.space_used')}</span>
-        <div>
+        <div data-testid={CURRENT_MBS_TEST_ID}>
           <span className={styles.currentMbs}>{currentMbs}</span> / {maxMbs} mb
         </div>
       </div>
       <div className={styles.barContainer}>
         <div className={classNames(styles.bar, styles.barBehind)} />
         <div
+          data-testid={BAR_FRONT_TEST_ID}
           style={{
             width: `${usedPercentage}%`
           }}

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.tsx
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import classNames from 'classnames'
+import { Progress } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Props } from './WorldsStorage.types'
 import styles from './WorldsStorage.module.css'
 
 export const CURRENT_MBS_TEST_ID = 'worlds-storage-current-mbs'
-export const BAR_FRONT_TEST_ID = 'worlds-storage-bar-front'
+export const PROGRESS_TEST_ID = 'worlds-storage-bar-front'
 
 const WorldsStorage = ({ maxBytes, currentBytes }: Props) => {
   const maxMbs = maxBytes / 1000000
@@ -20,16 +20,7 @@ const WorldsStorage = ({ maxBytes, currentBytes }: Props) => {
           <span className={styles.currentMbs}>{currentMbs.toFixed(2)}</span> / {maxMbs.toFixed(2)} mb
         </div>
       </div>
-      <div className={styles.barContainer}>
-        <div className={classNames(styles.bar, styles.barBehind)} />
-        <div
-          data-testid={BAR_FRONT_TEST_ID}
-          style={{
-            width: `${Math.trunc(usedPercentage)}%`
-          }}
-          className={classNames(styles.bar, styles.barFront)}
-        />
-      </div>
+      <Progress data-testid={PROGRESS_TEST_ID} percent={Math.trunc(usedPercentage)} className={styles.bar} size="small" />
       <div className={styles.viewDetails}>{t('worlds_list_page.worlds_storage.view_details')}</div>
     </div>
   )

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.tsx
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.tsx
@@ -8,8 +8,8 @@ export const CURRENT_MBS_TEST_ID = 'worlds-storage-current-mbs'
 export const BAR_FRONT_TEST_ID = 'worlds-storage-bar-front'
 
 const WorldsStorage = ({ maxBytes, currentBytes }: Props) => {
-  const maxMbs = Number(BigInt(maxBytes) / BigInt(1000000))
-  const currentMbs = Number(BigInt(currentBytes) / BigInt(1000000))
+  const maxMbs = maxBytes / 1000000
+  const currentMbs = currentBytes / 1000000
   const usedPercentage = (currentMbs * 100) / maxMbs
 
   return (
@@ -25,7 +25,7 @@ const WorldsStorage = ({ maxBytes, currentBytes }: Props) => {
         <div
           data-testid={BAR_FRONT_TEST_ID}
           style={{
-            width: `${usedPercentage}%`
+            width: `${Math.trunc(usedPercentage)}%`
           }}
           className={classNames(styles.bar, styles.barFront)}
         />

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.tsx
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.tsx
@@ -3,7 +3,7 @@ import { Props } from './WorldsStorage.types'
 import styles from './WorldsStorage.module.css'
 import classNames from 'classnames'
 
-const WorldsStorage = ({ maxBytes, currentBytes: currentBytes }: Props) => {
+const WorldsStorage = ({ maxBytes, currentBytes }: Props) => {
   const maxMbs = BigInt(maxBytes) / BigInt(1000000)
   const currentMbs = BigInt(currentBytes) / BigInt(1000000)
   const usedPercentage = (currentMbs * BigInt(100)) / maxMbs

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.tsx
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.tsx
@@ -1,19 +1,20 @@
 import React from 'react'
+import classNames from 'classnames'
+import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Props } from './WorldsStorage.types'
 import styles from './WorldsStorage.module.css'
-import classNames from 'classnames'
 
 const WorldsStorage = ({ maxBytes, currentBytes }: Props) => {
-  const maxMbs = BigInt(maxBytes) / BigInt(1000000)
-  const currentMbs = BigInt(currentBytes) / BigInt(1000000)
-  const usedPercentage = (currentMbs * BigInt(100)) / maxMbs
+  const maxMbs = Number(BigInt(maxBytes) / BigInt(1000000))
+  const currentMbs = Number(BigInt(currentBytes) / BigInt(1000000))
+  const usedPercentage = (currentMbs * 100) / maxMbs
 
   return (
     <div className={styles.worldsStorage}>
       <div className={styles.spaceContainer}>
-        <span>Space used</span>
+        <span>{t('worlds_list_page.worlds_storage.space_used')}</span>
         <div>
-          <span className={styles.currentMbs}>{currentMbs.toString()}</span> / {maxMbs.toString()} mb
+          <span className={styles.currentMbs}>{currentMbs}</span> / {maxMbs} mb
         </div>
       </div>
       <div className={styles.barContainer}>
@@ -25,7 +26,7 @@ const WorldsStorage = ({ maxBytes, currentBytes }: Props) => {
           className={classNames(styles.bar, styles.barFront)}
         />
       </div>
-      <div className={styles.viewDetails}>view details</div>
+      <div className={styles.viewDetails}>{t('worlds_list_page.worlds_storage.view_details')}</div>
     </div>
   )
 }

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.tsx
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.tsx
@@ -17,7 +17,7 @@ const WorldsStorage = ({ maxBytes, currentBytes }: Props) => {
       <div className={styles.spaceContainer}>
         <span>{t('worlds_list_page.worlds_storage.space_used')}</span>
         <div data-testid={CURRENT_MBS_TEST_ID}>
-          <span className={styles.currentMbs}>{currentMbs}</span> / {maxMbs} mb
+          <span className={styles.currentMbs}>{currentMbs.toFixed(2)}</span> / {maxMbs.toFixed(2)} mb
         </div>
       </div>
       <div className={styles.barContainer}>

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.types.ts
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.types.ts
@@ -1,4 +1,4 @@
 export type Props = {
-  maxBytes: string
-  currentBytes: string
+  maxBytes: number
+  currentBytes: number
 }

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.types.ts
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/WorldsStorage.types.ts
@@ -1,0 +1,4 @@
+export type Props = {
+  maxBytes: string
+  currentBytes: string
+}

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/index.ts
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldsStorage/index.ts
@@ -1,0 +1,2 @@
+import WorldStorage from './WorldsStorage'
+export default WorldStorage

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -611,6 +611,10 @@
     "name_tabs": {
       "dcl_names": "Decentraland names",
       "ens_names": "ENS names"
+    },
+    "worlds_storage": {
+      "space_used": "Space used",
+      "view_details": "view details"
     }
   },
   "error_page": {

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -613,6 +613,10 @@
     "name_tabs": {
       "dcl_names": "Nombres de Decentraland",
       "ens_names": "Nombre de ENS"
+    },
+    "worlds_storage": {
+      "space_used": "Espacio utilizado",
+      "view_details": "ver detalles"
     }
   },
   "error_page": {

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -615,6 +615,10 @@
     "name_tabs": {
       "dcl_names": "Decentraland 名称",
       "ens_names": "ENS 名称"
+    },
+    "worlds_storage": {
+      "space_used": "使用空间",
+      "view_details": "查看详情"
     }
   },
   "estate_editor": {


### PR DESCRIPTION
Displays how much storage left the user has for world deployments.

This is just a preview, the component can be later placed anywhere in the layout.

<img width="1454" alt="image" src="https://github.com/decentraland/builder/assets/24811313/41ea5f7c-dad8-41d3-99b3-1cd79b8ccc2d">


