### PR TITLE
feat: upgrade @dcl/sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/hashing": "^3.0.4",
         "@dcl/mini-rpc": "^1.0.7",
         "@dcl/schemas": "^9.4.1",
-        "@dcl/sdk": "^7.3.19-6449538299.commit-bf7aa87",
+        "@dcl/sdk": "7.3.20",
         "@dcl/single-sign-on-client": "^0.1.0",
         "@dcl/ui-env": "^1.2.0",
         "@sentry/react": "^7.64.0",
@@ -2173,9 +2173,9 @@
       "integrity": "sha512-N0IScucthQKwk3svG/phJ0VCP4hqQzgJdUNmQJTR92ifJPZPh9QP4ps7rPtDMuPKlu3eMlH4SU5KBEMuTNkQ0w=="
     },
     "node_modules/@dcl/asset-packs": {
-      "version": "0.0.0-20231007231138.commit-4ee8384",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-0.0.0-20231007231138.commit-4ee8384.tgz",
-      "integrity": "sha512-q2bzkYGqH8rJB3OjIxux35ljPyTyDqyhr+/rgqB8QIXgGjcSyPco9ITg8LYEbdnHhzz+7XIQJhOObj0TfyEPKg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.2.3.tgz",
+      "integrity": "sha512-gjyWSNpjSY4ddYLExAbEiiD5copAl4Qfi8PuYmxr9i2XvWe4SXWtwIgRWlAEhBv1dFKsOfMOw+TXKXM7kApwBg==",
       "dependencies": {
         "@dcl-sdk/utils": "^1.1.3",
         "@dcl/js-runtime": "7.3.18",
@@ -2183,277 +2183,10 @@
         "mitt": "^3.0.1"
       }
     },
-    "node_modules/@dcl/asset-packs/node_modules/@dcl/ecs": {
-      "version": "7.3.18",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.18.tgz",
-      "integrity": "sha512-J3BOeAFwcYmwpOv2akphYUNq+rfwHTzEgU5/NENy3eQrsyU2TyQaiCWGQpdfOeKLyJIIpcBjKpzL3GM3Amf+Rg=="
-    },
-    "node_modules/@dcl/asset-packs/node_modules/@dcl/hashing": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@dcl/hashing/-/hashing-1.1.3.tgz",
-      "integrity": "sha512-mU1+Q8jcFLAR1hSBOd6WcnLwvQmKIPAH8+UPf2DZUk+Ntu7jWqSOqG+PoWRlh7/gPfI/gKofeW0a+HzVUK6N/g==",
-      "dependencies": {
-        "ethereum-cryptography": "^1.0.3",
-        "ipfs-unixfs-importer": "^7.0.3",
-        "multiformats": "^9.6.3"
-      }
-    },
-    "node_modules/@dcl/asset-packs/node_modules/@dcl/inspector": {
-      "version": "7.3.18",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.18.tgz",
-      "integrity": "sha512-cPrORAjCqQExZyrW1wJWty6ONSEof7orILZ3wrCCewXHZ4ifV6UeXvHk/p4A+6XEys2n/QtXfVvv+c3GLde8Cw=="
-    },
     "node_modules/@dcl/asset-packs/node_modules/@dcl/js-runtime": {
       "version": "7.3.18",
       "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.18.tgz",
       "integrity": "sha512-kdcjyIdS2jgklZpFKGhy3PWecDpng9u7Goyn8ek4JLtBxYtD35F9yb5mSAflnayoyy8M2lQwRbW7gDZF8n7DYw=="
-    },
-    "node_modules/@dcl/asset-packs/node_modules/@dcl/react-ecs": {
-      "version": "7.3.18",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.18.tgz",
-      "integrity": "sha512-xL0FNSCnn1L/bOKfkowFPkstcp/RqJSmZ+atRLglgUGEb7+LLMg7AKxf/6FsccojZw+KJuvR0gS8V29xlZUHHQ==",
-      "dependencies": {
-        "@dcl/ecs": "7.3.18",
-        "react": "^18.2.0",
-        "react-reconciler": "^0.29.0"
-      }
-    },
-    "node_modules/@dcl/asset-packs/node_modules/@dcl/schemas": {
-      "version": "8.2.3-20230801124703.commit-ade94fc",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-8.2.3-20230801124703.commit-ade94fc.tgz",
-      "integrity": "sha512-GP8veICDcxZaxcCbsr8oT0tgOtv3OPN+LJMo3DsNPx1ABe2UhrjJGk5qETfZX5qyTtcKLNMhEMZ3SP11PbU2qg==",
-      "dependencies": {
-        "ajv": "^8.11.0",
-        "ajv-errors": "^3.0.0",
-        "ajv-keywords": "^5.1.0"
-      }
-    },
-    "node_modules/@dcl/asset-packs/node_modules/@dcl/sdk": {
-      "version": "7.3.18",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.18.tgz",
-      "integrity": "sha512-z9MoibCdNPjnqSVwWcT/8BZllU8QUX+ny3lsRipHVn6864JB8lF9qA5feKfxyCT16BK8Jn/obWGUe6mCEBKNEg==",
-      "dependencies": {
-        "@dcl/ecs": "7.3.18",
-        "@dcl/ecs-math": "2.0.2",
-        "@dcl/explorer": "1.0.148846-20231002132009.commit-60a8fe3",
-        "@dcl/js-runtime": "7.3.18",
-        "@dcl/react-ecs": "7.3.18",
-        "@dcl/sdk-commands": "7.3.18"
-      }
-    },
-    "node_modules/@dcl/asset-packs/node_modules/@dcl/sdk-commands": {
-      "version": "7.3.18",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.18.tgz",
-      "integrity": "sha512-4H+X3HxSBzkp2t+cKPAl1PbDvFpdgT+eGA/fKGLcukU68nC/lgFIg0ehs+2X5IS5IA/PnvMl78EWrIxBsPMlhg==",
-      "dependencies": {
-        "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.3.18",
-        "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.3.18",
-        "@dcl/linker-dapp": "^0.11.0",
-        "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-6314457636.commit-a9a962a",
-        "@dcl/quests-manager": "^0.1.2",
-        "@dcl/rpc": "^1.1.1",
-        "@dcl/schemas": "^8.2.3-20230718182824.commit-356025c",
-        "@segment/analytics-node": "^1.0.0-beta.22",
-        "@well-known-components/env-config-provider": "^1.2.0",
-        "@well-known-components/fetch-component": "^2.0.2",
-        "@well-known-components/http-server": "^2.0.0-20230501134558.commit-be9a25d",
-        "@well-known-components/logger": "^3.1.2",
-        "@well-known-components/metrics": "^2.0.1",
-        "archiver": "^5.3.1",
-        "arg": "^5.0.2",
-        "chokidar": "^3.5.3",
-        "colorette": "^2.0.19",
-        "dcl-catalyst-client": "^21.5.0",
-        "esbuild": "^0.18.17",
-        "extract-zip": "2.0.1",
-        "fp-future": "^1.0.1",
-        "glob": "^9.3.2",
-        "ignore": "^5.2.4",
-        "node-fetch": "^2.7.0",
-        "open": "^8.4.0",
-        "portfinder": "^1.0.32",
-        "prompts": "^2.4.2",
-        "typescript": "^5.0.2",
-        "undici": "^5.19.1",
-        "uuid": "^9.0.0"
-      },
-      "bin": {
-        "sdk-commands": "dist/index.js"
-      }
-    },
-    "node_modules/@dcl/asset-packs/node_modules/ajv-errors": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
-      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
-      "peerDependencies": {
-        "ajv": "^8.0.1"
-      }
-    },
-    "node_modules/@dcl/asset-packs/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@dcl/asset-packs/node_modules/glob": {
-      "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "minimatch": "^8.0.2",
-        "minipass": "^4.2.4",
-        "path-scurry": "^1.6.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@dcl/asset-packs/node_modules/minimatch": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@dcl/asset-packs/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@dcl/asset-packs/node_modules/open": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
-      "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@dcl/asset-packs/node_modules/prompts": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-      "dependencies": {
-        "kleur": "^3.0.3",
-        "sisteransi": "^1.0.5"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@dcl/asset-packs/node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@dcl/asset-packs/node_modules/react-reconciler": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.0.tgz",
-      "integrity": "sha512-wa0fGj7Zht1EYMRhKWwoo1H9GApxYLBuhoAuXN0TlltESAjDssB+Apf0T/DngVqaMyPypDmabL37vw/2aRM98Q==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/@dcl/asset-packs/node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/@dcl/asset-packs/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/@dcl/asset-packs/node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/@dcl/asset-packs/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@dcl/asset-packs/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/@dcl/asset-packs/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/@dcl/build-ecs": {
       "version": "6.11.1",
@@ -2557,9 +2290,9 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.3.19-6449538299.commit-bf7aa87",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.19-6449538299.commit-bf7aa87.tgz",
-      "integrity": "sha512-KsV+Pwte+IduBEGe9hAZ21+m9x4DL9r+dwxiNlfquTi1s9IYVEm7HBDBFyOiEkR+NlYMxNQQ7rCPRDJwZnva2Q=="
+      "version": "7.3.20",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.20.tgz",
+      "integrity": "sha512-dcHjyGP+L1ZRD1AcEvZ8FsLE3mQLDVpPUSJe4rd0OS0ROF1/gAlBA14FCiNJckK0x1ccE6lLSKXsThwJkDfghg=="
     },
     "node_modules/@dcl/ecs-math": {
       "version": "2.0.2",
@@ -2567,9 +2300,9 @@
       "integrity": "sha512-w01+a3mpHvxGPHepu0hAAX8OfpBSQEqBbC1+U8o+5SBSQVXHiRwt3P4cK20yM8QCgZe3enPttmpqePnjTliTig=="
     },
     "node_modules/@dcl/explorer": {
-      "version": "1.0.148846-20231002132009.commit-60a8fe3",
-      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.148846-20231002132009.commit-60a8fe3.tgz",
-      "integrity": "sha512-en65I+qBqfV7cvFE671qe9N9zu6ZZ8C5uqV6wVgsgd6ods9jaTx0cgd4s1FxGHTY2WYdBd1fHVNRlvcxHhKtmA=="
+      "version": "1.0.150826-20231009190521.commit-9698dfc",
+      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.150826-20231009190521.commit-9698dfc.tgz",
+      "integrity": "sha512-B2jWNDz8nnt/2EkRXPDji4A8KT+zljWSmLnQnPG/zQ8PaBbPIHdn9XvxqrEvU7BnofdKyP/R+sODkao9333Bbw=="
     },
     "node_modules/@dcl/hashing": {
       "version": "3.0.4",
@@ -2577,17 +2310,17 @@
       "integrity": "sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg=="
     },
     "node_modules/@dcl/inspector": {
-      "version": "7.3.19-6449538299.commit-bf7aa87",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.19-6449538299.commit-bf7aa87.tgz",
-      "integrity": "sha512-R0yWnZd6VHO2UerLt0co+rByIENAhgebcAPQG3kCVFnhBuu09GvMR0ZPMtRS+S+VX0daVGIUPkcLJ1Xpv7zCXA==",
+      "version": "7.3.20",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.20.tgz",
+      "integrity": "sha512-QxTBC+aBET5jw+bJvULjLw6WbVEHAgp/DfeFZ/JUCLJ/Y8uP/ZVzr8XgY4kBF0BEfT76CGu0K0h21k76xhbR5g==",
       "dependencies": {
-        "@dcl/asset-packs": "^0.0.0-20231007231138.commit-4ee8384"
+        "@dcl/asset-packs": "^1.2.3"
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.3.19-6449538299.commit-bf7aa87",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.19-6449538299.commit-bf7aa87.tgz",
-      "integrity": "sha512-1OGJFR4/aVxCT1IlV3W24QaqkXWBhf5ki1NyUu2VP0HNyfen7WJE9Auc5XkmHnPtqlT2hNVHDzcBGV6dDnd1rA=="
+      "version": "7.3.20",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.20.tgz",
+      "integrity": "sha512-qVHdikkowzmHBgaapDfslAmB190nyphO5bNUf5jCwnt4fM06+AEmbqev7iQ5kBt/DLCLFNrM4vfJxWgkiYWOAg=="
     },
     "node_modules/@dcl/kernel": {
       "version": "1.0.0-2505075507.commit-6af9c3b",
@@ -2692,11 +2425,11 @@
       "integrity": "sha512-4iSvVQdiR558XDcnUvQPvuGfaGa0CK2mRac8RnAQeW1k45JkOPWiVv8cv6LT6bF5IcuksK0LkQIVG252eF1VRw=="
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.3.19-6449538299.commit-bf7aa87",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.19-6449538299.commit-bf7aa87.tgz",
-      "integrity": "sha512-KWNMA8LnhwiqsOxUkw+dpJZBnAVn6D6KKozH1VnMXVHa3tGY9xd8HEaBx6MQJHMCoRhnt6WYWeVBkWRVVk3C9g==",
+      "version": "7.3.20",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.20.tgz",
+      "integrity": "sha512-Id7vvirDHujdinVccvCeu6vx5XnwMDdhNhiaIWjQwgPX0I91DwdW8ldsIvfr5fcwawfjS/6ZMfzBMduo7HNNcA==",
       "dependencies": {
-        "@dcl/ecs": "7.3.19-6449538299.commit-bf7aa87",
+        "@dcl/ecs": "7.3.20",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -2763,27 +2496,27 @@
       }
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.3.19-6449538299.commit-bf7aa87",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.19-6449538299.commit-bf7aa87.tgz",
-      "integrity": "sha512-tuP/z44Lqkga11EYLn3sV75r0nRpL4NMwubPMzc09pu2fgqZkHtzRJXU8iGkrGW/QENN8Xx1fP0kpPzS5Tj8zA==",
+      "version": "7.3.20",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.20.tgz",
+      "integrity": "sha512-sAVRQK4z42PPOF8m//U70zVDw5Rt5YyQ5VoQJ6NKqqqCdg6l7/ubgCLY5dvrqW9g4tDgpa21+RyCDP4w0WcKYA==",
       "dependencies": {
-        "@dcl/ecs": "7.3.19-6449538299.commit-bf7aa87",
+        "@dcl/ecs": "7.3.20",
         "@dcl/ecs-math": "2.0.2",
-        "@dcl/explorer": "1.0.148846-20231002132009.commit-60a8fe3",
-        "@dcl/js-runtime": "7.3.19-6449538299.commit-bf7aa87",
-        "@dcl/react-ecs": "7.3.19-6449538299.commit-bf7aa87",
-        "@dcl/sdk-commands": "7.3.19-6449538299.commit-bf7aa87"
+        "@dcl/explorer": "1.0.150826-20231009190521.commit-9698dfc",
+        "@dcl/js-runtime": "7.3.20",
+        "@dcl/react-ecs": "7.3.20",
+        "@dcl/sdk-commands": "7.3.20"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.3.19-6449538299.commit-bf7aa87",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.19-6449538299.commit-bf7aa87.tgz",
-      "integrity": "sha512-KtXqyRfZcY+suxuT5V+f+rp46fjbaBFZRT9ixmhN5o2VN+1M8lFj1p6K4y/C+F9Fq80lVcnnXcl+OGNZEYgY1Q==",
+      "version": "7.3.20",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.20.tgz",
+      "integrity": "sha512-LqD7vtXSdpHaMHWIPw1KZuY2wErzD8e6KT9nvdRh4jpIgRkYyh5pC5PgmyqB5SPHAbHNV9XRXHHdiCOGiHPcSA==",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.3.19-6449538299.commit-bf7aa87",
+        "@dcl/ecs": "7.3.20",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.3.19-6449538299.commit-bf7aa87",
+        "@dcl/inspector": "7.3.20",
         "@dcl/linker-dapp": "^0.11.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-6314457636.commit-a9a962a",
@@ -5396,9 +5129,9 @@
       }
     },
     "node_modules/@segment/analytics-core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.3.1.tgz",
-      "integrity": "sha512-KGblJ8WQNC4t0j31zeyYBm2thHWuPULNAoP7waU5ts7Asz9ipvGoHqFSLG6warqvcnBdkiRbNam242zmxX53oA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.3.2.tgz",
+      "integrity": "sha512-NpeBCfOyMdO2/BDKfhCUNHcEwxg88N2iTnswBoEMh38rtsQ03TWLVYwgiTakPjNQFezdKkR6jq3JhQ3WWgq67g==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
         "dset": "^3.1.2",
@@ -5406,12 +5139,12 @@
       }
     },
     "node_modules/@segment/analytics-node": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-1.1.1.tgz",
-      "integrity": "sha512-YNn32SfD8KrxIBowLz3MVav0GzhGIbBRgAtjW4Kv57oHwgaJNSLEp/z/ypnu7vAqUjm9jAwAW9Wfc24ssZI49g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-1.1.2.tgz",
+      "integrity": "sha512-pYQwG4/1YDxwzu97v2glfxZpwMj3A7UOKId1IdnSyDharesYawdbXpiTxBqOS3JpgP7iU4TZSiRmk7InFel/MA==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
-        "@segment/analytics-core": "1.3.1",
+        "@segment/analytics-core": "1.3.2",
         "buffer": "^6.0.3",
         "node-fetch": "^2.6.7",
         "tslib": "^2.4.1"
@@ -29692,9 +29425,9 @@
       }
     },
     "node_modules/ts-proto": {
-      "version": "1.160.0",
-      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.160.0.tgz",
-      "integrity": "sha512-AUJQ0noLEkLew81MYmNPF/z8QDIBxAIJ4UKt9sH2AwdaywOTk1jh1NoluoCr3cGScpVh0GHWCB/UA4V0fOO8fg==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.161.0.tgz",
+      "integrity": "sha512-AU1SxJbPETTDdzkle5okqwfqQqHKXemc587A6Lh9hkOL1HJbgowi8xLLQXHlb9zJVygYz8J+4LBccuohYKha4A==",
       "dependencies": {
         "case-anything": "^2.1.13",
         "protobufjs": "^7.2.4",
@@ -34101,9 +33834,9 @@
       "integrity": "sha512-N0IScucthQKwk3svG/phJ0VCP4hqQzgJdUNmQJTR92ifJPZPh9QP4ps7rPtDMuPKlu3eMlH4SU5KBEMuTNkQ0w=="
     },
     "@dcl/asset-packs": {
-      "version": "0.0.0-20231007231138.commit-4ee8384",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-0.0.0-20231007231138.commit-4ee8384.tgz",
-      "integrity": "sha512-q2bzkYGqH8rJB3OjIxux35ljPyTyDqyhr+/rgqB8QIXgGjcSyPco9ITg8LYEbdnHhzz+7XIQJhOObj0TfyEPKg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.2.3.tgz",
+      "integrity": "sha512-gjyWSNpjSY4ddYLExAbEiiD5copAl4Qfi8PuYmxr9i2XvWe4SXWtwIgRWlAEhBv1dFKsOfMOw+TXKXM7kApwBg==",
       "requires": {
         "@dcl-sdk/utils": "^1.1.3",
         "@dcl/js-runtime": "7.3.18",
@@ -34111,217 +33844,10 @@
         "mitt": "^3.0.1"
       },
       "dependencies": {
-        "@dcl/ecs": {
-          "version": "7.3.18",
-          "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.18.tgz",
-          "integrity": "sha512-J3BOeAFwcYmwpOv2akphYUNq+rfwHTzEgU5/NENy3eQrsyU2TyQaiCWGQpdfOeKLyJIIpcBjKpzL3GM3Amf+Rg=="
-        },
-        "@dcl/hashing": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/@dcl/hashing/-/hashing-1.1.3.tgz",
-          "integrity": "sha512-mU1+Q8jcFLAR1hSBOd6WcnLwvQmKIPAH8+UPf2DZUk+Ntu7jWqSOqG+PoWRlh7/gPfI/gKofeW0a+HzVUK6N/g==",
-          "requires": {
-            "ethereum-cryptography": "^1.0.3",
-            "ipfs-unixfs-importer": "^7.0.3",
-            "multiformats": "^9.6.3"
-          }
-        },
-        "@dcl/inspector": {
-          "version": "7.3.18",
-          "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.18.tgz",
-          "integrity": "sha512-cPrORAjCqQExZyrW1wJWty6ONSEof7orILZ3wrCCewXHZ4ifV6UeXvHk/p4A+6XEys2n/QtXfVvv+c3GLde8Cw=="
-        },
         "@dcl/js-runtime": {
           "version": "7.3.18",
           "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.18.tgz",
           "integrity": "sha512-kdcjyIdS2jgklZpFKGhy3PWecDpng9u7Goyn8ek4JLtBxYtD35F9yb5mSAflnayoyy8M2lQwRbW7gDZF8n7DYw=="
-        },
-        "@dcl/react-ecs": {
-          "version": "7.3.18",
-          "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.18.tgz",
-          "integrity": "sha512-xL0FNSCnn1L/bOKfkowFPkstcp/RqJSmZ+atRLglgUGEb7+LLMg7AKxf/6FsccojZw+KJuvR0gS8V29xlZUHHQ==",
-          "requires": {
-            "@dcl/ecs": "7.3.18",
-            "react": "^18.2.0",
-            "react-reconciler": "^0.29.0"
-          }
-        },
-        "@dcl/schemas": {
-          "version": "8.2.3-20230801124703.commit-ade94fc",
-          "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-8.2.3-20230801124703.commit-ade94fc.tgz",
-          "integrity": "sha512-GP8veICDcxZaxcCbsr8oT0tgOtv3OPN+LJMo3DsNPx1ABe2UhrjJGk5qETfZX5qyTtcKLNMhEMZ3SP11PbU2qg==",
-          "requires": {
-            "ajv": "^8.11.0",
-            "ajv-errors": "^3.0.0",
-            "ajv-keywords": "^5.1.0"
-          }
-        },
-        "@dcl/sdk": {
-          "version": "7.3.18",
-          "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.18.tgz",
-          "integrity": "sha512-z9MoibCdNPjnqSVwWcT/8BZllU8QUX+ny3lsRipHVn6864JB8lF9qA5feKfxyCT16BK8Jn/obWGUe6mCEBKNEg==",
-          "requires": {
-            "@dcl/ecs": "7.3.18",
-            "@dcl/ecs-math": "2.0.2",
-            "@dcl/explorer": "1.0.148846-20231002132009.commit-60a8fe3",
-            "@dcl/js-runtime": "7.3.18",
-            "@dcl/react-ecs": "7.3.18",
-            "@dcl/sdk-commands": "7.3.18"
-          }
-        },
-        "@dcl/sdk-commands": {
-          "version": "7.3.18",
-          "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.18.tgz",
-          "integrity": "sha512-4H+X3HxSBzkp2t+cKPAl1PbDvFpdgT+eGA/fKGLcukU68nC/lgFIg0ehs+2X5IS5IA/PnvMl78EWrIxBsPMlhg==",
-          "requires": {
-            "@dcl/crypto": "^3.4.4",
-            "@dcl/ecs": "7.3.18",
-            "@dcl/hashing": "1.1.3",
-            "@dcl/inspector": "7.3.18",
-            "@dcl/linker-dapp": "^0.11.0",
-            "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-            "@dcl/protocol": "1.0.0-6314457636.commit-a9a962a",
-            "@dcl/quests-manager": "^0.1.2",
-            "@dcl/rpc": "^1.1.1",
-            "@dcl/schemas": "^8.2.3-20230718182824.commit-356025c",
-            "@segment/analytics-node": "^1.0.0-beta.22",
-            "@well-known-components/env-config-provider": "^1.2.0",
-            "@well-known-components/fetch-component": "^2.0.2",
-            "@well-known-components/http-server": "^2.0.0-20230501134558.commit-be9a25d",
-            "@well-known-components/logger": "^3.1.2",
-            "@well-known-components/metrics": "^2.0.1",
-            "archiver": "^5.3.1",
-            "arg": "^5.0.2",
-            "chokidar": "^3.5.3",
-            "colorette": "^2.0.19",
-            "dcl-catalyst-client": "^21.5.0",
-            "esbuild": "^0.18.17",
-            "extract-zip": "2.0.1",
-            "fp-future": "^1.0.1",
-            "glob": "^9.3.2",
-            "ignore": "^5.2.4",
-            "node-fetch": "^2.7.0",
-            "open": "^8.4.0",
-            "portfinder": "^1.0.32",
-            "prompts": "^2.4.2",
-            "typescript": "^5.0.2",
-            "undici": "^5.19.1",
-            "uuid": "^9.0.0"
-          }
-        },
-        "ajv-errors": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
-          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
-          "requires": {}
-        },
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "glob": {
-          "version": "9.3.5",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-          "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "minimatch": "^8.0.2",
-            "minipass": "^4.2.4",
-            "path-scurry": "^1.6.1"
-          }
-        },
-        "minimatch": {
-          "version": "8.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-          "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        },
-        "node-fetch": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-          "requires": {
-            "whatwg-url": "^5.0.0"
-          }
-        },
-        "open": {
-          "version": "8.4.2",
-          "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-          "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
-          "requires": {
-            "define-lazy-prop": "^2.0.0",
-            "is-docker": "^2.1.1",
-            "is-wsl": "^2.2.0"
-          }
-        },
-        "prompts": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-          "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-          "requires": {
-            "kleur": "^3.0.3",
-            "sisteransi": "^1.0.5"
-          }
-        },
-        "react": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-          "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-          "requires": {
-            "loose-envify": "^1.1.0"
-          }
-        },
-        "react-reconciler": {
-          "version": "0.29.0",
-          "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.0.tgz",
-          "integrity": "sha512-wa0fGj7Zht1EYMRhKWwoo1H9GApxYLBuhoAuXN0TlltESAjDssB+Apf0T/DngVqaMyPypDmabL37vw/2aRM98Q==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "scheduler": "^0.23.0"
-          }
-        },
-        "scheduler": {
-          "version": "0.23.0",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-          "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-          "requires": {
-            "loose-envify": "^1.1.0"
-          }
-        },
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-        },
-        "typescript": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
-        },
-        "uuid": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
         }
       }
     },
@@ -34410,9 +33936,9 @@
       }
     },
     "@dcl/ecs": {
-      "version": "7.3.19-6449538299.commit-bf7aa87",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.19-6449538299.commit-bf7aa87.tgz",
-      "integrity": "sha512-KsV+Pwte+IduBEGe9hAZ21+m9x4DL9r+dwxiNlfquTi1s9IYVEm7HBDBFyOiEkR+NlYMxNQQ7rCPRDJwZnva2Q=="
+      "version": "7.3.20",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.3.20.tgz",
+      "integrity": "sha512-dcHjyGP+L1ZRD1AcEvZ8FsLE3mQLDVpPUSJe4rd0OS0ROF1/gAlBA14FCiNJckK0x1ccE6lLSKXsThwJkDfghg=="
     },
     "@dcl/ecs-math": {
       "version": "2.0.2",
@@ -34420,9 +33946,9 @@
       "integrity": "sha512-w01+a3mpHvxGPHepu0hAAX8OfpBSQEqBbC1+U8o+5SBSQVXHiRwt3P4cK20yM8QCgZe3enPttmpqePnjTliTig=="
     },
     "@dcl/explorer": {
-      "version": "1.0.148846-20231002132009.commit-60a8fe3",
-      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.148846-20231002132009.commit-60a8fe3.tgz",
-      "integrity": "sha512-en65I+qBqfV7cvFE671qe9N9zu6ZZ8C5uqV6wVgsgd6ods9jaTx0cgd4s1FxGHTY2WYdBd1fHVNRlvcxHhKtmA=="
+      "version": "1.0.150826-20231009190521.commit-9698dfc",
+      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.150826-20231009190521.commit-9698dfc.tgz",
+      "integrity": "sha512-B2jWNDz8nnt/2EkRXPDji4A8KT+zljWSmLnQnPG/zQ8PaBbPIHdn9XvxqrEvU7BnofdKyP/R+sODkao9333Bbw=="
     },
     "@dcl/hashing": {
       "version": "3.0.4",
@@ -34430,17 +33956,17 @@
       "integrity": "sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg=="
     },
     "@dcl/inspector": {
-      "version": "7.3.19-6449538299.commit-bf7aa87",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.19-6449538299.commit-bf7aa87.tgz",
-      "integrity": "sha512-R0yWnZd6VHO2UerLt0co+rByIENAhgebcAPQG3kCVFnhBuu09GvMR0ZPMtRS+S+VX0daVGIUPkcLJ1Xpv7zCXA==",
+      "version": "7.3.20",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.3.20.tgz",
+      "integrity": "sha512-QxTBC+aBET5jw+bJvULjLw6WbVEHAgp/DfeFZ/JUCLJ/Y8uP/ZVzr8XgY4kBF0BEfT76CGu0K0h21k76xhbR5g==",
       "requires": {
-        "@dcl/asset-packs": "^0.0.0-20231007231138.commit-4ee8384"
+        "@dcl/asset-packs": "^1.2.3"
       }
     },
     "@dcl/js-runtime": {
-      "version": "7.3.19-6449538299.commit-bf7aa87",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.19-6449538299.commit-bf7aa87.tgz",
-      "integrity": "sha512-1OGJFR4/aVxCT1IlV3W24QaqkXWBhf5ki1NyUu2VP0HNyfen7WJE9Auc5XkmHnPtqlT2hNVHDzcBGV6dDnd1rA=="
+      "version": "7.3.20",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.3.20.tgz",
+      "integrity": "sha512-qVHdikkowzmHBgaapDfslAmB190nyphO5bNUf5jCwnt4fM06+AEmbqev7iQ5kBt/DLCLFNrM4vfJxWgkiYWOAg=="
     },
     "@dcl/kernel": {
       "version": "1.0.0-2505075507.commit-6af9c3b",
@@ -34531,11 +34057,11 @@
       "integrity": "sha512-4iSvVQdiR558XDcnUvQPvuGfaGa0CK2mRac8RnAQeW1k45JkOPWiVv8cv6LT6bF5IcuksK0LkQIVG252eF1VRw=="
     },
     "@dcl/react-ecs": {
-      "version": "7.3.19-6449538299.commit-bf7aa87",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.19-6449538299.commit-bf7aa87.tgz",
-      "integrity": "sha512-KWNMA8LnhwiqsOxUkw+dpJZBnAVn6D6KKozH1VnMXVHa3tGY9xd8HEaBx6MQJHMCoRhnt6WYWeVBkWRVVk3C9g==",
+      "version": "7.3.20",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.3.20.tgz",
+      "integrity": "sha512-Id7vvirDHujdinVccvCeu6vx5XnwMDdhNhiaIWjQwgPX0I91DwdW8ldsIvfr5fcwawfjS/6ZMfzBMduo7HNNcA==",
       "requires": {
-        "@dcl/ecs": "7.3.19-6449538299.commit-bf7aa87",
+        "@dcl/ecs": "7.3.20",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       },
@@ -34595,27 +34121,27 @@
       }
     },
     "@dcl/sdk": {
-      "version": "7.3.19-6449538299.commit-bf7aa87",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.19-6449538299.commit-bf7aa87.tgz",
-      "integrity": "sha512-tuP/z44Lqkga11EYLn3sV75r0nRpL4NMwubPMzc09pu2fgqZkHtzRJXU8iGkrGW/QENN8Xx1fP0kpPzS5Tj8zA==",
+      "version": "7.3.20",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.3.20.tgz",
+      "integrity": "sha512-sAVRQK4z42PPOF8m//U70zVDw5Rt5YyQ5VoQJ6NKqqqCdg6l7/ubgCLY5dvrqW9g4tDgpa21+RyCDP4w0WcKYA==",
       "requires": {
-        "@dcl/ecs": "7.3.19-6449538299.commit-bf7aa87",
+        "@dcl/ecs": "7.3.20",
         "@dcl/ecs-math": "2.0.2",
-        "@dcl/explorer": "1.0.148846-20231002132009.commit-60a8fe3",
-        "@dcl/js-runtime": "7.3.19-6449538299.commit-bf7aa87",
-        "@dcl/react-ecs": "7.3.19-6449538299.commit-bf7aa87",
-        "@dcl/sdk-commands": "7.3.19-6449538299.commit-bf7aa87"
+        "@dcl/explorer": "1.0.150826-20231009190521.commit-9698dfc",
+        "@dcl/js-runtime": "7.3.20",
+        "@dcl/react-ecs": "7.3.20",
+        "@dcl/sdk-commands": "7.3.20"
       }
     },
     "@dcl/sdk-commands": {
-      "version": "7.3.19-6449538299.commit-bf7aa87",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.19-6449538299.commit-bf7aa87.tgz",
-      "integrity": "sha512-KtXqyRfZcY+suxuT5V+f+rp46fjbaBFZRT9ixmhN5o2VN+1M8lFj1p6K4y/C+F9Fq80lVcnnXcl+OGNZEYgY1Q==",
+      "version": "7.3.20",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.3.20.tgz",
+      "integrity": "sha512-LqD7vtXSdpHaMHWIPw1KZuY2wErzD8e6KT9nvdRh4jpIgRkYyh5pC5PgmyqB5SPHAbHNV9XRXHHdiCOGiHPcSA==",
       "requires": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.3.19-6449538299.commit-bf7aa87",
+        "@dcl/ecs": "7.3.20",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.3.19-6449538299.commit-bf7aa87",
+        "@dcl/inspector": "7.3.20",
         "@dcl/linker-dapp": "^0.11.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-6314457636.commit-a9a962a",
@@ -36378,9 +35904,9 @@
       }
     },
     "@segment/analytics-core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.3.1.tgz",
-      "integrity": "sha512-KGblJ8WQNC4t0j31zeyYBm2thHWuPULNAoP7waU5ts7Asz9ipvGoHqFSLG6warqvcnBdkiRbNam242zmxX53oA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.3.2.tgz",
+      "integrity": "sha512-NpeBCfOyMdO2/BDKfhCUNHcEwxg88N2iTnswBoEMh38rtsQ03TWLVYwgiTakPjNQFezdKkR6jq3JhQ3WWgq67g==",
       "requires": {
         "@lukeed/uuid": "^2.0.0",
         "dset": "^3.1.2",
@@ -36388,12 +35914,12 @@
       }
     },
     "@segment/analytics-node": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-1.1.1.tgz",
-      "integrity": "sha512-YNn32SfD8KrxIBowLz3MVav0GzhGIbBRgAtjW4Kv57oHwgaJNSLEp/z/ypnu7vAqUjm9jAwAW9Wfc24ssZI49g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-1.1.2.tgz",
+      "integrity": "sha512-pYQwG4/1YDxwzu97v2glfxZpwMj3A7UOKId1IdnSyDharesYawdbXpiTxBqOS3JpgP7iU4TZSiRmk7InFel/MA==",
       "requires": {
         "@lukeed/uuid": "^2.0.0",
-        "@segment/analytics-core": "1.3.1",
+        "@segment/analytics-core": "1.3.2",
         "buffer": "^6.0.3",
         "node-fetch": "^2.6.7",
         "tslib": "^2.4.1"
@@ -55816,9 +55342,9 @@
       }
     },
     "ts-proto": {
-      "version": "1.160.0",
-      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.160.0.tgz",
-      "integrity": "sha512-AUJQ0noLEkLew81MYmNPF/z8QDIBxAIJ4UKt9sH2AwdaywOTk1jh1NoluoCr3cGScpVh0GHWCB/UA4V0fOO8fg==",
+      "version": "1.161.0",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.161.0.tgz",
+      "integrity": "sha512-AU1SxJbPETTDdzkle5okqwfqQqHKXemc587A6Lh9hkOL1HJbgowi8xLLQXHlb9zJVygYz8J+4LBccuohYKha4A==",
       "requires": {
         "case-anything": "^2.1.13",
         "protobufjs": "^7.2.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@dcl/hashing": "^3.0.4",
     "@dcl/mini-rpc": "^1.0.7",
     "@dcl/schemas": "^9.4.1",
-    "@dcl/sdk": "^7.3.19-6449538299.commit-bf7aa87",
+    "@dcl/sdk": "7.3.20",
     "@dcl/single-sign-on-client": "^0.1.0",
     "@dcl/ui-env": "^1.2.0",
     "@sentry/react": "^7.64.0",


### PR DESCRIPTION
This PR upgrades the `@dcl/sdk` to the latest version to support exporting to VSCode