### PR TITLE
fix: Create SW loading state does not change after selecting the video preview

### DIFF
--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
@@ -500,6 +500,7 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
   handleSaveVideo = () => {
     this.setState({
       fromView: undefined,
+      isLoading: false,
       view: CreateItemView.DETAILS
     })
   }


### PR DESCRIPTION
This PR fixes the permanent loading state when creating a smart wearable and uploading a video preview