### PR TITLE
fix: Remove DISABLE_backpack_editor_v2 explorer var

### DIFF
--- a/src/modules/collection/utils.ts
+++ b/src/modules/collection/utils.ts
@@ -71,9 +71,7 @@ export function getExplorerURL({
     URL += `&position=${position.x},${position.y}`
   }
 
-  const BACKPACK_V1_ROLLBACK = `&DISABLE_backpack_editor_v2=&ENABLE_backpack_editor_v1=` // TODO: Remove this once the backpack editor v2 is ready for the in world preview
-
-  return `${URL}${BACKPACK_V1_ROLLBACK}`
+  return URL
 }
 
 export function getCollectionBaseURI() {


### PR DESCRIPTION
This PR removes the `DISABLE_backpack_editor_v2` var. Items not deployed are supported now by the backpack v2.