### PR TITLE
fix: wrong feature flag

### DIFF
--- a/src/components/Modals/CustomLayoutModal/CustomLayoutModal.tsx
+++ b/src/components/Modals/CustomLayoutModal/CustomLayoutModal.tsx
@@ -53,9 +53,9 @@ export default class CustomLayoutModal extends React.PureComponent<Props, State>
   }
 
   handleSubmit = (sdk: SDKVersion) => {
-    const { onCreateProject, onClose, isSDK7TemplatesEnabled } = this.props
+    const { onCreateProject, onClose } = this.props
     const { name, description, rows, cols } = this.state
-    onCreateProject(name, description, fromLayout(rows, cols), isSDK7TemplatesEnabled ? SDKVersion.SDK7 : sdk)
+    onCreateProject(name, description, fromLayout(rows, cols), sdk)
     onClose()
   }
 


### PR DESCRIPTION
This PR fixes an issue with feature flags. 

When both feature flags `builder-create-scene-only-sdk7` and `builder-sdk7-templates` are OFF (as it is the case in PRD) everything is fine. When both flags are ON as they were in DEV and STG then everything is fine too. 

The problem is when `builder-sdk7-templates` is ON and `builder-create-scene-only-sdk7` is OFF, then the scene creation flow allows you to choose which SDK version to use, but it will always create the scene using SDK7... this was because the `isSDK7TemplatesEnabled` property was wrongly used in the submit handler of the scene creation flow.. 

This PR fixes that issue so the two feature flags can be used separately, which is necessary to release the SDK7 templates without disabling the creation of SDK6 scenes.