### PR TITLE
fix: world urls

### DIFF
--- a/src/components/Modals/DeployModal/DeployToWorld/DeployToWorld.tsx
+++ b/src/components/Modals/DeployModal/DeployToWorld/DeployToWorld.tsx
@@ -150,7 +150,7 @@ export default function DeployToWorld({
     if (isDevelopment) {
       return `${EXPLORER_URL}/?realm=${WORLDS_CONTENT_SERVER_URL}/world/${world}&NETWORK=sepolia`
     }
-    return `${EXPLORER_URL}/world/${world}`
+    return `${EXPLORER_URL}?realm=${world}`
   }, [world])
 
   const nameTypeOptions = useMemo(

--- a/src/components/SceneDetailPage/DeploymentDetail/DeploymentDetail.tsx
+++ b/src/components/SceneDetailPage/DeploymentDetail/DeploymentDetail.tsx
@@ -61,7 +61,7 @@ export default class DeploymentDetail extends React.PureComponent<Props> {
     if (isDevelopment) {
       return `${EXPLORER_URL}/?realm=${WORLDS_CONTENT_SERVER_URL}/world/${world}&NETWORK=sepolia`
     }
-    return `${EXPLORER_URL}/world/${world}`
+    return `${EXPLORER_URL}?realm=${world}`
   }
 
   render() {

--- a/src/components/WorldListPage/WorldListPage.tsx
+++ b/src/components/WorldListPage/WorldListPage.tsx
@@ -76,7 +76,7 @@ const WorldListPage: React.FC<Props> = props => {
       if (isDevelopment) {
         return `${EXPLORER_URL}/?realm=${WORLDS_CONTENT_SERVER_URL}/world/${world}&NETWORK=sepolia`
       }
-      return `${EXPLORER_URL}/world/${world}`
+      return `${EXPLORER_URL}?realm=${world}`
     },
     [isDevelopment]
   )


### PR DESCRIPTION
The `decentraland.org/play/world/<ens>` url is not working (I dunno since when, if this was intended or not) so in order to get this fixed in prod I'm swiching to the `play?realm=<ens>` url that works fine. 