### PR TITLE
chore: Update @dcl/sdk version to 7.4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@dcl/hashing": "^3.0.4",
         "@dcl/mini-rpc": "^1.0.7",
         "@dcl/schemas": "^9.14.0",
-        "@dcl/sdk": "^7.4.3",
+        "@dcl/sdk": "^7.4.5",
         "@dcl/single-sign-on-client": "^0.1.0",
         "@dcl/ui-env": "^1.5.0",
         "@sentry/react": "^7.64.0",
@@ -1906,9 +1906,9 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.3.tgz",
-      "integrity": "sha512-iDBMVp9j/41gcCI2ZA6iHv9myEDT3QYDuJOm0jv10v//whINLIfQZMcXutvtkeLeUxWvj4kiNUMFjvTGtKQR/Q=="
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.5.tgz",
+      "integrity": "sha512-hNhEzABVBMYnmDz87vfn3qXir/XCUqbzorbkyGIfWzLoDFYcCLSpAbAQZ6zcAiaZl9yCYOxYetXNAmab4ci1xQ=="
     },
     "node_modules/@dcl/ecs-math": {
       "version": "2.0.2",
@@ -1926,18 +1926,18 @@
       "integrity": "sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg=="
     },
     "node_modules/@dcl/inspector": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.4.3.tgz",
-      "integrity": "sha512-d+6jGUj9MEUv5qAqEMBwLevQQ+aX90i+yfHZVxBPNrLZWbrP8PZqWnOVH5KA9kZ+tyhTCHAjKUZyMgL022B7ug==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.4.5.tgz",
+      "integrity": "sha512-4ug4qS31Z1/Qwbh0pWDyiRtExaCUoPZb1E5S69DnWLvpVnWC1n07Vo7BXU9vmqJ/JKJvjIUtfSa4bF87kbG+Dg==",
       "dependencies": {
         "@dcl/asset-packs": "^1.12.2",
         "ts-deepmerge": "^7.0.0"
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.4.3.tgz",
-      "integrity": "sha512-lmlVL64WxHHLhYPieCigaZwGsiRM0Li/cfWVL8S2RQuNqTEo6GuMVLFrKrDn7Y9tV7TxbclWdxVvGvLyY/416Q=="
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.4.5.tgz",
+      "integrity": "sha512-EBj9waFym0fvQA4kwe1LCVYichGt/YN4os+m9pkvIOx5Ta/RrkfyTy6fNHuIyBHT2QxM++f+OsMEH2yXu2rAGg=="
     },
     "node_modules/@dcl/linker-dapp": {
       "version": "0.12.0",
@@ -2012,11 +2012,11 @@
       "integrity": "sha512-IPB043+NbQB3om2FlmQGmaRxTokHaSM9o3a7sEL0yJgBb60mukCpMdNXxzdIcemixfV3EhIJQ2G8HgK30XKTkA=="
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.4.3.tgz",
-      "integrity": "sha512-Lu2nLtO4HZgFL7W70u3SjtRG6TXJ6zm5PKYOE3CGTjSsY0HD4DcvJUC7XrRlGzLGvANuMVMPzcWnt8sCC5Z8BA==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.4.5.tgz",
+      "integrity": "sha512-aClH865GKA3i2JdEKaq1SyXSByFkWJn3e7TroKHy5ajyp7hLhqDHQcQytBFwW6WDi24nzQ3JvDMzmCDELC2KeQ==",
       "dependencies": {
-        "@dcl/ecs": "7.4.3",
+        "@dcl/ecs": "7.4.5",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -2075,28 +2075,28 @@
       }
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.4.3.tgz",
-      "integrity": "sha512-y22wP/sG8qKpnpfRcda9E6rLkAlx/XFzzoCotL3MVL4vynU0i/sa0lwwRgKWlUJeMKS2qXm7jCVGsnqt5Dj8Dw==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.4.5.tgz",
+      "integrity": "sha512-QehNZUIpBrUaBX7dME1tIWSOYw/0oCf6g/HsL3DVKi6tK4VlKtd9DgtRFQJO5ezN16oOW37A4zZcAAnF9YteIQ==",
       "dependencies": {
-        "@dcl/ecs": "7.4.3",
+        "@dcl/ecs": "7.4.5",
         "@dcl/ecs-math": "2.0.2",
         "@dcl/explorer": "1.0.160056-20240212151637.commit-33b7e01",
-        "@dcl/js-runtime": "7.4.3",
-        "@dcl/react-ecs": "7.4.3",
-        "@dcl/sdk-commands": "7.4.3",
+        "@dcl/js-runtime": "7.4.5",
+        "@dcl/react-ecs": "7.4.5",
+        "@dcl/sdk-commands": "7.4.5",
         "text-encoding": "0.7.0"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.4.3.tgz",
-      "integrity": "sha512-tBjL/THHaaKtNFhDI539kdohb284fNdzqKmAfbCi77V4mNuWjXRXWOQkOK6Ste4gjW2TZ894wrYVHVqm7PrnHg==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.4.5.tgz",
+      "integrity": "sha512-1h1lcc4Waf1QHcfqhxrNX4ekvSB3nOUkU0SQxsA8KXaxzrJvYjJAjkBARkmRCcDRrjOvXciOEFzIWgxigxFAng==",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.4.3",
+        "@dcl/ecs": "7.4.5",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.4.3",
+        "@dcl/inspector": "7.4.5",
         "@dcl/linker-dapp": "^0.12.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-7716486147.commit-7433b10",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@dcl/hashing": "^3.0.4",
     "@dcl/mini-rpc": "^1.0.7",
     "@dcl/schemas": "^9.14.0",
-    "@dcl/sdk": "^7.4.3",
+    "@dcl/sdk": "^7.4.5",
     "@dcl/single-sign-on-client": "^0.1.0",
     "@dcl/ui-env": "^1.5.0",
     "@sentry/react": "^7.64.0",


### PR DESCRIPTION
This PR upgrades the package `@dcl/sdk` to the version to `7.4.5`