### PR TITLE
feat: Show real data in worlds storage component

### DIFF
--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldListPage.container.ts
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldListPage.container.ts
@@ -10,6 +10,8 @@ import { FETCH_LANDS_REQUEST } from 'modules/land/actions'
 import { getLoading as getLandsLoading } from 'modules/land/selectors'
 import { isLoggingIn, isLoggedIn } from 'modules/identity/selectors'
 import { getProjects } from 'modules/ui/dashboard/selectors'
+import { fetchWorldsWalletStatsRequest } from 'modules/worlds/actions'
+import { getConnectedWalletStats, getLoading as getLoadingWorlds } from 'modules/worlds/selectors'
 import { MapStateProps, MapDispatchProps, MapDispatch } from './WorldListPage.types'
 import WorldListPage from './WorldListPage'
 
@@ -22,12 +24,15 @@ const mapState = (state: RootState): MapStateProps => ({
     isLoadingType(getLoading(state), FETCH_ENS_LIST_REQUEST) ||
     isLoadingType(getDeploymentsLoading(state), FETCH_WORLD_DEPLOYMENTS_REQUEST) ||
     isLoadingType(getLandsLoading(state), FETCH_LANDS_REQUEST) ||
+    isLoadingType(getLoadingWorlds(state), FETCH_WORLD_DEPLOYMENTS_REQUEST) ||
     isLoggingIn(state),
-  isLoggedIn: isLoggedIn(state)
+  isLoggedIn: isLoggedIn(state),
+  worldsWalletStats: getConnectedWalletStats(state)
 })
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
-  onNavigate: path => dispatch(push(path))
+  onNavigate: path => dispatch(push(path)),
+  onFetchWorldsWalletStats: () => dispatch(fetchWorldsWalletStatsRequest())
 })
 
 export default connect(mapState, mapDispatch)(WorldListPage)

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldListPage.tsx
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldListPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import {
   Button,
@@ -32,7 +32,7 @@ const WORLDS_CONTENT_SERVER_URL = config.get('WORLDS_CONTENT_SERVER', '')
 const PAGE_SIZE = 12
 
 const WorldListPage: React.FC<Props> = props => {
-  const { ensList, error, deploymentsByWorlds, isLoading, projects, onNavigate } = props
+  const { ensList, error, deploymentsByWorlds, isLoading, projects, worldsWalletStats, onNavigate, onFetchWorldsWalletStats } = props
   const [sortBy, setSortBy] = useState(SortBy.ASC)
   const [page, setPage] = useState(1)
 
@@ -233,6 +233,10 @@ const WorldListPage: React.FC<Props> = props => {
     )
   }
 
+  useEffect(() => {
+    onFetchWorldsWalletStats()
+  }, [onFetchWorldsWalletStats])
+
   return (
     <LoggedInDetailPage
       className="WorldListPage view"
@@ -250,7 +254,9 @@ const WorldListPage: React.FC<Props> = props => {
             marginBottom: '1rem'
           }}
         >
-          <WorldsStorage maxBytes={100000000} currentBytes={75000000} />
+          {worldsWalletStats ? (
+            <WorldsStorage maxBytes={Number(worldsWalletStats.maxAllowedSpace)} currentBytes={Number(worldsWalletStats.usedSpace)} />
+          ) : null}
         </div>
       </Container>
       {/** Old ens list which will be removed or replaced with the new worlds for ens owners feature */}

--- a/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldListPage.types.ts
+++ b/src/components/WorldListPage_WorldsForEnsOwnersFeature/WorldListPage.types.ts
@@ -2,6 +2,7 @@ import { Dispatch } from 'redux'
 import { Deployment } from 'modules/deployment/types'
 import { ENS } from 'modules/ens/types'
 import { Project } from 'modules/project/types'
+import { WorldsWalletStats } from 'lib/api/worlds'
 
 export enum SortBy {
   DESC = 'DESC',
@@ -15,7 +16,9 @@ export type Props = {
   projects: Project[]
   isLoggedIn: boolean
   isLoading: boolean
+  worldsWalletStats?: WorldsWalletStats
   onNavigate: (path: string) => void
+  onFetchWorldsWalletStats: () => void
 }
 
 export type State = {
@@ -23,6 +26,9 @@ export type State = {
   sortBy: SortBy
 }
 
-export type MapStateProps = Pick<Props, 'ensList' | 'deploymentsByWorlds' | 'isLoading' | 'error' | 'projects' | 'isLoggedIn'>
-export type MapDispatchProps = Pick<Props, 'onNavigate'>
+export type MapStateProps = Pick<
+  Props,
+  'ensList' | 'deploymentsByWorlds' | 'isLoading' | 'error' | 'projects' | 'isLoggedIn' | 'worldsWalletStats'
+>
+export type MapDispatchProps = Pick<Props, 'onNavigate' | 'onFetchWorldsWalletStats'>
 export type MapDispatch = Dispatch

--- a/src/modules/common/sagas.ts
+++ b/src/modules/common/sagas.ts
@@ -46,6 +46,7 @@ import { collectionCurationSaga } from 'modules/curations/collectionCuration/sag
 import { getPeerWithNoGBCollectorURL } from './utils'
 import { itemCurationSaga } from 'modules/curations/itemCuration/sagas'
 import { inspectorSaga } from 'modules/inspector/sagas'
+import { worldsSaga } from 'modules/worlds/sagas'
 import { RootStore } from './types'
 
 const profileSaga = createProfileSaga({ peerUrl: PEER_URL, peerWithNoGbCollectorUrl: getPeerWithNoGBCollectorURL() })
@@ -95,6 +96,7 @@ export function* rootSaga(
     featuresSaga({ polling: { apps: [ApplicationName.BUILDER], delay: 60000 /** 60 seconds */ } }),
     inspectorSaga(builderAPI, store),
     loginSaga(),
-    newsletterSagas(builderAPI)
+    newsletterSagas(builderAPI),
+    worldsSaga()
   ])
 }

--- a/src/modules/worlds/actions.spec.ts
+++ b/src/modules/worlds/actions.spec.ts
@@ -57,7 +57,7 @@ describe('when creating the failure action to fetch worlds stats for a wallet', 
   })
 
   it('should return the failure action to fetch worlds stats for a wallet', () => {
-    expect(fetchWorldsWalletStatsFailure(address, error)).toEqual({
+    expect(fetchWorldsWalletStatsFailure(error, address)).toEqual({
       type: FETCH_WORLDS_WALLET_STATS_FAILURE,
       payload: {
         address,

--- a/src/modules/worlds/actions.ts
+++ b/src/modules/worlds/actions.ts
@@ -6,10 +6,10 @@ export const FETCH_WORLDS_WALLET_STATS_REQUEST = '[Request] Fetch Worlds Wallet 
 export const FETCH_WORLDS_WALLET_STATS_SUCCESS = '[Success] Fetch Worlds Wallet Stats'
 export const FETCH_WORLDS_WALLET_STATS_FAILURE = '[Failure] Fetch Worlds Wallet Stats'
 
-export const fetchWorldsWalletStatsRequest = (address: string) => action(FETCH_WORLDS_WALLET_STATS_REQUEST, { address })
+export const fetchWorldsWalletStatsRequest = (address?: string) => action(FETCH_WORLDS_WALLET_STATS_REQUEST, { address })
 export const fetchWorldsWalletStatsSuccess = (address: string, stats: WorldsWalletStats) =>
   action(FETCH_WORLDS_WALLET_STATS_SUCCESS, { address, stats })
-export const fetchWorldsWalletStatsFailure = (address: string, error: string) =>
+export const fetchWorldsWalletStatsFailure = (error: string, address?: string) =>
   action(FETCH_WORLDS_WALLET_STATS_FAILURE, { address, error })
 
 export type FetchWalletWorldsStatsRequestAction = ReturnType<typeof fetchWorldsWalletStatsRequest>

--- a/src/modules/worlds/reducer.spec.ts
+++ b/src/modules/worlds/reducer.spec.ts
@@ -40,7 +40,7 @@ describe('when handling the action to fetch worlds stats for a wallet', () => {
     })
 
     it('should remove the action from loading and set the error', () => {
-      const action = fetchWorldsWalletStatsFailure(address, error)
+      const action = fetchWorldsWalletStatsFailure(error, address)
 
       expect(worldsReducer(state, action)).toEqual({
         ...state,

--- a/src/modules/worlds/reducer.ts
+++ b/src/modules/worlds/reducer.ts
@@ -11,7 +11,7 @@ import { WorldsWalletStats } from 'lib/api/worlds'
 
 export type WorldsState = {
   // TODO: Find a use for the data object when there is something more relevant as the core data for the worlds module.
-  data: Record<string, any>
+  data: Record<string, unknown>
   walletStats: Record<string, WorldsWalletStats>
   loading: LoadingState
   error: string | null

--- a/src/modules/worlds/sagas.spec.ts
+++ b/src/modules/worlds/sagas.spec.ts
@@ -106,7 +106,7 @@ describe('when handling the request action to fetch worlds stats for a wallet', 
     })
 
     describe('and there is no address available in the store', () => {
-      let connectProvider: any
+      let connectProvide: any
       let connectionAddress: string
 
       beforeEach(() => {
@@ -115,12 +115,12 @@ describe('when handling the request action to fetch worlds stats for a wallet', 
 
       describe('and the wallet connection fails', () => {
         beforeEach(() => {
-          connectProvider = [take(CONNECT_WALLET_FAILURE), connectWalletFailure('some error')]
+          connectProvide = [take(CONNECT_WALLET_FAILURE), connectWalletFailure('some error')]
         })
 
         it('should put a failure action with an undefined address and the error message', () => {
           return expectSaga(worldsSaga)
-            .provide([[select(getAddress), addressInStore], connectProvider])
+            .provide([[select(getAddress), addressInStore], connectProvide])
             .put(fetchWorldsWalletStatsFailure('An address is required', addressInStore))
             .dispatch(fetchWorldsWalletStatsRequest(address))
             .silentRun()
@@ -130,7 +130,7 @@ describe('when handling the request action to fetch worlds stats for a wallet', 
       describe('and the wallet connection does not fail', () => {
         beforeEach(() => {
           connectionAddress = '0x123'
-          connectProvider = [take(CONNECT_WALLET_SUCCESS), connectWalletSuccess({ address: connectionAddress } as Wallet)]
+          connectProvide = [take(CONNECT_WALLET_SUCCESS), connectWalletSuccess({ address: connectionAddress } as Wallet)]
         })
 
         describe('and the request to fetch wallet stats responds with the worlds wallet stats', () => {
@@ -148,7 +148,7 @@ describe('when handling the request action to fetch worlds stats for a wallet', 
             return expectSaga(worldsSaga)
               .provide([
                 [select(getAddress), addressInStore],
-                connectProvider,
+                connectProvide,
                 [call([content, content.fetchWalletStats], connectionAddress), stats]
               ])
               .put(fetchWorldsWalletStatsSuccess(connectionAddress, stats))

--- a/src/modules/worlds/sagas.spec.ts
+++ b/src/modules/worlds/sagas.spec.ts
@@ -1,62 +1,115 @@
 import { expectSaga } from 'redux-saga-test-plan'
-import { worldsSaga } from './sagas'
-import { call } from 'redux-saga/effects'
+import { call, select } from 'redux-saga/effects'
+import { throwError } from 'redux-saga-test-plan/providers'
+import { getAddress } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import { WorldsWalletStats, content } from 'lib/api/worlds'
 import { fetchWorldsWalletStatsFailure, fetchWorldsWalletStatsRequest, fetchWorldsWalletStatsSuccess } from './actions'
-import { throwError } from 'redux-saga-test-plan/providers'
+import { worldsSaga } from './sagas'
 
 describe('when handling the request action to fetch worlds stats for a wallet', () => {
-  let address: string
+  let address: string | undefined
+  let stats: WorldsWalletStats
 
-  beforeEach(() => {
-    address = '0x123'
+  describe('when the address is provided in the action', () => {
+    beforeEach(() => {
+      address = '0x123'
+    })
+
+    describe('when the worlds api request throws an error', () => {
+      let error: Error
+
+      beforeEach(() => {
+        error = new Error('some error')
+      })
+
+      it('should put the failure action with the request action address and the error message', () => {
+        return expectSaga(worldsSaga)
+          .provide([[call([content, content.fetchWalletStats], address!), throwError(error)]])
+          .put(fetchWorldsWalletStatsFailure(error.message, address))
+          .dispatch(fetchWorldsWalletStatsRequest(address))
+          .silentRun()
+      })
+    })
+
+    describe('when the worlds api request returns null', () => {
+      it('should put the failure action with the request action address and the error message', () => {
+        return expectSaga(worldsSaga)
+          .provide([[call([content, content.fetchWalletStats], address!), null]])
+          .put(fetchWorldsWalletStatsFailure('Could not fetch wallet stats', address))
+          .dispatch(fetchWorldsWalletStatsRequest(address))
+          .silentRun()
+      })
+    })
+
+    describe('when the worlds api request returns the stats', () => {
+      beforeEach(() => {
+        stats = {
+          dclNames: [],
+          ensNames: [],
+          maxAllowedSpace: '',
+          usedSpace: '',
+          wallet: address!
+        }
+      })
+
+      it('should put the success action with the request action address and the stats', () => {
+        return expectSaga(worldsSaga)
+          .provide([[call([content, content.fetchWalletStats], address!), stats]])
+          .put(fetchWorldsWalletStatsSuccess(address!, stats))
+          .dispatch(fetchWorldsWalletStatsRequest(address))
+          .silentRun()
+      })
+    })
   })
 
-  describe('when the worlds api request throws an error', () => {
-    let error: Error
+  describe('when the address is not provided in the action', () => {
+    let addressInStore: string | undefined
 
     beforeEach(() => {
-      error = new Error('some error')
+      address = undefined
     })
 
-    it('should put the failure action with the request action address and the error message', () => {
-      return expectSaga(worldsSaga)
-        .provide([[call([content, content.fetchWalletStats], address), throwError(error)]])
-        .put(fetchWorldsWalletStatsFailure(error.message, address))
-        .dispatch(fetchWorldsWalletStatsRequest(address))
-        .silentRun()
-    })
-  })
+    describe('and there is an address available in the store', () => {
+      beforeEach(() => {
+        addressInStore = '0x123'
+      })
 
-  describe('when the worlds api request returns null', () => {
-    it('should put the failure action with the request action address and the error message', () => {
-      return expectSaga(worldsSaga)
-        .provide([[call([content, content.fetchWalletStats], address), null]])
-        .put(fetchWorldsWalletStatsFailure('Could not fetch wallet stats', address))
-        .dispatch(fetchWorldsWalletStatsRequest(address))
-        .silentRun()
-    })
-  })
+      describe('and the request to fetch wallet stats responds with the worlds wallet stats', () => {
+        beforeEach(() => {
+          stats = {
+            dclNames: [],
+            ensNames: [],
+            maxAllowedSpace: '',
+            usedSpace: '',
+            wallet: address!
+          }
+        })
 
-  describe('when the worlds api request returns the stats', () => {
-    let stats: WorldsWalletStats
-
-    beforeEach(() => {
-      stats = {
-        dclNames: [],
-        ensNames: [],
-        maxAllowedSpace: '',
-        usedSpace: '',
-        wallet: address
-      }
+        it('should put the success action with the address in the store and the stats', () => {
+          return expectSaga(worldsSaga)
+            .provide([
+              [select(getAddress), addressInStore],
+              [call([content, content.fetchWalletStats], addressInStore!), stats]
+            ])
+            .put(fetchWorldsWalletStatsSuccess(addressInStore!, stats))
+            .dispatch(fetchWorldsWalletStatsRequest(address))
+            .silentRun()
+        })
+      })
     })
 
-    it('should put the success action with the request action address and the stats', () => {
-      return expectSaga(worldsSaga)
-        .provide([[call([content, content.fetchWalletStats], address), stats]])
-        .put(fetchWorldsWalletStatsSuccess(address, stats))
-        .dispatch(fetchWorldsWalletStatsRequest(address))
-        .silentRun()
+    describe('and there is no address available in the store', () => {
+      beforeEach(() => {
+        addressInStore = undefined
+      })
+
+      it('should put the failure action with an undefined address and the error message', () => {
+        return expectSaga(worldsSaga)
+          .provide([[select(getAddress), addressInStore]])
+          .put(fetchWorldsWalletStatsFailure('An address is required', addressInStore))
+          .dispatch(fetchWorldsWalletStatsRequest(address))
+          .silentRun()
+      })
     })
   })
 })

--- a/src/modules/worlds/sagas.spec.ts
+++ b/src/modules/worlds/sagas.spec.ts
@@ -22,7 +22,7 @@ describe('when handling the request action to fetch worlds stats for a wallet', 
     it('should put the failure action with the request action address and the error message', () => {
       return expectSaga(worldsSaga)
         .provide([[call([content, content.fetchWalletStats], address), throwError(error)]])
-        .put(fetchWorldsWalletStatsFailure(address, error.message))
+        .put(fetchWorldsWalletStatsFailure(error.message, address))
         .dispatch(fetchWorldsWalletStatsRequest(address))
         .silentRun()
     })
@@ -32,7 +32,7 @@ describe('when handling the request action to fetch worlds stats for a wallet', 
     it('should put the failure action with the request action address and the error message', () => {
       return expectSaga(worldsSaga)
         .provide([[call([content, content.fetchWalletStats], address), null]])
-        .put(fetchWorldsWalletStatsFailure(address, 'Could not fetch wallet stats'))
+        .put(fetchWorldsWalletStatsFailure('Could not fetch wallet stats', address))
         .dispatch(fetchWorldsWalletStatsRequest(address))
         .silentRun()
     })

--- a/src/modules/worlds/sagas.ts
+++ b/src/modules/worlds/sagas.ts
@@ -18,6 +18,12 @@ export function* worldsSaga() {
   yield takeEvery(FETCH_WORLDS_WALLET_STATS_REQUEST, handlefetchWorldsWalletStatsRequest)
 }
 
+/**
+ * Handle the fetch of the provided or current user's wallet stats.
+ * If no address is provided through the action, the wallet address from the currently connected wallet will be used.
+ * This saga is intended to be used without providing an address only if a wallet is connected or connecting.
+ * If called without a connected wallet and providing no address, it will get stuck until a wallet is connected.
+ */
 function* handlefetchWorldsWalletStatsRequest(action: FetchWalletWorldsStatsRequestAction) {
   let address = action.payload.address
 

--- a/src/modules/worlds/sagas.ts
+++ b/src/modules/worlds/sagas.ts
@@ -1,4 +1,4 @@
-import { call, put, takeEvery } from 'redux-saga/effects'
+import { call, put, select, takeEvery } from 'redux-saga/effects'
 import { WorldsWalletStats, content as WorldsAPIContent } from 'lib/api/worlds'
 import {
   FETCH_WORLDS_WALLET_STATS_REQUEST,
@@ -6,15 +6,24 @@ import {
   fetchWorldsWalletStatsFailure,
   fetchWorldsWalletStatsSuccess
 } from './actions'
+import { getAddress } from 'decentraland-dapps/dist/modules/wallet/selectors'
 
 export function* worldsSaga() {
   yield takeEvery(FETCH_WORLDS_WALLET_STATS_REQUEST, handlefetchWorldsWalletStatsRequest)
 }
 
 function* handlefetchWorldsWalletStatsRequest(action: FetchWalletWorldsStatsRequestAction) {
-  const { address } = action.payload
+  let address = action.payload.address
+
+  if (!address) {
+    address = yield select(getAddress)
+  }
 
   try {
+    if (!address) {
+      throw new Error('An address is required')
+    }
+
     const stats: WorldsWalletStats | null = yield call([WorldsAPIContent, WorldsAPIContent.fetchWalletStats], address)
 
     if (!stats) {
@@ -23,6 +32,6 @@ function* handlefetchWorldsWalletStatsRequest(action: FetchWalletWorldsStatsRequ
 
     yield put(fetchWorldsWalletStatsSuccess(address, stats))
   } catch (e) {
-    yield put(fetchWorldsWalletStatsFailure(address, e.message))
+    yield put(fetchWorldsWalletStatsFailure(e.message, address))
   }
 }

--- a/src/modules/worlds/selectors.spec.ts
+++ b/src/modules/worlds/selectors.spec.ts
@@ -1,12 +1,20 @@
 import { RootState } from 'modules/common/types'
 import { INITIAL_STATE } from './reducer'
-import { getData, getError, getLoading, getState, getWalletStats } from './selectors'
+import { getConnectedWalletStats, getData, getError, getLoading, getState, getWalletStats } from './selectors'
 
+let connectedWallet: string
 let state: RootState
 
 beforeEach(() => {
+  connectedWallet = '0x123'
+
   state = {
-    worlds: INITIAL_STATE
+    worlds: { ...INITIAL_STATE, walletStats: { [connectedWallet]: {} } },
+    wallet: {
+      data: {
+        address: connectedWallet
+      }
+    }
   } as RootState
 })
 
@@ -37,5 +45,11 @@ describe('when getting the worlds error', () => {
 describe('when getting the worlds wallet stats', () => {
   it('should return the worlds wallet stats', () => {
     expect(getWalletStats(state)).toEqual(state.worlds.walletStats)
+  })
+})
+
+describe('when getting the worlds wallet stats for the connected wallet', () => {
+  it('should return the worlds wallet stats for the connected wallet', () => {
+    expect(getConnectedWalletStats(state)).toEqual(state.worlds.walletStats[connectedWallet])
   })
 })

--- a/src/modules/worlds/selectors.ts
+++ b/src/modules/worlds/selectors.ts
@@ -1,3 +1,4 @@
+import { getAddress } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import { RootState } from 'modules/common/types'
 
 export const getState = (state: RootState) => state.worlds
@@ -5,3 +6,13 @@ export const getData = (state: RootState) => getState(state).data
 export const getWalletStats = (state: RootState) => getState(state).walletStats
 export const getLoading = (state: RootState) => getState(state).loading
 export const getError = (state: RootState) => getState(state).error
+
+export const getConnectedWalletStats = (state: RootState) => {
+  const address = getAddress(state)
+
+  if (!address) {
+    return undefined
+  }
+
+  return getWalletStats(state)[address]
+}


### PR DESCRIPTION
Closes #2929 

<img width="1414" alt="Screenshot 2023-10-02 at 12 00 47" src="https://github.com/decentraland/builder/assets/24811313/0a266711-5bbb-4bd5-b01f-b34d423150fc">

Uses real data from the endpoint:

```
GET https://worlds-content-server.decentraland.zone/wallet/0x24e5f44999c151f08609f8e27b2238c773c4d020/stats

{
    "wallet": "0x24e5f44999c151f08609f8e27b2238c773c4d020",
    "dclNames": [
        {
            "name": "nan2.dcl.eth",
            "size": "780813"
        },
        {
            "name": "niswoman.dcl.eth",
            "size": "1206426"
        },
        {
            "name": "alberto.dcl.eth",
            "size": "1012688"
        }
    ],
    "ensNames": [
        {
            "name": "luffy.eth",
            "size": "1012682"
        }
    ],
    "usedSpace": "2999927",
    "maxAllowedSpace": "15728640000"
}
```