### PR TITLE
feat: SDK7 templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babylonjs/core": "^4.2.0",
         "@babylonjs/loaders": "^4.2.0",
         "@dcl/builder-client": "^3.3.0",
-        "@dcl/builder-templates": "^0.0.0-20231218185049.commit-1aa54da",
+        "@dcl/builder-templates": "^0.1.1",
         "@dcl/content-hash-tree": "^1.1.3",
         "@dcl/crypto": "^3.0.1",
         "@dcl/hashing": "^3.0.4",
@@ -2264,9 +2264,9 @@
       }
     },
     "node_modules/@dcl/builder-templates": {
-      "version": "0.0.0-20231218185049.commit-1aa54da",
-      "resolved": "https://registry.npmjs.org/@dcl/builder-templates/-/builder-templates-0.0.0-20231218185049.commit-1aa54da.tgz",
-      "integrity": "sha512-1GQzfdbYFORQL92Fcbsmv7Y/xvMsWlGJJGacKA8SYmhMfEEWlshSwMXyylo2LwmhNy7pvWJ3hkQlXU0s91bdmA=="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@dcl/builder-templates/-/builder-templates-0.1.1.tgz",
+      "integrity": "sha512-YI/6gfMf4PNQo5ZmADgqlFrvDYb8Y0gErRJ72kL1Om4xnCgKNZ6lTJ5RJmJzriILgGNPjD6nnuTJkbLNCyR4Sw=="
     },
     "node_modules/@dcl/catalyst-contracts": {
       "version": "4.0.2",
@@ -35250,9 +35250,9 @@
       }
     },
     "@dcl/builder-templates": {
-      "version": "0.0.0-20231218185049.commit-1aa54da",
-      "resolved": "https://registry.npmjs.org/@dcl/builder-templates/-/builder-templates-0.0.0-20231218185049.commit-1aa54da.tgz",
-      "integrity": "sha512-1GQzfdbYFORQL92Fcbsmv7Y/xvMsWlGJJGacKA8SYmhMfEEWlshSwMXyylo2LwmhNy7pvWJ3hkQlXU0s91bdmA=="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@dcl/builder-templates/-/builder-templates-0.1.1.tgz",
+      "integrity": "sha512-YI/6gfMf4PNQo5ZmADgqlFrvDYb8Y0gErRJ72kL1Om4xnCgKNZ6lTJ5RJmJzriILgGNPjD6nnuTJkbLNCyR4Sw=="
     },
     "@dcl/catalyst-contracts": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babylonjs/core": "^4.2.0",
         "@babylonjs/loaders": "^4.2.0",
         "@dcl/builder-client": "^3.3.0",
-        "@dcl/builder-templates": "^0.1.1",
+        "@dcl/builder-templates": "^0.2.0",
         "@dcl/content-hash-tree": "^1.1.3",
         "@dcl/crypto": "^3.0.1",
         "@dcl/hashing": "^3.0.4",
@@ -2264,9 +2264,9 @@
       }
     },
     "node_modules/@dcl/builder-templates": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@dcl/builder-templates/-/builder-templates-0.1.1.tgz",
-      "integrity": "sha512-YI/6gfMf4PNQo5ZmADgqlFrvDYb8Y0gErRJ72kL1Om4xnCgKNZ6lTJ5RJmJzriILgGNPjD6nnuTJkbLNCyR4Sw=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@dcl/builder-templates/-/builder-templates-0.2.0.tgz",
+      "integrity": "sha512-n7BTTOyeFJbZicGcLGzhFlVx7I+kVYOgJlFDaFYecdR2iGBLa1Y2sFLrTpMbSHJpt9dIPGdNbdmpEhDgQpWI+w=="
     },
     "node_modules/@dcl/catalyst-contracts": {
       "version": "4.0.2",
@@ -6103,7 +6103,6 @@
       "version": "8.20.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
       "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -6222,8 +6221,7 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
-      "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
-      "dev": true
+      "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.19",
@@ -6840,7 +6838,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.36.2.tgz",
       "integrity": "sha512-OwwR8LRwSnI98tdc2z7mJYgY60gf7I9ZfGjN5EjCwwns9bdTuQfAXcsjSB2wSQ/TVNYSGKf4kzVXbNGaZvwiXw==",
-      "dev": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.36.2",
         "@typescript-eslint/type-utils": "5.36.2",
@@ -6873,7 +6870,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.36.2.tgz",
       "integrity": "sha512-cNNP51L8SkIFSfce8B1NSUBTJTu2Ts4nWeWbFrdaqjmn9yKrAaJUBHkyTZc0cL06OFHpb+JZq5AUHROS398Orw==",
-      "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "5.36.2",
         "@typescript-eslint/visitor-keys": "5.36.2"
@@ -6890,7 +6886,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.36.2.tgz",
       "integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -6903,7 +6898,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.36.2.tgz",
       "integrity": "sha512-BtRvSR6dEdrNt7Net2/XDjbYKU5Ml6GqJgVfXT0CxTCJlnIqK7rAGreuWKMT2t8cFUT2Msv5oxw0GMRD7T5J7A==",
-      "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "5.36.2",
         "eslint-visitor-keys": "^3.3.0"
@@ -6920,7 +6914,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -6929,7 +6922,6 @@
       "version": "7.3.7",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
       "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -6967,7 +6959,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.36.2.tgz",
       "integrity": "sha512-qS/Kb0yzy8sR0idFspI9Z6+t7mqk/oRjnAYfewG+VN73opAUvmYL3oPIMmgOX6CnQS6gmVIXGshlb5RY/R22pA==",
-      "dev": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.36.2",
         "@typescript-eslint/types": "5.36.2",
@@ -6994,7 +6985,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.36.2.tgz",
       "integrity": "sha512-cNNP51L8SkIFSfce8B1NSUBTJTu2Ts4nWeWbFrdaqjmn9yKrAaJUBHkyTZc0cL06OFHpb+JZq5AUHROS398Orw==",
-      "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "5.36.2",
         "@typescript-eslint/visitor-keys": "5.36.2"
@@ -7011,7 +7001,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.36.2.tgz",
       "integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -7024,7 +7013,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.36.2.tgz",
       "integrity": "sha512-8fyH+RfbKc0mTspfuEjlfqA4YywcwQK2Amcf6TDOwaRLg7Vwdu4bZzyvBZp4bjt1RRjQ5MDnOZahxMrt2l5v9w==",
-      "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "5.36.2",
         "@typescript-eslint/visitor-keys": "5.36.2",
@@ -7051,7 +7039,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.36.2.tgz",
       "integrity": "sha512-BtRvSR6dEdrNt7Net2/XDjbYKU5Ml6GqJgVfXT0CxTCJlnIqK7rAGreuWKMT2t8cFUT2Msv5oxw0GMRD7T5J7A==",
-      "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "5.36.2",
         "eslint-visitor-keys": "^3.3.0"
@@ -7068,7 +7055,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -7077,7 +7063,6 @@
       "version": "7.3.7",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
       "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -7108,7 +7093,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.36.2.tgz",
       "integrity": "sha512-rPQtS5rfijUWLouhy6UmyNquKDPhQjKsaKH0WnY6hl/07lasj8gPaH2UD8xWkePn6SC+jW2i9c2DZVDnL+Dokw==",
-      "dev": true,
       "dependencies": {
         "@typescript-eslint/typescript-estree": "5.36.2",
         "@typescript-eslint/utils": "5.36.2",
@@ -7135,7 +7119,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.36.2.tgz",
       "integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -7148,7 +7131,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.36.2.tgz",
       "integrity": "sha512-8fyH+RfbKc0mTspfuEjlfqA4YywcwQK2Amcf6TDOwaRLg7Vwdu4bZzyvBZp4bjt1RRjQ5MDnOZahxMrt2l5v9w==",
-      "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "5.36.2",
         "@typescript-eslint/visitor-keys": "5.36.2",
@@ -7175,7 +7157,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.36.2.tgz",
       "integrity": "sha512-BtRvSR6dEdrNt7Net2/XDjbYKU5Ml6GqJgVfXT0CxTCJlnIqK7rAGreuWKMT2t8cFUT2Msv5oxw0GMRD7T5J7A==",
-      "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "5.36.2",
         "eslint-visitor-keys": "^3.3.0"
@@ -7192,7 +7173,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -7201,7 +7181,6 @@
       "version": "7.3.7",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
       "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -7268,7 +7247,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.36.2.tgz",
       "integrity": "sha512-uNcopWonEITX96v9pefk9DC1bWMdkweeSsewJ6GeC7L6j2t0SJywisgkr9wUTtXk90fi2Eljj90HSHm3OGdGRg==",
-      "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "@typescript-eslint/scope-manager": "5.36.2",
@@ -7292,7 +7270,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.36.2.tgz",
       "integrity": "sha512-cNNP51L8SkIFSfce8B1NSUBTJTu2Ts4nWeWbFrdaqjmn9yKrAaJUBHkyTZc0cL06OFHpb+JZq5AUHROS398Orw==",
-      "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "5.36.2",
         "@typescript-eslint/visitor-keys": "5.36.2"
@@ -7309,7 +7286,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.36.2.tgz",
       "integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -7322,7 +7298,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.36.2.tgz",
       "integrity": "sha512-8fyH+RfbKc0mTspfuEjlfqA4YywcwQK2Amcf6TDOwaRLg7Vwdu4bZzyvBZp4bjt1RRjQ5MDnOZahxMrt2l5v9w==",
-      "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "5.36.2",
         "@typescript-eslint/visitor-keys": "5.36.2",
@@ -7349,7 +7324,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.36.2.tgz",
       "integrity": "sha512-BtRvSR6dEdrNt7Net2/XDjbYKU5Ml6GqJgVfXT0CxTCJlnIqK7rAGreuWKMT2t8cFUT2Msv5oxw0GMRD7T5J7A==",
-      "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "5.36.2",
         "eslint-visitor-keys": "^3.3.0"
@@ -7366,7 +7340,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -7375,7 +7348,6 @@
       "version": "7.3.7",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
       "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -14221,7 +14193,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.28.0.tgz",
       "integrity": "sha512-UMfH0VSjP0G4p3EWirscJEQ/cHqnT/iuH6oNZOB94nBjWbMnhGEPxsZm1eyIW0C/9jLI0Fow4W5DXLjEI7mn1g==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.2",
@@ -14792,7 +14763,6 @@
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
       "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.10.4"
       }
@@ -14801,7 +14771,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -14817,7 +14786,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
       "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-      "dev": true,
       "dependencies": {
         "eslint-visitor-keys": "^1.1.0"
       },
@@ -14832,7 +14800,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -14841,7 +14808,6 @@
       "version": "13.17.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
       "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
-      "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -14856,7 +14822,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -14864,14 +14829,12 @@
     "node_modules/eslint/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/eslint/node_modules/type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -21119,7 +21082,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -35230,7 +35192,8 @@
         "ajv-errors": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
-          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ=="
+          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+          "requires": {}
         },
         "form-data": {
           "version": "4.0.0",
@@ -35250,9 +35213,9 @@
       }
     },
     "@dcl/builder-templates": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@dcl/builder-templates/-/builder-templates-0.1.1.tgz",
-      "integrity": "sha512-YI/6gfMf4PNQo5ZmADgqlFrvDYb8Y0gErRJ72kL1Om4xnCgKNZ6lTJ5RJmJzriILgGNPjD6nnuTJkbLNCyR4Sw=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@dcl/builder-templates/-/builder-templates-0.2.0.tgz",
+      "integrity": "sha512-n7BTTOyeFJbZicGcLGzhFlVx7I+kVYOgJlFDaFYecdR2iGBLa1Y2sFLrTpMbSHJpt9dIPGdNbdmpEhDgQpWI+w=="
     },
     "@dcl/catalyst-contracts": {
       "version": "4.0.2",
@@ -35360,12 +35323,14 @@
         "ajv-errors": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
-          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ=="
+          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+          "requires": {}
         },
         "ws": {
           "version": "8.15.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.15.1.tgz",
-          "integrity": "sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ=="
+          "integrity": "sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ==",
+          "requires": {}
         }
       }
     },
@@ -35466,7 +35431,8 @@
         "ajv-errors": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
-          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ=="
+          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+          "requires": {}
         }
       }
     },
@@ -35548,7 +35514,8 @@
         "ajv-errors": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
-          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ=="
+          "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+          "requires": {}
         },
         "brace-expansion": {
           "version": "2.0.1",
@@ -36197,7 +36164,8 @@
         "ws": {
           "version": "7.4.6",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
+          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+          "requires": {}
         }
       }
     },
@@ -36860,7 +36828,8 @@
     "@magic-sdk/commons": {
       "version": "17.4.1",
       "resolved": "https://registry.npmjs.org/@magic-sdk/commons/-/commons-17.4.1.tgz",
-      "integrity": "sha512-1YXNV4WBkYcNKC87zDdUqY5fTUDpns1XUNiFSsCPitqggbxeNtLE+VAj7KbqB2Ea2xdkKRRlQeP4OMgpb42jSw=="
+      "integrity": "sha512-1YXNV4WBkYcNKC87zDdUqY5fTUDpns1XUNiFSsCPitqggbxeNtLE+VAj7KbqB2Ea2xdkKRRlQeP4OMgpb42jSw==",
+      "requires": {}
     },
     "@magic-sdk/provider": {
       "version": "21.4.1",
@@ -37217,7 +37186,8 @@
         "ajv-keywords": {
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+          "requires": {}
         },
         "json-schema-traverse": {
           "version": "0.4.1",
@@ -37878,7 +37848,6 @@
       "version": "8.20.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
       "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -37963,8 +37932,7 @@
     "@types/aria-query": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
-      "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
-      "dev": true
+      "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q=="
     },
     "@types/babel__core": {
       "version": "7.1.19",
@@ -38578,7 +38546,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.36.2.tgz",
       "integrity": "sha512-OwwR8LRwSnI98tdc2z7mJYgY60gf7I9ZfGjN5EjCwwns9bdTuQfAXcsjSB2wSQ/TVNYSGKf4kzVXbNGaZvwiXw==",
-      "dev": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.36.2",
         "@typescript-eslint/type-utils": "5.36.2",
@@ -38595,7 +38562,6 @@
           "version": "5.36.2",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.36.2.tgz",
           "integrity": "sha512-cNNP51L8SkIFSfce8B1NSUBTJTu2Ts4nWeWbFrdaqjmn9yKrAaJUBHkyTZc0cL06OFHpb+JZq5AUHROS398Orw==",
-          "dev": true,
           "requires": {
             "@typescript-eslint/types": "5.36.2",
             "@typescript-eslint/visitor-keys": "5.36.2"
@@ -38604,14 +38570,12 @@
         "@typescript-eslint/types": {
           "version": "5.36.2",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.36.2.tgz",
-          "integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ==",
-          "dev": true
+          "integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ=="
         },
         "@typescript-eslint/visitor-keys": {
           "version": "5.36.2",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.36.2.tgz",
           "integrity": "sha512-BtRvSR6dEdrNt7Net2/XDjbYKU5Ml6GqJgVfXT0CxTCJlnIqK7rAGreuWKMT2t8cFUT2Msv5oxw0GMRD7T5J7A==",
-          "dev": true,
           "requires": {
             "@typescript-eslint/types": "5.36.2",
             "eslint-visitor-keys": "^3.3.0"
@@ -38620,14 +38584,12 @@
         "eslint-visitor-keys": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-          "dev": true
+          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA=="
         },
         "semver": {
           "version": "7.3.7",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
           "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -38651,7 +38613,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.36.2.tgz",
       "integrity": "sha512-qS/Kb0yzy8sR0idFspI9Z6+t7mqk/oRjnAYfewG+VN73opAUvmYL3oPIMmgOX6CnQS6gmVIXGshlb5RY/R22pA==",
-      "dev": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.36.2",
         "@typescript-eslint/types": "5.36.2",
@@ -38663,7 +38624,6 @@
           "version": "5.36.2",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.36.2.tgz",
           "integrity": "sha512-cNNP51L8SkIFSfce8B1NSUBTJTu2Ts4nWeWbFrdaqjmn9yKrAaJUBHkyTZc0cL06OFHpb+JZq5AUHROS398Orw==",
-          "dev": true,
           "requires": {
             "@typescript-eslint/types": "5.36.2",
             "@typescript-eslint/visitor-keys": "5.36.2"
@@ -38672,14 +38632,12 @@
         "@typescript-eslint/types": {
           "version": "5.36.2",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.36.2.tgz",
-          "integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ==",
-          "dev": true
+          "integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ=="
         },
         "@typescript-eslint/typescript-estree": {
           "version": "5.36.2",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.36.2.tgz",
           "integrity": "sha512-8fyH+RfbKc0mTspfuEjlfqA4YywcwQK2Amcf6TDOwaRLg7Vwdu4bZzyvBZp4bjt1RRjQ5MDnOZahxMrt2l5v9w==",
-          "dev": true,
           "requires": {
             "@typescript-eslint/types": "5.36.2",
             "@typescript-eslint/visitor-keys": "5.36.2",
@@ -38694,7 +38652,6 @@
           "version": "5.36.2",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.36.2.tgz",
           "integrity": "sha512-BtRvSR6dEdrNt7Net2/XDjbYKU5Ml6GqJgVfXT0CxTCJlnIqK7rAGreuWKMT2t8cFUT2Msv5oxw0GMRD7T5J7A==",
-          "dev": true,
           "requires": {
             "@typescript-eslint/types": "5.36.2",
             "eslint-visitor-keys": "^3.3.0"
@@ -38703,14 +38660,12 @@
         "eslint-visitor-keys": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-          "dev": true
+          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA=="
         },
         "semver": {
           "version": "7.3.7",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
           "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -38730,7 +38685,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.36.2.tgz",
       "integrity": "sha512-rPQtS5rfijUWLouhy6UmyNquKDPhQjKsaKH0WnY6hl/07lasj8gPaH2UD8xWkePn6SC+jW2i9c2DZVDnL+Dokw==",
-      "dev": true,
       "requires": {
         "@typescript-eslint/typescript-estree": "5.36.2",
         "@typescript-eslint/utils": "5.36.2",
@@ -38741,14 +38695,12 @@
         "@typescript-eslint/types": {
           "version": "5.36.2",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.36.2.tgz",
-          "integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ==",
-          "dev": true
+          "integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ=="
         },
         "@typescript-eslint/typescript-estree": {
           "version": "5.36.2",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.36.2.tgz",
           "integrity": "sha512-8fyH+RfbKc0mTspfuEjlfqA4YywcwQK2Amcf6TDOwaRLg7Vwdu4bZzyvBZp4bjt1RRjQ5MDnOZahxMrt2l5v9w==",
-          "dev": true,
           "requires": {
             "@typescript-eslint/types": "5.36.2",
             "@typescript-eslint/visitor-keys": "5.36.2",
@@ -38763,7 +38715,6 @@
           "version": "5.36.2",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.36.2.tgz",
           "integrity": "sha512-BtRvSR6dEdrNt7Net2/XDjbYKU5Ml6GqJgVfXT0CxTCJlnIqK7rAGreuWKMT2t8cFUT2Msv5oxw0GMRD7T5J7A==",
-          "dev": true,
           "requires": {
             "@typescript-eslint/types": "5.36.2",
             "eslint-visitor-keys": "^3.3.0"
@@ -38772,14 +38723,12 @@
         "eslint-visitor-keys": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-          "dev": true
+          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA=="
         },
         "semver": {
           "version": "7.3.7",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
           "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -38819,7 +38768,6 @@
       "version": "5.36.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.36.2.tgz",
       "integrity": "sha512-uNcopWonEITX96v9pefk9DC1bWMdkweeSsewJ6GeC7L6j2t0SJywisgkr9wUTtXk90fi2Eljj90HSHm3OGdGRg==",
-      "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
         "@typescript-eslint/scope-manager": "5.36.2",
@@ -38833,7 +38781,6 @@
           "version": "5.36.2",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.36.2.tgz",
           "integrity": "sha512-cNNP51L8SkIFSfce8B1NSUBTJTu2Ts4nWeWbFrdaqjmn9yKrAaJUBHkyTZc0cL06OFHpb+JZq5AUHROS398Orw==",
-          "dev": true,
           "requires": {
             "@typescript-eslint/types": "5.36.2",
             "@typescript-eslint/visitor-keys": "5.36.2"
@@ -38842,14 +38789,12 @@
         "@typescript-eslint/types": {
           "version": "5.36.2",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.36.2.tgz",
-          "integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ==",
-          "dev": true
+          "integrity": "sha512-9OJSvvwuF1L5eS2EQgFUbECb99F0mwq501w0H0EkYULkhFa19Qq7WFbycdw1PexAc929asupbZcgjVIe6OK/XQ=="
         },
         "@typescript-eslint/typescript-estree": {
           "version": "5.36.2",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.36.2.tgz",
           "integrity": "sha512-8fyH+RfbKc0mTspfuEjlfqA4YywcwQK2Amcf6TDOwaRLg7Vwdu4bZzyvBZp4bjt1RRjQ5MDnOZahxMrt2l5v9w==",
-          "dev": true,
           "requires": {
             "@typescript-eslint/types": "5.36.2",
             "@typescript-eslint/visitor-keys": "5.36.2",
@@ -38864,7 +38809,6 @@
           "version": "5.36.2",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.36.2.tgz",
           "integrity": "sha512-BtRvSR6dEdrNt7Net2/XDjbYKU5Ml6GqJgVfXT0CxTCJlnIqK7rAGreuWKMT2t8cFUT2Msv5oxw0GMRD7T5J7A==",
-          "dev": true,
           "requires": {
             "@typescript-eslint/types": "5.36.2",
             "eslint-visitor-keys": "^3.3.0"
@@ -38873,14 +38817,12 @@
         "eslint-visitor-keys": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-          "dev": true
+          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA=="
         },
         "semver": {
           "version": "7.3.7",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
           "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -39623,7 +39565,8 @@
     "@well-known-components/logger": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@well-known-components/logger/-/logger-3.1.3.tgz",
-      "integrity": "sha512-tTjD27CdfU4SVe+kPfjRbPSqdrw0Crg+M31RNejinCuMEBtEGbhYLtB1M4gn+PSTy2Oi3cI3iOdeQ1xVhMSerQ=="
+      "integrity": "sha512-tTjD27CdfU4SVe+kPfjRbPSqdrw0Crg+M31RNejinCuMEBtEGbhYLtB1M4gn+PSTy2Oi3cI3iOdeQ1xVhMSerQ==",
+      "requires": {}
     },
     "@well-known-components/metrics": {
       "version": "2.0.1",
@@ -39726,7 +39669,8 @@
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -39794,7 +39738,8 @@
     "ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+      "requires": {}
     },
     "ajv-formats": {
       "version": "2.1.1",
@@ -40625,7 +40570,8 @@
         "ajv-keywords": {
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+          "requires": {}
         },
         "json-schema-traverse": {
           "version": "0.4.1",
@@ -40715,7 +40661,8 @@
     "babel-plugin-named-asset-import": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz",
-      "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q=="
+      "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==",
+      "requires": {}
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.3.1",
@@ -42668,7 +42615,8 @@
         "ajv-keywords": {
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+          "requires": {}
         },
         "json-schema-traverse": {
           "version": "0.4.1",
@@ -43070,7 +43018,8 @@
     "dcl-scene-writer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/dcl-scene-writer/-/dcl-scene-writer-1.1.2.tgz",
-      "integrity": "sha512-1GrnacmjHSNxhHwjbnAc3MzN8xZG3tFSFEZ9Tb/njHPuxKEmoYaawfVnlUcUehHaKsQsJdpRMGdOvH/QILNDlw=="
+      "integrity": "sha512-1GrnacmjHSNxhHwjbnAc3MzN8xZG3tFSFEZ9Tb/njHPuxKEmoYaawfVnlUcUehHaKsQsJdpRMGdOvH/QILNDlw==",
+      "requires": {}
     },
     "debug": {
       "version": "4.3.4",
@@ -43275,7 +43224,8 @@
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "ansi-styles": {
           "version": "3.2.1",
@@ -44442,7 +44392,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.28.0.tgz",
       "integrity": "sha512-UMfH0VSjP0G4p3EWirscJEQ/cHqnT/iuH6oNZOB94nBjWbMnhGEPxsZm1eyIW0C/9jLI0Fow4W5DXLjEI7mn1g==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.2",
@@ -44489,7 +44438,6 @@
           "version": "7.12.11",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
           "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.10.4"
           }
@@ -44498,7 +44446,6 @@
           "version": "6.12.6",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
           "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -44510,7 +44457,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
           "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-          "dev": true,
           "requires": {
             "eslint-visitor-keys": "^1.1.0"
           },
@@ -44518,8 +44464,7 @@
             "eslint-visitor-keys": {
               "version": "1.3.0",
               "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-              "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-              "dev": true
+              "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
             }
           }
         },
@@ -44527,7 +44472,6 @@
           "version": "13.17.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
           "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
-          "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -44535,20 +44479,17 @@
         "ignore": {
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-          "dev": true
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
         },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "type-fest": {
           "version": "0.20.2",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-          "dev": true
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
       }
     },
@@ -44556,7 +44497,8 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-react-app": {
       "version": "6.0.0",
@@ -44785,7 +44727,8 @@
     "eslint-plugin-react-hooks": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
-      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g=="
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "requires": {}
     },
     "eslint-plugin-testing-library": {
       "version": "3.10.2",
@@ -48251,7 +48194,8 @@
     "isomorphic-ws": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "requires": {}
     },
     "isstream": {
       "version": "0.1.2",
@@ -48913,7 +48857,8 @@
     "jest-pnp-resolver": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w=="
+      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -49862,8 +49807,7 @@
     "lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="
     },
     "mafmt": {
       "version": "7.1.0",
@@ -50130,7 +50074,8 @@
         "ajv-keywords": {
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+          "requires": {}
         },
         "json-schema-traverse": {
           "version": "0.4.1",
@@ -52172,7 +52117,8 @@
         "ajv-keywords": {
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+          "requires": {}
         },
         "json-schema-traverse": {
           "version": "0.4.1",
@@ -54131,7 +54077,8 @@
     "react-virtualized-auto-sizer": {
       "version": "1.0.20",
       "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.20.tgz",
-      "integrity": "sha512-OdIyHwj4S4wyhbKHOKM1wLSj/UDXm839Z3Cvfg2a9j+He6yDa6i5p0qQvEiCnyQlGO/HyfSnigQwuxvYalaAXA=="
+      "integrity": "sha512-OdIyHwj4S4wyhbKHOKM1wLSj/UDXm839Z3Cvfg2a9j+He6yDa6i5p0qQvEiCnyQlGO/HyfSnigQwuxvYalaAXA==",
+      "requires": {}
     },
     "read-pkg": {
       "version": "5.2.0",
@@ -55005,7 +54952,8 @@
         "ws": {
           "version": "8.15.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.15.1.tgz",
-          "integrity": "sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ=="
+          "integrity": "sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ==",
+          "requires": {}
         }
       }
     },
@@ -55358,7 +55306,8 @@
         "ajv-keywords": {
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+          "requires": {}
         },
         "json-schema-traverse": {
           "version": "0.4.1",
@@ -56454,7 +56403,8 @@
         "ajv-keywords": {
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+          "requires": {}
         },
         "json-schema-traverse": {
           "version": "0.4.1",
@@ -57176,7 +57126,8 @@
     "ts-essentials": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
-      "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ=="
+      "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==",
+      "requires": {}
     },
     "ts-invariant": {
       "version": "0.4.4",
@@ -57903,7 +57854,8 @@
     "use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "utf-8-validate": {
       "version": "5.0.10",
@@ -58593,7 +58545,8 @@
         "ajv-keywords": {
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+          "requires": {}
         },
         "braces": {
           "version": "2.3.2",
@@ -58917,7 +58870,8 @@
         "ajv-keywords": {
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+          "requires": {}
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -59855,7 +59809,8 @@
     "ws": {
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
-      "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw=="
+      "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
+      "requires": {}
     },
     "xhr": {
       "version": "2.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@babylonjs/core": "^4.2.0",
         "@babylonjs/loaders": "^4.2.0",
         "@dcl/builder-client": "^3.3.0",
+        "@dcl/builder-templates": "^0.0.0-20231218153107.commit-5755a71",
         "@dcl/content-hash-tree": "^1.1.3",
         "@dcl/crypto": "^3.0.1",
         "@dcl/hashing": "^3.0.4",
@@ -2261,6 +2262,11 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/@dcl/builder-templates": {
+      "version": "0.0.0-20231218153107.commit-5755a71",
+      "resolved": "https://registry.npmjs.org/@dcl/builder-templates/-/builder-templates-0.0.0-20231218153107.commit-5755a71.tgz",
+      "integrity": "sha512-oqVlZDn0wDQ+GIzUnGSPbvc3YOtmMbjlh61tdHWNDus5Y+ifu5NMpJzjcsyaBoL/OjL03fZ1fcATwYX6u0ZF+g=="
     },
     "node_modules/@dcl/catalyst-contracts": {
       "version": "4.0.2",
@@ -6517,12 +6523,25 @@
       "integrity": "sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw=="
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
-      "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==",
       "dependencies": {
         "@types/node": "*",
-        "form-data": "^3.0.0"
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -35230,6 +35249,11 @@
         }
       }
     },
+    "@dcl/builder-templates": {
+      "version": "0.0.0-20231218153107.commit-5755a71",
+      "resolved": "https://registry.npmjs.org/@dcl/builder-templates/-/builder-templates-0.0.0-20231218153107.commit-5755a71.tgz",
+      "integrity": "sha512-oqVlZDn0wDQ+GIzUnGSPbvc3YOtmMbjlh61tdHWNDus5Y+ifu5NMpJzjcsyaBoL/OjL03fZ1fcATwYX6u0ZF+g=="
+    },
     "@dcl/catalyst-contracts": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@dcl/catalyst-contracts/-/catalyst-contracts-4.0.2.tgz",
@@ -38240,12 +38264,24 @@
       "integrity": "sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw=="
     },
     "@types/node-fetch": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
-      "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==",
       "requires": {
         "@types/node": "*",
-        "form-data": "^3.0.0"
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "@types/normalize-package-data": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babylonjs/core": "^4.2.0",
         "@babylonjs/loaders": "^4.2.0",
         "@dcl/builder-client": "^3.3.0",
-        "@dcl/builder-templates": "^0.0.0-20231218153107.commit-5755a71",
+        "@dcl/builder-templates": "^0.0.0-20231218185049.commit-1aa54da",
         "@dcl/content-hash-tree": "^1.1.3",
         "@dcl/crypto": "^3.0.1",
         "@dcl/hashing": "^3.0.4",
@@ -2264,9 +2264,9 @@
       }
     },
     "node_modules/@dcl/builder-templates": {
-      "version": "0.0.0-20231218153107.commit-5755a71",
-      "resolved": "https://registry.npmjs.org/@dcl/builder-templates/-/builder-templates-0.0.0-20231218153107.commit-5755a71.tgz",
-      "integrity": "sha512-oqVlZDn0wDQ+GIzUnGSPbvc3YOtmMbjlh61tdHWNDus5Y+ifu5NMpJzjcsyaBoL/OjL03fZ1fcATwYX6u0ZF+g=="
+      "version": "0.0.0-20231218185049.commit-1aa54da",
+      "resolved": "https://registry.npmjs.org/@dcl/builder-templates/-/builder-templates-0.0.0-20231218185049.commit-1aa54da.tgz",
+      "integrity": "sha512-1GQzfdbYFORQL92Fcbsmv7Y/xvMsWlGJJGacKA8SYmhMfEEWlshSwMXyylo2LwmhNy7pvWJ3hkQlXU0s91bdmA=="
     },
     "node_modules/@dcl/catalyst-contracts": {
       "version": "4.0.2",
@@ -35250,9 +35250,9 @@
       }
     },
     "@dcl/builder-templates": {
-      "version": "0.0.0-20231218153107.commit-5755a71",
-      "resolved": "https://registry.npmjs.org/@dcl/builder-templates/-/builder-templates-0.0.0-20231218153107.commit-5755a71.tgz",
-      "integrity": "sha512-oqVlZDn0wDQ+GIzUnGSPbvc3YOtmMbjlh61tdHWNDus5Y+ifu5NMpJzjcsyaBoL/OjL03fZ1fcATwYX6u0ZF+g=="
+      "version": "0.0.0-20231218185049.commit-1aa54da",
+      "resolved": "https://registry.npmjs.org/@dcl/builder-templates/-/builder-templates-0.0.0-20231218185049.commit-1aa54da.tgz",
+      "integrity": "sha512-1GQzfdbYFORQL92Fcbsmv7Y/xvMsWlGJJGacKA8SYmhMfEEWlshSwMXyylo2LwmhNy7pvWJ3hkQlXU0s91bdmA=="
     },
     "@dcl/catalyst-contracts": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@babylonjs/core": "^4.2.0",
     "@babylonjs/loaders": "^4.2.0",
     "@dcl/builder-client": "^3.3.0",
+    "@dcl/builder-templates": "^0.0.0-20231218153107.commit-5755a71",
     "@dcl/content-hash-tree": "^1.1.3",
     "@dcl/crypto": "^3.0.1",
     "@dcl/hashing": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@babylonjs/core": "^4.2.0",
     "@babylonjs/loaders": "^4.2.0",
     "@dcl/builder-client": "^3.3.0",
-    "@dcl/builder-templates": "^0.1.1",
+    "@dcl/builder-templates": "^0.2.0",
     "@dcl/content-hash-tree": "^1.1.3",
     "@dcl/crypto": "^3.0.1",
     "@dcl/hashing": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@babylonjs/core": "^4.2.0",
     "@babylonjs/loaders": "^4.2.0",
     "@dcl/builder-client": "^3.3.0",
-    "@dcl/builder-templates": "^0.0.0-20231218185049.commit-1aa54da",
+    "@dcl/builder-templates": "^0.1.1",
     "@dcl/content-hash-tree": "^1.1.3",
     "@dcl/crypto": "^3.0.1",
     "@dcl/hashing": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@babylonjs/core": "^4.2.0",
     "@babylonjs/loaders": "^4.2.0",
     "@dcl/builder-client": "^3.3.0",
-    "@dcl/builder-templates": "^0.0.0-20231218153107.commit-5755a71",
+    "@dcl/builder-templates": "^0.0.0-20231218185049.commit-1aa54da",
     "@dcl/content-hash-tree": "^1.1.3",
     "@dcl/crypto": "^3.0.1",
     "@dcl/hashing": "^3.0.4",

--- a/src/components/Modals/CustomLayoutModal/CustomLayoutModal.container.ts
+++ b/src/components/Modals/CustomLayoutModal/CustomLayoutModal.container.ts
@@ -12,13 +12,14 @@ import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors
 import { getLoadingProjectIds } from 'modules/sync/selectors'
 import { SDKVersion } from 'modules/scene/types'
 import { Project } from 'modules/project/types'
-import { getIsSDK7TemplatesEnabled } from 'modules/features/selectors'
+import { getIsCreateSceneOnlySDK7Enabled, getIsSDK7TemplatesEnabled } from 'modules/features/selectors'
 
 const mapState = (state: RootState): MapStateProps => {
   return {
     isLoading: isLoadingType(getProjectLoading(state), LOAD_MANIFEST_REQUEST) || getLoadingProjectIds(state).length > 0,
     error: getProjectError(state),
-    isSDK7TemplatesEnabled: getIsSDK7TemplatesEnabled(state)
+    isSDK7TemplatesEnabled: getIsSDK7TemplatesEnabled(state),
+    isCreateSceneOnlySDK7Enabled: getIsCreateSceneOnlySDK7Enabled(state)
   }
 }
 

--- a/src/components/Modals/CustomLayoutModal/CustomLayoutModal.container.ts
+++ b/src/components/Modals/CustomLayoutModal/CustomLayoutModal.container.ts
@@ -12,11 +12,13 @@ import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors
 import { getLoadingProjectIds } from 'modules/sync/selectors'
 import { SDKVersion } from 'modules/scene/types'
 import { Project } from 'modules/project/types'
+import { getIsSDK7TemplatesEnabled } from 'modules/features/selectors'
 
 const mapState = (state: RootState): MapStateProps => {
   return {
     isLoading: isLoadingType(getProjectLoading(state), LOAD_MANIFEST_REQUEST) || getLoadingProjectIds(state).length > 0,
-    error: getProjectError(state)
+    error: getProjectError(state),
+    isSDK7TemplatesEnabled: getIsSDK7TemplatesEnabled(state)
   }
 }
 

--- a/src/components/Modals/CustomLayoutModal/CustomLayoutModal.tsx
+++ b/src/components/Modals/CustomLayoutModal/CustomLayoutModal.tsx
@@ -104,7 +104,7 @@ export default class CustomLayoutModal extends React.PureComponent<Props, State>
   }
 
   renderModalActions = () => {
-    const { isSDK7TemplatesEnabled } = this.props
+    const { isCreateSceneOnlySDK7Enabled } = this.props
     const { hasError, name, step } = this.state
 
     switch (step) {
@@ -128,7 +128,7 @@ export default class CustomLayoutModal extends React.PureComponent<Props, State>
             <Button
               primary
               disabled={hasError || !name}
-              onClick={isSDK7TemplatesEnabled ? this.handleSubmit.bind(this, SDKVersion.SDK7) : this.handleNext}
+              onClick={isCreateSceneOnlySDK7Enabled ? this.handleSubmit.bind(this, SDKVersion.SDK7) : this.handleNext}
             >
               {t('global.next')}
             </Button>

--- a/src/components/Modals/CustomLayoutModal/CustomLayoutModal.tsx
+++ b/src/components/Modals/CustomLayoutModal/CustomLayoutModal.tsx
@@ -27,6 +27,7 @@ export default class CustomLayoutModal extends React.PureComponent<Props, State>
   handleBack = () => {
     const { step } = this.state
     switch (step) {
+      // TODO: remove this after removing the SDK7_TEMPLATES feature flag
       case SceneCreationStep.SDK:
         this.setState({ step: SceneCreationStep.SIZE })
         break
@@ -45,15 +46,16 @@ export default class CustomLayoutModal extends React.PureComponent<Props, State>
     const { step } = this.state
     if (step === SceneCreationStep.INFO) {
       this.setState({ step: SceneCreationStep.SIZE })
+      // TODO: remove this after removing the SDK7_TEMPLATES feature flag
     } else if (step === SceneCreationStep.SIZE) {
       this.setState({ step: SceneCreationStep.SDK })
     }
   }
 
   handleSubmit = (sdk: SDKVersion) => {
-    const { onCreateProject, onClose } = this.props
+    const { onCreateProject, onClose, isSDK7TemplatesEnabled } = this.props
     const { name, description, rows, cols } = this.state
-    onCreateProject(name, description, fromLayout(rows, cols), sdk)
+    onCreateProject(name, description, fromLayout(rows, cols), isSDK7TemplatesEnabled ? SDKVersion.SDK7 : sdk)
     onClose()
   }
 
@@ -64,6 +66,7 @@ export default class CustomLayoutModal extends React.PureComponent<Props, State>
         return t('create_modal.name_subtitle')
       case SceneCreationStep.SIZE:
         return t('create_modal.size_subtitle')
+      // TODO: remove this after removing the SDK7_TEMPLATES feature flag
       case SceneCreationStep.SDK:
         return t('create_modal.sdk_subtitle')
     }
@@ -101,6 +104,7 @@ export default class CustomLayoutModal extends React.PureComponent<Props, State>
   }
 
   renderModalActions = () => {
+    const { isSDK7TemplatesEnabled } = this.props
     const { hasError, name, step } = this.state
 
     switch (step) {
@@ -121,11 +125,16 @@ export default class CustomLayoutModal extends React.PureComponent<Props, State>
             <Button secondary onClick={this.handleBack}>
               {t('global.back')}
             </Button>
-            <Button primary disabled={hasError || !name} onClick={this.handleNext}>
+            <Button
+              primary
+              disabled={hasError || !name}
+              onClick={isSDK7TemplatesEnabled ? this.handleSubmit.bind(this, SDKVersion.SDK7) : this.handleNext}
+            >
               {t('global.next')}
             </Button>
           </div>
         )
+      // TODO: remove this after removing the SDK7_TEMPLATES feature flag
       case SceneCreationStep.SDK:
         return (
           <div className={styles.sdkActionContainer}>
@@ -147,6 +156,7 @@ export default class CustomLayoutModal extends React.PureComponent<Props, State>
     return (
       <Modal name={modalName}>
         <ModalNavigation
+          // TODO: remove this after removing the SDK7_TEMPLATES feature flag
           title={step !== SceneCreationStep.SDK ? t('create_modal.title') : t('create_modal.sdk_title')}
           subtitle={this.getSubtitle()}
           onBack={step !== SceneCreationStep.INFO ? this.handleBack : undefined}

--- a/src/components/Modals/CustomLayoutModal/CustomLayoutModal.types.ts
+++ b/src/components/Modals/CustomLayoutModal/CustomLayoutModal.types.ts
@@ -10,11 +10,13 @@ export type Props = ModalProps & {
   error: string | null
   isLoading: boolean
   onCreateProject: (name: string, description: string, template: Template, sdk: SDKVersion) => void
+  isSDK7TemplatesEnabled: boolean
 }
 
 export enum SceneCreationStep {
   INFO = 'info',
   SIZE = 'size',
+  // TODO: remove this after removing the SDK7_TEMPLATES feature flag
   SDK = 'sdk'
 }
 
@@ -27,6 +29,6 @@ export type State = {
   description: string
 }
 
-export type MapStateProps = Pick<Props, 'error' | 'isLoading'>
+export type MapStateProps = Pick<Props, 'error' | 'isLoading' | 'isSDK7TemplatesEnabled'>
 export type MapDispatchProps = Pick<Props, 'onCreateProject'>
 export type MapDispatch = Dispatch<CreateProjectFromTemplateAction | CallHistoryMethodAction>

--- a/src/components/Modals/CustomLayoutModal/CustomLayoutModal.types.ts
+++ b/src/components/Modals/CustomLayoutModal/CustomLayoutModal.types.ts
@@ -11,6 +11,7 @@ export type Props = ModalProps & {
   isLoading: boolean
   onCreateProject: (name: string, description: string, template: Template, sdk: SDKVersion) => void
   isSDK7TemplatesEnabled: boolean
+  isCreateSceneOnlySDK7Enabled: boolean
 }
 
 export enum SceneCreationStep {
@@ -29,6 +30,6 @@ export type State = {
   description: string
 }
 
-export type MapStateProps = Pick<Props, 'error' | 'isLoading' | 'isSDK7TemplatesEnabled'>
+export type MapStateProps = Pick<Props, 'error' | 'isLoading' | 'isSDK7TemplatesEnabled' | 'isCreateSceneOnlySDK7Enabled'>
 export type MapDispatchProps = Pick<Props, 'onCreateProject'>
 export type MapDispatch = Dispatch<CreateProjectFromTemplateAction | CallHistoryMethodAction>

--- a/src/lib/api/builder.ts
+++ b/src/lib/api/builder.ts
@@ -661,6 +661,7 @@ export class BuilderAPI extends BaseAPI {
     return items.map(fromPoolGroup)
   }
 
+  // TODO: remove this after removing the SDK7_TEMPLATES feature flag
   async fetchTemplates() {
     const { items }: { items: RemoteProject[]; total: number } = await this.request('get', '/templates', {
       retry: retryParams,

--- a/src/modules/common/store.ts
+++ b/src/modules/common/store.ts
@@ -133,7 +133,8 @@ const { storageMiddleware, loadStorageMiddleware } = createStorageMiddleware({
   },
   onError: (err, store) => {
     const isQuotaModalOpen = !!getOpenModals(store.getState())['QuotaExceededModal']
-    if (err instanceof DOMException && err.name === 'QuotaExceededError' && !isQuotaModalOpen) {
+    const isCloneTemplateModalOpen = !!getOpenModals(store.getState())['CloneTemplateModal']
+    if (err instanceof DOMException && err.name === 'QuotaExceededError' && !isQuotaModalOpen && !isCloneTemplateModalOpen) {
       store.dispatch(openModal('QuotaExceededModal'))
     }
   }

--- a/src/modules/features/selectors.spec.ts
+++ b/src/modules/features/selectors.spec.ts
@@ -1,7 +1,12 @@
 import { getIsFeatureEnabled } from 'decentraland-dapps/dist/modules/features/selectors'
 import { ApplicationName } from 'decentraland-dapps/dist/modules/features/types'
 import { RootState } from 'modules/common/types'
-import { getIsMaintenanceEnabled, getIsWorldsForEnsOwnersEnabled } from './selectors'
+import {
+  getIsCreateSceneOnlySDK7Enabled,
+  getIsMaintenanceEnabled,
+  getIsSDK7TemplatesEnabled,
+  getIsWorldsForEnsOwnersEnabled
+} from './selectors'
 import { FeatureName } from './types'
 
 jest.mock('decentraland-dapps/dist/modules/features/selectors')
@@ -53,7 +58,11 @@ describe('when getting if maintainance is enabled', () => {
   })
 })
 
-const ffSelectors = [{ selector: getIsWorldsForEnsOwnersEnabled, app: ApplicationName.BUILDER, feature: FeatureName.WORLDS_FOR_ENS_OWNERS }]
+const ffSelectors = [
+  { selector: getIsWorldsForEnsOwnersEnabled, app: ApplicationName.BUILDER, feature: FeatureName.WORLDS_FOR_ENS_OWNERS },
+  { selector: getIsSDK7TemplatesEnabled, app: ApplicationName.BUILDER, feature: FeatureName.SDK7_TEMPLATES },
+  { selector: getIsCreateSceneOnlySDK7Enabled, app: ApplicationName.BUILDER, feature: FeatureName.CREATE_SCENE_ONLY_SDK7 }
+]
 
 ffSelectors.forEach(({ selector, app, feature }) => {
   describe(`when getting if ${feature} is enabled`, () => {

--- a/src/modules/features/selectors.ts
+++ b/src/modules/features/selectors.ts
@@ -61,3 +61,11 @@ export const getIsSDK7TemplatesEnabled = (state: RootState) => {
     return false
   }
 }
+
+export const getIsCreateSceneOnlySDK7Enabled = (state: RootState) => {
+  try {
+    return getIsFeatureEnabled(state, ApplicationName.BUILDER, FeatureName.CREATE_SCENE_ONLY_SDK7)
+  } catch (e) {
+    return false
+  }
+}

--- a/src/modules/features/selectors.ts
+++ b/src/modules/features/selectors.ts
@@ -53,3 +53,11 @@ export const getIsWorldsForEnsOwnersEnabled = (state: RootState) => {
     return false
   }
 }
+
+export const getIsSDK7TemplatesEnabled = (state: RootState) => {
+  try {
+    return getIsFeatureEnabled(state, ApplicationName.BUILDER, FeatureName.SDK7_TEMPLATES)
+  } catch (e) {
+    return false
+  }
+}

--- a/src/modules/features/types.ts
+++ b/src/modules/features/types.ts
@@ -6,5 +6,6 @@ export enum FeatureName {
   NEW_NAVBAR_DROPDOWN = 'new-navbar-dropdown',
   EMOTES_V2 = 'emotes-2.0',
   SMART_ITEMS = 'smart-items',
-  WORLDS_FOR_ENS_OWNERS = 'worlds-for-ens-owners'
+  WORLDS_FOR_ENS_OWNERS = 'worlds-for-ens-owners',
+  SDK7_TEMPLATES = 'sdk7-templates'
 }

--- a/src/modules/features/types.ts
+++ b/src/modules/features/types.ts
@@ -7,5 +7,6 @@ export enum FeatureName {
   EMOTES_V2 = 'emotes-2.0',
   SMART_ITEMS = 'smart-items',
   WORLDS_FOR_ENS_OWNERS = 'worlds-for-ens-owners',
-  SDK7_TEMPLATES = 'sdk7-templates'
+  SDK7_TEMPLATES = 'sdk7-templates',
+  CREATE_SCENE_ONLY_SDK7 = 'create-scene-only-sdk7'
 }

--- a/src/modules/project/sagas.spec.ts
+++ b/src/modules/project/sagas.spec.ts
@@ -12,6 +12,7 @@ const builderAPI = {
   fetchTemplates: jest.fn()
 } as unknown as BuilderAPI
 
+// TODO: remove this after removing the SDK7_TEMPLATES feature flag
 describe('when handling the loadTemplatesRequest action', () => {
   describe('and the request is successful', () => {
     it('should put a loadTemplatesSuccess action with the project templates', () => {

--- a/src/modules/project/sagas.ts
+++ b/src/modules/project/sagas.ts
@@ -173,13 +173,15 @@ export function* projectSaga(builder: BuilderAPI) {
 
   function* handleDuplicateProjectRequest(action: DuplicateProjectRequestAction) {
     const { project, type, shouldRedirect } = action.payload
+    const isSDK7TemplatesEnabled: boolean = yield select(getIsSDK7TemplatesEnabled)
     const ethAddress: string = yield select(getAddress)
     const scene: Scene = yield getSceneByProjectId(project.id, type)
 
     let thumbnail: string = project.thumbnail
 
     try {
-      if (project.isTemplate) {
+      // TODO: remove this when the SDK7_TEMPLATES feature flag is removed
+      if (!isSDK7TemplatesEnabled && project.isTemplate) {
         thumbnail = yield call(getImageAsDataUrl, `${BUILDER_SERVER_URL}/projects/${project.id}/media/thumbnail.png`)
       } else if (thumbnail && isRemoteURL(thumbnail)) {
         thumbnail = yield call(getImageAsDataUrl, project.thumbnail)

--- a/src/modules/project/sagas.ts
+++ b/src/modules/project/sagas.ts
@@ -71,14 +71,15 @@ import { Gizmo, PreviewType } from 'modules/editor/types'
 import { Pool } from 'modules/pool/types'
 import { loadProfileRequest } from 'decentraland-dapps/dist/modules/profile/actions'
 import { LOGIN_SUCCESS, LoginSuccessAction } from 'modules/identity/actions'
+import { changeLayout, getParcels } from 'modules/inspector/utils'
+import { setInspectorReloading } from 'modules/inspector/actions'
 import { getName } from 'modules/profile/selectors'
 import { getDefaultGroundAsset } from 'modules/deployment/utils'
 import { locations } from 'routing/locations'
 import { downloadZip } from 'lib/zip'
-import { didUpdateLayout, getImageAsDataUrl } from './utils'
+import { didUpdateLayout, getImageAsDataUrl, getTemplate, getTemplates } from './utils'
 import { createFiles, createSDK7Files } from './export'
-import { changeLayout, getParcels } from 'modules/inspector/utils'
-import { setInspectorReloading } from 'modules/inspector/actions'
+import { getIsSDK7TemplatesEnabled } from 'modules/features/selectors'
 
 export function* projectSaga(builder: BuilderAPI) {
   yield takeLatest(CREATE_PROJECT_FROM_TEMPLATE, handleCreateProjectFromTemplate)
@@ -207,7 +208,7 @@ export function* projectSaga(builder: BuilderAPI) {
 
       if (project.isTemplate) {
         yield take(SAVE_PROJECT_SUCCESS)
-        yield put(push(locations.sceneEditor(newProject.id)))
+        yield put(push(scene.sdk6 ? locations.sceneEditor(newProject.id) : locations.inspector(newProject.id)))
       } else if (shouldRedirect) {
         yield put(push(locations.scenes()))
       }
@@ -358,13 +359,19 @@ export function* projectSaga(builder: BuilderAPI) {
   function* handleLoadProjectSceneRequest(action: LoadProjectSceneRequestAction) {
     const { project, type } = action.payload
     try {
-      const scenes: ReturnType<typeof getScenes> = yield select(getScenes)
-      if (scenes && scenes[project.sceneId]) {
-        yield put(loadProjectSceneSuccess(scenes[project.sceneId]))
-        return
+      const isSDK7TemplatesEnabled: boolean = yield select(getIsSDK7TemplatesEnabled)
+      if (isSDK7TemplatesEnabled && type === PreviewType.TEMPLATE) {
+        const template = getTemplate(project.id)
+        yield put(loadProjectSceneSuccess(template.scene))
+      } else {
+        const scenes: ReturnType<typeof getScenes> = yield select(getScenes)
+        if (scenes && scenes[project.sceneId]) {
+          yield put(loadProjectSceneSuccess(scenes[project.sceneId]))
+          return
+        }
+        const manifest: Manifest<Project> = yield call([builder, 'fetchManifest'], project.id, type)
+        yield put(loadProjectSceneSuccess(manifest.scene))
       }
-      const manifest: Manifest<Project> = yield call([builder, 'fetchManifest'], project.id, type)
-      yield put(loadProjectSceneSuccess(manifest.scene))
     } catch (e) {
       yield put(loadProjectSceneFailure(e.message))
     }
@@ -373,8 +380,14 @@ export function* projectSaga(builder: BuilderAPI) {
   function* handleLoadManifestRequest(action: LoadManifestRequestAction) {
     const { id, type } = action.payload
     try {
-      const manifest: Manifest<Project> = yield call([builder, 'fetchManifest'], id, type)
-      yield put(loadManifestSuccess(manifest))
+      const isSDK7TemplatesEnabled: boolean = yield select(getIsSDK7TemplatesEnabled)
+      if (isSDK7TemplatesEnabled && type === PreviewType.TEMPLATE) {
+        const manifest = getTemplate(id)
+        yield put(loadManifestSuccess(manifest))
+      } else {
+        const manifest: Manifest<Project> = yield call([builder, 'fetchManifest'], id, type)
+        yield put(loadManifestSuccess(manifest))
+      }
     } catch (e) {
       yield put(loadManifestFailure(e.message))
     }
@@ -382,7 +395,10 @@ export function* projectSaga(builder: BuilderAPI) {
 
   function* handleLoadTemplatesRequest() {
     try {
-      const projects: Project[] = yield call([builder, 'fetchTemplates'])
+      const isSDK7TemplatesEnabled: boolean = yield select(getIsSDK7TemplatesEnabled)
+      const projects: Project[] = isSDK7TemplatesEnabled
+        ? getTemplates().map(template => template.project)
+        : yield call([builder, 'fetchTemplates'])
       const record: ModelById<Project> = {}
 
       for (const project of projects) {

--- a/src/modules/project/selectors.ts
+++ b/src/modules/project/selectors.ts
@@ -22,7 +22,9 @@ export const getUserProjects = createSelector(getAddress, getData, (address, pro
     const project = projects[projectId]
     const isOwnedByUser = !!project.ethAddress && !!address && isEqual(project.ethAddress, address)
     if (isOwnedByUser || project.ethAddress === null) {
-      record[projectId] = project
+      if (!project.isTemplate) {
+        record[projectId] = project
+      }
     }
     return record
   }, {} as ProjectState['data'])

--- a/src/modules/project/selectors.ts
+++ b/src/modules/project/selectors.ts
@@ -21,10 +21,8 @@ export const getUserProjects = createSelector(getAddress, getData, (address, pro
   return Object.keys(projects).reduce((record, projectId) => {
     const project = projects[projectId]
     const isOwnedByUser = !!project.ethAddress && !!address && isEqual(project.ethAddress, address)
-    if (isOwnedByUser || project.ethAddress === null) {
-      if (!project.isTemplate) {
-        record[projectId] = project
-      }
+    if ((isOwnedByUser || project.ethAddress === null) && !project.isTemplate) {
+      record[projectId] = project
     }
     return record
   }, {} as ProjectState['data'])

--- a/src/modules/project/utils.ts
+++ b/src/modules/project/utils.ts
@@ -1,7 +1,10 @@
-import { Project, Layout } from 'modules/project/types'
+import { Project, Layout, Manifest } from 'modules/project/types'
 import { Coordinate, Rotation } from 'modules/deployment/types'
 import { NO_CACHE_HEADERS } from 'lib/headers'
 import { getDimensions } from 'lib/layout'
+import _templateData from '@dcl/builder-templates/templates.json'
+
+const templates = _templateData.templates as unknown as Manifest[]
 
 export function getProjectDimensions(project: Project): string {
   const { rows, cols } = project.layout
@@ -82,4 +85,17 @@ export async function getImageAsDataUrl(url: string): Promise<string> {
   reader.readAsDataURL(imgBlob)
 
   return out
+}
+
+export function getTemplates(): Manifest[] {
+  return templates
+}
+
+export function getTemplate(projectId: string) {
+  const templates = getTemplates()
+  const template = templates.find(template => template.project.id === projectId)
+  if (!template) {
+    throw new Error(`Could not find template with projectId="${projectId}"`)
+  }
+  return template
 }


### PR DESCRIPTION
This PR does the following:
- Shows templates from `@dcl/builder-templates` package instead of loading them from the Builder Server
- Adds support for SDK7 templates
- Removes the creation flow of SDK6 scenes (if a user has SDK6 scenes they can still open them on the legacy builder).
- Everything is behind feature flags (one for enabling the SDK7 templates and one to enable the create from scratch only with SDK7)