### PR TITLE
fix: Only show the warning when scene limits are exceeded

### DIFF
--- a/src/components/InspectorPage/TopBar/TopBar.tsx
+++ b/src/components/InspectorPage/TopBar/TopBar.tsx
@@ -54,8 +54,8 @@ export default function TopBar({ currentProject, metrics, limits, areEntitiesOut
   )
 
   const isPublishDisabled = useMemo(() => {
-    return isUploading || areEntitiesOutOfBoundaries || someMetricExceedsLimit
-  }, [metrics, limits, areEntitiesOutOfBoundaries, someMetricExceedsLimit, isUploading])
+    return isUploading || areEntitiesOutOfBoundaries
+  }, [metrics, limits, areEntitiesOutOfBoundaries, isUploading])
 
   const isPopupDisabled = useMemo(() => isUploading || !isPublishDisabled, [isUploading, isPublishDisabled])
 


### PR DESCRIPTION
This PR removes the validation to publish scenes when the limits are exceeded