### PR TITLE
fix: Inspector layout

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,6 +13,6 @@ jobs:
           node-version: 18.x
           cache: 'npm'
       - name: Install
-        run: npm i --legacy-peer-deps
+        run: npm ci
       - name: Audit signatures
         run: npm audit signatures

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -12,6 +12,8 @@ jobs:
         with:
           node-version: 18.x
           cache: 'npm'
+      - name: Upgrade npm
+        run: npm i -g npm
       - name: Install
         run: npm ci
       - name: Audit signatures

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@dcl/hashing": "^3.0.4",
         "@dcl/mini-rpc": "^1.0.7",
         "@dcl/schemas": "^9.14.0",
-        "@dcl/sdk": "^7.4.6",
+        "@dcl/sdk": "^7.4.7",
         "@dcl/single-sign-on-client": "^0.1.0",
         "@dcl/ui-env": "^1.5.0",
         "@sentry/react": "^7.64.0",
@@ -1906,9 +1906,9 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.6.tgz",
-      "integrity": "sha512-OzcCmsMVr9JMTArI4tR7gFyn7n33OQ4Ss2riwH13ifv0fP8Par32rKAxzTtRX071b5olfvsDujZUWIa4Ss8jOg=="
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.7.tgz",
+      "integrity": "sha512-k0xYenP9S399Dt+CRPWlRiYH2TQIpe04Gc9K0gDV0Ns1KyNkBJgulwPTWU50ZKZHj1aF1uDpE++vfxyRfzCeHA=="
     },
     "node_modules/@dcl/ecs-math": {
       "version": "2.0.2",
@@ -1926,18 +1926,18 @@
       "integrity": "sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg=="
     },
     "node_modules/@dcl/inspector": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.4.6.tgz",
-      "integrity": "sha512-tRfTqjXJiU1n31cO/IJP0pRWivVjp5X2x305G6KROm7GZUoPepiT2kOQH1d8rF1I2KiVpnVoouSQd+G5E6cMoA==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.4.7.tgz",
+      "integrity": "sha512-0POwSm4wUvC4Dkuv58UGClEDJhXVpNjceWcuzSjqeDw0x+Aw5zJaLce5Fl9oApt+cEgj6E5xrdsq/NL/HWkHWw==",
       "dependencies": {
         "@dcl/asset-packs": "^1.12.2",
         "ts-deepmerge": "^7.0.0"
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.4.6.tgz",
-      "integrity": "sha512-3NdaINSNNwJHsF1SZzjen55HQFMUGCAemymYAxo+KpbkbxpUgaK7AX4IcX5QF5xZEV3UbdPk+HgTgbNrWsdniw=="
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.4.7.tgz",
+      "integrity": "sha512-ZT3QRVPIZV2ASCynoC0Gl/Ix91DL/sUgcFPEXZiBMs8lEmOBTC/ONBuf+nqSKyBPRyKEAqAz4Yea5xasDnc7dg=="
     },
     "node_modules/@dcl/linker-dapp": {
       "version": "0.12.0",
@@ -2012,11 +2012,11 @@
       "integrity": "sha512-IPB043+NbQB3om2FlmQGmaRxTokHaSM9o3a7sEL0yJgBb60mukCpMdNXxzdIcemixfV3EhIJQ2G8HgK30XKTkA=="
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.4.6.tgz",
-      "integrity": "sha512-L/kd0RYz+kRMBtr/htG1ZHkto1BuyME/Qh6XLpD2y9UGAVxNqiN3dtPAgEagaEvn8MbXoXEhD6ogSgIEmGNwww==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.4.7.tgz",
+      "integrity": "sha512-7M/kAchsPB41F2YQFi6yjDCmCLTlsXL3cQBmFBsW8KjQszJ/mIHVvCeEdF2uzCoYz9EFfN+AuWSulWWu0q9sgg==",
       "dependencies": {
-        "@dcl/ecs": "7.4.6",
+        "@dcl/ecs": "7.4.7",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -2075,28 +2075,28 @@
       }
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.4.6.tgz",
-      "integrity": "sha512-q4yYEl4bLWleORPPxPlPKytt+dUzPpm1l29tsIddxS7Bi8XevbxBOMa/NVvW0BAwLXcPoUj/jhIlQ9dodIG2+A==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.4.7.tgz",
+      "integrity": "sha512-U2X4PufRpfVDpb2Bz1hcg62d8vefj/2ezSeViF9sqMl4+ACkS0CTNt2RRTuMRpaerq8BNsOun9gOjZ02abPCaA==",
       "dependencies": {
-        "@dcl/ecs": "7.4.6",
+        "@dcl/ecs": "7.4.7",
         "@dcl/ecs-math": "2.0.2",
         "@dcl/explorer": "1.0.160056-20240212151637.commit-33b7e01",
-        "@dcl/js-runtime": "7.4.6",
-        "@dcl/react-ecs": "7.4.6",
-        "@dcl/sdk-commands": "7.4.6",
+        "@dcl/js-runtime": "7.4.7",
+        "@dcl/react-ecs": "7.4.7",
+        "@dcl/sdk-commands": "7.4.7",
         "text-encoding": "0.7.0"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.4.6.tgz",
-      "integrity": "sha512-fK9iyFL7AiiZPI3Nw7QXJlYJdgBpZCG+4EYdy+cDrjiGuN9L9dKkaCVp6jQd/2BZ3WLJp1sBiCq3u+dnANHBKw==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.4.7.tgz",
+      "integrity": "sha512-UlaGMT603Q0Yh/XwqNqZbp49zViC0p4lC7WMUzfU+zC+7UgVE8P/w4iQdpruiJuXaZ2qY+EcdzBemBnykf6TdA==",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.4.6",
+        "@dcl/ecs": "7.4.7",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.4.6",
+        "@dcl/inspector": "7.4.7",
         "@dcl/linker-dapp": "^0.12.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-7716486147.commit-7433b10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@dcl/hashing": "^3.0.4",
         "@dcl/mini-rpc": "^1.0.7",
         "@dcl/schemas": "^9.14.0",
-        "@dcl/sdk": "^7.4.5",
+        "@dcl/sdk": "^7.4.6",
         "@dcl/single-sign-on-client": "^0.1.0",
         "@dcl/ui-env": "^1.5.0",
         "@sentry/react": "^7.64.0",
@@ -1906,9 +1906,9 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.5.tgz",
-      "integrity": "sha512-hNhEzABVBMYnmDz87vfn3qXir/XCUqbzorbkyGIfWzLoDFYcCLSpAbAQZ6zcAiaZl9yCYOxYetXNAmab4ci1xQ=="
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.6.tgz",
+      "integrity": "sha512-OzcCmsMVr9JMTArI4tR7gFyn7n33OQ4Ss2riwH13ifv0fP8Par32rKAxzTtRX071b5olfvsDujZUWIa4Ss8jOg=="
     },
     "node_modules/@dcl/ecs-math": {
       "version": "2.0.2",
@@ -1926,18 +1926,18 @@
       "integrity": "sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg=="
     },
     "node_modules/@dcl/inspector": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.4.5.tgz",
-      "integrity": "sha512-4ug4qS31Z1/Qwbh0pWDyiRtExaCUoPZb1E5S69DnWLvpVnWC1n07Vo7BXU9vmqJ/JKJvjIUtfSa4bF87kbG+Dg==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.4.6.tgz",
+      "integrity": "sha512-tRfTqjXJiU1n31cO/IJP0pRWivVjp5X2x305G6KROm7GZUoPepiT2kOQH1d8rF1I2KiVpnVoouSQd+G5E6cMoA==",
       "dependencies": {
         "@dcl/asset-packs": "^1.12.2",
         "ts-deepmerge": "^7.0.0"
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.4.5.tgz",
-      "integrity": "sha512-EBj9waFym0fvQA4kwe1LCVYichGt/YN4os+m9pkvIOx5Ta/RrkfyTy6fNHuIyBHT2QxM++f+OsMEH2yXu2rAGg=="
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.4.6.tgz",
+      "integrity": "sha512-3NdaINSNNwJHsF1SZzjen55HQFMUGCAemymYAxo+KpbkbxpUgaK7AX4IcX5QF5xZEV3UbdPk+HgTgbNrWsdniw=="
     },
     "node_modules/@dcl/linker-dapp": {
       "version": "0.12.0",
@@ -2012,11 +2012,11 @@
       "integrity": "sha512-IPB043+NbQB3om2FlmQGmaRxTokHaSM9o3a7sEL0yJgBb60mukCpMdNXxzdIcemixfV3EhIJQ2G8HgK30XKTkA=="
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.4.5.tgz",
-      "integrity": "sha512-aClH865GKA3i2JdEKaq1SyXSByFkWJn3e7TroKHy5ajyp7hLhqDHQcQytBFwW6WDi24nzQ3JvDMzmCDELC2KeQ==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.4.6.tgz",
+      "integrity": "sha512-L/kd0RYz+kRMBtr/htG1ZHkto1BuyME/Qh6XLpD2y9UGAVxNqiN3dtPAgEagaEvn8MbXoXEhD6ogSgIEmGNwww==",
       "dependencies": {
-        "@dcl/ecs": "7.4.5",
+        "@dcl/ecs": "7.4.6",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -2075,28 +2075,28 @@
       }
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.4.5.tgz",
-      "integrity": "sha512-QehNZUIpBrUaBX7dME1tIWSOYw/0oCf6g/HsL3DVKi6tK4VlKtd9DgtRFQJO5ezN16oOW37A4zZcAAnF9YteIQ==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.4.6.tgz",
+      "integrity": "sha512-q4yYEl4bLWleORPPxPlPKytt+dUzPpm1l29tsIddxS7Bi8XevbxBOMa/NVvW0BAwLXcPoUj/jhIlQ9dodIG2+A==",
       "dependencies": {
-        "@dcl/ecs": "7.4.5",
+        "@dcl/ecs": "7.4.6",
         "@dcl/ecs-math": "2.0.2",
         "@dcl/explorer": "1.0.160056-20240212151637.commit-33b7e01",
-        "@dcl/js-runtime": "7.4.5",
-        "@dcl/react-ecs": "7.4.5",
-        "@dcl/sdk-commands": "7.4.5",
+        "@dcl/js-runtime": "7.4.6",
+        "@dcl/react-ecs": "7.4.6",
+        "@dcl/sdk-commands": "7.4.6",
         "text-encoding": "0.7.0"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.4.5.tgz",
-      "integrity": "sha512-1h1lcc4Waf1QHcfqhxrNX4ekvSB3nOUkU0SQxsA8KXaxzrJvYjJAjkBARkmRCcDRrjOvXciOEFzIWgxigxFAng==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.4.6.tgz",
+      "integrity": "sha512-fK9iyFL7AiiZPI3Nw7QXJlYJdgBpZCG+4EYdy+cDrjiGuN9L9dKkaCVp6jQd/2BZ3WLJp1sBiCq3u+dnANHBKw==",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.4.5",
+        "@dcl/ecs": "7.4.6",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.4.5",
+        "@dcl/inspector": "7.4.6",
         "@dcl/linker-dapp": "^0.12.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-7716486147.commit-7433b10",
@@ -3702,9 +3702,9 @@
       }
     },
     "node_modules/@fastify/busboy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
-      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
       "engines": {
         "node": ">=14"
       }
@@ -23100,9 +23100,9 @@
       }
     },
     "node_modules/ts-proto": {
-      "version": "1.167.8",
-      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.167.8.tgz",
-      "integrity": "sha512-HHfwCN7MZgnQ7BhFfeLbg6mZIheqOZ3kGy6/BmBNVVzrk19bCoO6Wkzb5Gb5O7+NmiSd/CBrFh/MnZIoNXEvUw==",
+      "version": "1.167.9",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.167.9.tgz",
+      "integrity": "sha512-zqZ15CzqvupSpoTl/fzOs5gG7SFvj1ENmWeKMgD4Yl2BSx8I5F+qgYkr9EZYMu7Ho7u+QtwzfudROo+/jwM2pg==",
       "dependencies": {
         "case-anything": "^2.1.13",
         "protobufjs": "^7.2.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@dcl/hashing": "^3.0.4",
     "@dcl/mini-rpc": "^1.0.7",
     "@dcl/schemas": "^9.14.0",
-    "@dcl/sdk": "^7.4.6",
+    "@dcl/sdk": "^7.4.7",
     "@dcl/single-sign-on-client": "^0.1.0",
     "@dcl/ui-env": "^1.5.0",
     "@sentry/react": "^7.64.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@dcl/hashing": "^3.0.4",
     "@dcl/mini-rpc": "^1.0.7",
     "@dcl/schemas": "^9.14.0",
-    "@dcl/sdk": "^7.4.5",
+    "@dcl/sdk": "^7.4.6",
     "@dcl/single-sign-on-client": "^0.1.0",
     "@dcl/ui-env": "^1.5.0",
     "@sentry/react": "^7.64.0",

--- a/src/components/DeployButton/DeployButton.container.ts
+++ b/src/components/DeployButton/DeployButton.container.ts
@@ -8,11 +8,12 @@ import DeployButton from './DeployButton'
 import { getCurrentLimits, getCurrentMetrics } from 'modules/scene/selectors'
 import { isReady, isLoading, areEntitiesOutOfBoundaries } from 'modules/editor/selectors'
 import { getCurrentProject } from 'modules/project/selectors'
+import { ModelMetrics } from 'modules/models/types'
 
 const mapState = (state: RootState): MapStateProps => ({
   project: getCurrentProject(state)!,
-  limits: getCurrentLimits(state),
-  metrics: getCurrentMetrics(state),
+  limits: getCurrentLimits(state) as ModelMetrics,
+  metrics: getCurrentMetrics(state) as ModelMetrics,
   isLoading: !isReady(state) || isLoading(state),
   areEntitiesOutOfBoundaries: areEntitiesOutOfBoundaries(state),
   deploymentStatus: getCurrentDeploymentStatus(state)

--- a/src/components/EditorPage/Metrics/Metrics.container.ts
+++ b/src/components/EditorPage/Metrics/Metrics.container.ts
@@ -3,13 +3,14 @@ import { connect } from 'react-redux'
 import { RootState } from 'modules/common/types'
 import { getCurrentProject } from 'modules/project/selectors'
 import { getCurrentMetrics, getCurrentLimits } from 'modules/scene/selectors'
+import { ModelMetrics } from 'modules/models/types'
 import { MapStateProps } from './Metrics.types'
 import Metrics from './Metrics'
 
 const mapState = (state: RootState): MapStateProps => {
   const currentProject = getCurrentProject(state)
-  const metrics = getCurrentMetrics(state)
-  const limits = getCurrentLimits(state)
+  const metrics = getCurrentMetrics(state) as ModelMetrics
+  const limits = getCurrentLimits(state) as ModelMetrics
 
   if (currentProject) {
     const { rows, cols } = currentProject.layout

--- a/src/components/InspectorPage/InspectorPage.tsx
+++ b/src/components/InspectorPage/InspectorPage.tsx
@@ -6,7 +6,16 @@ import TopBar from './TopBar'
 import { Props, State } from './InspectorPage.types'
 import './InspectorPage.css'
 
-const PUBLIC_URL = process.env.VITE_BASE_URL
+/**
+ * Sanitizes a URL by removing the last '/' segment of the path.
+ * @param url - The URL to sanitize.
+ * @returns The sanitized URL.
+ */
+const sanitizeUrl = (url: string) => {
+  return url.replace(/\/([^/]*)$/, '')
+}
+
+const PUBLIC_URL = sanitizeUrl(process.env.VITE_BASE_URL ?? '')
 
 export default class InspectorPage extends React.PureComponent<Props, State> {
   state: State = {

--- a/src/components/InspectorPage/TopBar/TopBar.container.ts
+++ b/src/components/InspectorPage/TopBar/TopBar.container.ts
@@ -2,15 +2,18 @@ import { connect } from 'react-redux'
 import { goBack } from 'connected-react-router'
 import { RootState } from 'modules/common/types'
 import { getCurrentProject } from 'modules/project/selectors'
-import { getCurrentMetrics } from 'modules/scene/selectors'
+import { getCurrentLimits, getCurrentMetrics, getEntitiesOutOfBoundaries } from 'modules/scene/selectors'
 import { isSavingCurrentProject } from 'modules/sync/selectors'
 import { openModal } from 'decentraland-dapps/dist/modules/modal/actions'
 import { MapStateProps, MapDispatchProps, MapDispatch } from './TopBar.types'
 import TopBar from './TopBar'
+import { SceneMetrics } from '@dcl/inspector/dist/redux/scene-metrics/types'
 
 const mapState = (state: RootState): MapStateProps => ({
   currentProject: getCurrentProject(state),
-  metrics: getCurrentMetrics(state),
+  metrics: getCurrentMetrics(state) as SceneMetrics,
+  limits: getCurrentLimits(state) as SceneMetrics,
+  areEntitiesOutOfBoundaries: getEntitiesOutOfBoundaries(state) > 0,
   isUploading: isSavingCurrentProject(state)
 })
 

--- a/src/components/InspectorPage/TopBar/TopBar.tsx
+++ b/src/components/InspectorPage/TopBar/TopBar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Button, Icon, Popup } from 'decentraland-ui'
+import { SceneMetrics } from '@dcl/inspector/dist/redux/scene-metrics/types'
 import { Env } from '@dcl/ui-env'
 import { config } from 'config'
 import OwnIcon from 'components/Icon'
@@ -13,7 +14,7 @@ import styles from './TopBar.module.css'
 const EXPLORER_URL = config.get('EXPLORER_URL', '')
 const BUILDER_SERVER_URL = config.get('BUILDER_SERVER_URL', '')
 
-export default function TopBar({ currentProject, isUploading, onBack, onOpenModal }: Props) {
+export default function TopBar({ currentProject, metrics, limits, areEntitiesOutOfBoundaries, isUploading, onBack, onOpenModal }: Props) {
   const handleDownload = useCallback(() => {
     onOpenModal('ExportModal', { project: currentProject })
   }, [currentProject, onOpenModal])
@@ -46,6 +47,11 @@ export default function TopBar({ currentProject, isUploading, onBack, onOpenModa
 
     return url.toString()
   }, [])
+
+  const isPublishDisabled = useMemo(() => {
+    const someMetricExceedsLimit = Object.keys(metrics).some(key => metrics[key as keyof SceneMetrics] > limits[key as keyof SceneMetrics])
+    return isUploading || areEntitiesOutOfBoundaries || someMetricExceedsLimit
+  }, [metrics, limits, areEntitiesOutOfBoundaries, isUploading])
 
   return (
     <div className={styles.container}>
@@ -82,7 +88,7 @@ export default function TopBar({ currentProject, isUploading, onBack, onOpenModa
           <Icon name="eye" />
           {t('inspector.top_bar.preview')}
         </Button>
-        <Button primary size="small" disabled={isUploading} onClick={handlePublish}>
+        <Button primary size="small" disabled={isPublishDisabled} onClick={handlePublish}>
           <Icon name="globe" />
           {t('inspector.top_bar.publish')}
         </Button>

--- a/src/components/InspectorPage/TopBar/TopBar.types.ts
+++ b/src/components/InspectorPage/TopBar/TopBar.types.ts
@@ -1,18 +1,20 @@
 import { Dispatch } from 'redux'
-import { ModelMetrics } from 'modules/models/types'
+import { SceneMetrics } from '@dcl/inspector/dist/redux/scene-metrics/types'
 import { OpenModalAction, openModal } from 'decentraland-dapps/dist/modules/modal/actions'
 import { Project } from 'modules/project/types'
 import { CallHistoryMethodAction, goBack } from 'connected-react-router'
 
 export type Props = {
-  metrics: ModelMetrics
+  metrics: SceneMetrics
+  limits: SceneMetrics
+  areEntitiesOutOfBoundaries: boolean
   currentProject: Project | null
   isUploading: boolean
   onBack: typeof goBack
   onOpenModal: typeof openModal
 }
 
-export type MapStateProps = Pick<Props, 'currentProject' | 'metrics' | 'isUploading'>
+export type MapStateProps = Pick<Props, 'currentProject' | 'metrics' | 'limits' | 'areEntitiesOutOfBoundaries' | 'isUploading'>
 
 export type MapDispatchProps = Pick<Props, 'onBack' | 'onOpenModal'>
 export type MapDispatch = Dispatch<CallHistoryMethodAction | OpenModalAction>

--- a/src/components/Modals/DeployModal/DeployToWorld/DeployToWorld.tsx
+++ b/src/components/Modals/DeployModal/DeployToWorld/DeployToWorld.tsx
@@ -17,6 +17,7 @@ import { getSizesFromDeploymentError } from './utils'
 import dclImage from './images/dcl.svg'
 import ensImage from './images/ens.svg'
 import styles from './DeployToWorld.module.css'
+import { ModelMetrics } from 'modules/models/types'
 
 const EXPLORER_URL = config.get('EXPLORER_URL', '')
 const WORLDS_CONTENT_SERVER_URL = config.get('WORLDS_CONTENT_SERVER', '')
@@ -316,9 +317,11 @@ export default function DeployToWorld({
           <List.Item>
             {t('metrics.materials')}: {metrics.materials}
           </List.Item>
-          <List.Item>
-            {t('metrics.meshes')}: {metrics.meshes}
-          </List.Item>
+          {Object.prototype.hasOwnProperty.call(metrics, 'meshes') ? (
+            <List.Item>
+              {t('metrics.meshes')}: {(metrics as ModelMetrics).meshes}
+            </List.Item>
+          ) : null}
           <List.Item>
             {t('metrics.bodies')}: {metrics.bodies}
           </List.Item>

--- a/src/components/Modals/DeployModal/DeployToWorld/DeployToWorld.types.ts
+++ b/src/components/Modals/DeployModal/DeployToWorld/DeployToWorld.types.ts
@@ -1,5 +1,6 @@
 import { Dispatch } from 'redux'
 import { CallHistoryMethodAction } from 'connected-react-router'
+import { SceneMetrics } from '@dcl/inspector/dist/redux/scene-metrics/types'
 import { deployToWorldRequest, DeployToWorldRequestAction } from 'modules/deployment/actions'
 import { recordMediaRequest, RecordMediaRequestAction } from 'modules/media/actions'
 import { ENS } from 'modules/ens/types'
@@ -16,7 +17,7 @@ export type Props = {
   name: string
   project: Project
   scene: Scene | null
-  metrics: ModelMetrics
+  metrics: ModelMetrics | SceneMetrics
   ensList: ENS[]
   externalNames: ENS[]
   deployments: Record<string, Deployment>

--- a/src/components/SDK6TopBar/SDK6TopBar.container.ts
+++ b/src/components/SDK6TopBar/SDK6TopBar.container.ts
@@ -12,12 +12,13 @@ import { isSavingCurrentProject } from 'modules/sync/selectors'
 import { MapStateProps, MapDispatchProps, MapDispatch } from './SDK6TopBar.types'
 import SDK6TopBar from './SDK6TopBar'
 import { hasHistory } from 'modules/location/selectors'
+import { ModelMetrics } from 'modules/models/types'
 
 const mapState = (state: RootState): MapStateProps => ({
   gizmo: getGizmo(state),
   currentProject: getCurrentProject(state),
   currentPoolGroup: getActivePoolGroup(state),
-  metrics: getCurrentMetrics(state),
+  metrics: getCurrentMetrics(state) as ModelMetrics,
   selectedEntityIds: getSelectedEntityIds(state),
   isLoading: !isReady(state) || isLoading(state),
   isPreviewing: isPreviewing(state),

--- a/src/modules/deployment/utils.ts
+++ b/src/modules/deployment/utils.ts
@@ -5,6 +5,7 @@ import { MemoryDatastore } from 'interface-datastore'
 import { EntityContentItemReference } from '@dcl/hashing'
 import { Asset } from 'modules/asset/types'
 import { Project } from 'modules/project/types'
+import { DEFAULT_SCENE_LIMITS } from 'modules/scene/constants'
 import { ComponentType, SceneSDK6 } from 'modules/scene/types'
 import { getContentsStorageUrl } from 'lib/api/builder'
 import { getCatalystContentUrl } from 'lib/api/peer'
@@ -185,14 +186,7 @@ export const getEmptyDeployment = (projectId: string): [Project, SceneSDK6] => {
       entities: 1,
       textures: 0
     },
-    limits: {
-      triangles: 10000,
-      materials: 20,
-      meshes: 200,
-      bodies: 300,
-      entities: 200,
-      textures: 10
-    },
+    limits: DEFAULT_SCENE_LIMITS,
     ground: {
       assetId: 'c9b17021-765c-4d9a-9966-ce93a9c323d1',
       componentId: '25783992-5e2f-4879-b734-eda41c0cc4c0'

--- a/src/modules/inspector/utils.ts
+++ b/src/modules/inspector/utils.ts
@@ -6,8 +6,8 @@ import { ComponentData, ComponentType, SceneSDK6, SceneSDK7 } from 'modules/scen
 
 export function getParcels(layout: Layout) {
   const parcels: { x: number; y: number }[] = []
-  for (let x = 0; x < layout.rows; x++) {
-    for (let y = 0; y < layout.cols; y++) {
+  for (let x = 0; x < layout.cols; x++) {
+    for (let y = 0; y < layout.rows; y++) {
       parcels.push({ x, y })
     }
   }

--- a/src/modules/scene/actions.ts
+++ b/src/modules/scene/actions.ts
@@ -1,4 +1,5 @@
 import { action } from 'typesafe-actions'
+import { SceneMetrics } from '@dcl/inspector/dist/redux/scene-metrics/types'
 import { Asset, AssetParameterValues } from 'modules/asset/types'
 import { Scene, ComponentType, ComponentData, SceneSDK6, SceneSDK7 } from './types'
 import { ModelMetrics, Vector3 } from 'modules/models/types'
@@ -24,8 +25,12 @@ export type ProvisionSceneAction = ReturnType<typeof provisionScene>
 
 export const UPDATE_METRICS = 'Update metrics'
 
-export const updateMetrics = (sceneId: string, metrics: ModelMetrics, limits: ModelMetrics) =>
-  action(UPDATE_METRICS, { sceneId, metrics, limits })
+export const updateMetrics = (
+  sceneId: string,
+  metrics: ModelMetrics | SceneMetrics,
+  limits: ModelMetrics | SceneMetrics,
+  entitiesOutOfBoundaries?: number
+) => action(UPDATE_METRICS, { sceneId, metrics, limits, entitiesOutOfBoundaries })
 
 export type UpdateMetricsAction = ReturnType<typeof updateMetrics>
 

--- a/src/modules/scene/constants.ts
+++ b/src/modules/scene/constants.ts
@@ -10,4 +10,13 @@ export const EMPTY_SCENE_METRICS: ModelMetrics = {
   textures: 0
 }
 
+export const DEFAULT_SCENE_LIMITS: ModelMetrics = {
+  triangles: 10000,
+  materials: 20,
+  meshes: 200,
+  bodies: 300,
+  entities: 200,
+  textures: 10
+}
+
 export const ShapeComponents = [ComponentType.GLTFShape, ComponentType.NFTShape]

--- a/src/modules/scene/reducer.ts
+++ b/src/modules/scene/reducer.ts
@@ -121,7 +121,7 @@ const baseSceneReducer = (state: SceneState = INITIAL_STATE, action: SceneReduce
       }
     }
     case UPDATE_METRICS: {
-      const { sceneId, metrics, limits } = action.payload
+      const { sceneId, metrics, limits, entitiesOutOfBoundaries } = action.payload
       const scene = state.data[sceneId]
       if (scene.sdk6) {
         return {
@@ -142,6 +142,22 @@ const baseSceneReducer = (state: SceneState = INITIAL_STATE, action: SceneReduce
                   // INCREASE MATERIALS LIMIT FOR TEMPLATES
                   materials: limits.materials * 1.1
                 }
+              }
+            }
+          }
+        }
+      } else if (scene.sdk7) {
+        return {
+          ...state,
+          data: {
+            ...state.data,
+            [sceneId]: {
+              ...scene,
+              sdk7: {
+                ...scene.sdk7,
+                metrics,
+                limits,
+                entitiesOutOfBoundaries
               }
             }
           }

--- a/src/modules/scene/selectors.ts
+++ b/src/modules/scene/selectors.ts
@@ -6,6 +6,7 @@ import { Project } from 'modules/project/types'
 import { ModelMetrics } from 'modules/models/types'
 import { ComponentDefinition, ComponentType, Scene, AnyComponent, ShapeComponent, SceneSDK6 } from './types'
 import { EMPTY_SCENE_METRICS, ShapeComponents } from './constants'
+import { SceneMetrics } from '@dcl/inspector/dist/redux/scene-metrics/types'
 
 export const getState: (state: RootState) => SceneState = state => state.scene.present
 
@@ -21,13 +22,33 @@ export const getCurrentScene = createSelector<RootState, Project | null, SceneSt
   (project, scenes) => (project ? scenes[project.sceneId] : null)
 )
 
-export const getCurrentMetrics = createSelector<RootState, Scene | null, ModelMetrics>(getCurrentScene, scene =>
-  scene && scene.sdk6 ? scene.sdk6.metrics : EMPTY_SCENE_METRICS
-)
+export const getCurrentMetrics = createSelector<RootState, Scene | null, ModelMetrics | SceneMetrics>(getCurrentScene, scene => {
+  if (scene) {
+    if (scene.sdk6) {
+      return scene.sdk6.metrics
+    } else if (scene.sdk7 && scene.sdk7.metrics) {
+      return scene.sdk7.metrics
+    }
+  }
 
-export const getCurrentLimits = createSelector<RootState, Scene | null, ModelMetrics>(getCurrentScene, scene =>
-  scene && scene.sdk6 ? scene.sdk6.limits : EMPTY_SCENE_METRICS
-)
+  return EMPTY_SCENE_METRICS
+})
+
+export const getCurrentLimits = createSelector<RootState, Scene | null, ModelMetrics | SceneMetrics>(getCurrentScene, scene => {
+  if (scene) {
+    if (scene.sdk6) {
+      return scene.sdk6.limits
+    } else if (scene.sdk7 && scene.sdk7.limits) {
+      return scene.sdk7.limits
+    }
+  }
+
+  return EMPTY_SCENE_METRICS
+})
+
+export const getEntitiesOutOfBoundaries = createSelector<RootState, Scene | null, number>(getCurrentScene, scene => {
+  return scene?.sdk7?.entitiesOutOfBoundaries || 0
+})
 
 export const getComponents = createSelector<RootState, Scene | null, SceneSDK6['components']>(getCurrentScene, scene =>
   scene && scene.sdk6 ? scene.sdk6.components : {}

--- a/src/modules/scene/types.ts
+++ b/src/modules/scene/types.ts
@@ -1,4 +1,5 @@
 import { CompositeDefinition } from '@dcl/ecs'
+import { SceneMetrics } from '@dcl/inspector/dist/redux/scene-metrics/types'
 import { Scene as SceneMetadata } from '@dcl/schemas'
 import { Asset, AssetParameterValues } from 'modules/asset/types'
 import { ModelMetrics, Vector3, Quaternion } from 'modules/models/types'
@@ -80,4 +81,7 @@ export type SceneSDK7 = {
   composite: CompositeDefinition
   mappings: Record<string, string>
   metadata?: Omit<SceneMetadata, 'main'> & { rating?: 'T' | 'A' }
+  metrics?: SceneMetrics
+  limits?: SceneMetrics
+  entitiesOutOfBoundaries?: number
 }


### PR DESCRIPTION
This PR fixes the layout base generation because there was a mismatch between how the layout is shown in the preview and how it is stored to be deployed.

`2 rows` x `1 col` is interpreted in the preview as `1 row` x `2 cols`.

It also adds the validations to avoid publishing a scene when the scene has entities outside the layout or the metrics exceed the limits.

Depends on: https://github.com/decentraland/js-sdk-toolchain/pull/906