### PR TITLE
chore: Upgrade the @dcl/sdk package to the version 7.4.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@dcl/hashing": "^3.0.4",
         "@dcl/mini-rpc": "^1.0.7",
         "@dcl/schemas": "^11.5.0",
-        "@dcl/sdk": "7.4.18",
+        "@dcl/sdk": "^7.4.21",
         "@dcl/single-sign-on-client": "^0.1.0",
         "@dcl/ui-env": "^1.5.0",
         "@sentry/react": "^7.64.0",
@@ -1707,6 +1707,11 @@
       "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.15.tgz",
       "integrity": "sha512-iGetQ19PpHq/NWs5SeqCFShg34iPmYK0IfIch8gmqPjOnLilRIanYg8Q0y1IzsZYs6kJ8sQf435xA76h07btiQ=="
     },
+    "node_modules/@dcl/asset-packs/node_modules/@dcl/explorer": {
+      "version": "1.0.161749-20240401171209.commit-d6d28f4",
+      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.161749-20240401171209.commit-d6d28f4.tgz",
+      "integrity": "sha512-5jji07MVmMiNPY9gIHWrL3Wwh4SpdaUKnzMHMiKy830QJ1Nif9jpi5qcISmoDdXhoEJbC2vM1Gyj5D4rQibHew=="
+    },
     "node_modules/@dcl/asset-packs/node_modules/@dcl/hashing": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@dcl/hashing/-/hashing-1.1.3.tgz",
@@ -2029,9 +2034,9 @@
       }
     },
     "node_modules/@dcl/asset-packs/node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2040,24 +2045,24 @@
       }
     },
     "node_modules/@dcl/asset-packs/node_modules/react-reconciler": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.0.tgz",
-      "integrity": "sha512-wa0fGj7Zht1EYMRhKWwoo1H9GApxYLBuhoAuXN0TlltESAjDssB+Apf0T/DngVqaMyPypDmabL37vw/2aRM98Q==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
+      "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
+        "scheduler": "^0.23.2"
       },
       "engines": {
         "node": ">=0.10.0"
       },
       "peerDependencies": {
-        "react": "^18.2.0"
+        "react": "^18.3.1"
       }
     },
     "node_modules/@dcl/asset-packs/node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -2388,9 +2393,9 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.4.18",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.18.tgz",
-      "integrity": "sha512-YINO0AnUPpppicOBlX4ONXMu8iN0fOtirfn5jS+3wJFGo0JoCCsChM+62ughZnImyQ/9+6K1/xVB3nJ96PgzxQ=="
+      "version": "7.4.21",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.21.tgz",
+      "integrity": "sha512-4LbmhogqStmrQ8h3gwchP4poTaFLB0Mf468mlRbinB9XaXvSusqCznLP/N/T18/c23f/riRFZ0xWfe1IGr//gg=="
     },
     "node_modules/@dcl/ecs-math": {
       "version": "2.0.2",
@@ -2398,9 +2403,9 @@
       "integrity": "sha512-w01+a3mpHvxGPHepu0hAAX8OfpBSQEqBbC1+U8o+5SBSQVXHiRwt3P4cK20yM8QCgZe3enPttmpqePnjTliTig=="
     },
     "node_modules/@dcl/explorer": {
-      "version": "1.0.161749-20240401171209.commit-d6d28f4",
-      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.161749-20240401171209.commit-d6d28f4.tgz",
-      "integrity": "sha512-5jji07MVmMiNPY9gIHWrL3Wwh4SpdaUKnzMHMiKy830QJ1Nif9jpi5qcISmoDdXhoEJbC2vM1Gyj5D4rQibHew=="
+      "version": "1.0.162830-20240429195817.commit-25498a3",
+      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.162830-20240429195817.commit-25498a3.tgz",
+      "integrity": "sha512-IJ22cesg57zZb1qy+Iq6vZ4YuqgWeCz9RQCjpe/MBssLmouSq2US88DKxEHDUQviQD8GeNPVKIyhR8vSOzOOVQ=="
     },
     "node_modules/@dcl/hashing": {
       "version": "3.0.4",
@@ -2408,18 +2413,18 @@
       "integrity": "sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg=="
     },
     "node_modules/@dcl/inspector": {
-      "version": "7.4.18",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.4.18.tgz",
-      "integrity": "sha512-BLQaMwqSWujmPnbAUpjos77KxDojTAJ4ya5NGZyKuyqp8mWIjfEmAOy7q2BwTAb3kjJEujBn/jwUQT3Dbupy4g==",
+      "version": "7.4.21",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.4.21.tgz",
+      "integrity": "sha512-jXNZqmtMosQ50Fs6YuZJe+AguDlJc/jkJUkZ4PP/Q3FPEIUXxncF61bqe+qFZmwjTGC+URASI/TFbqzj5JKAtQ==",
       "dependencies": {
         "@dcl/asset-packs": "1.17.0",
         "ts-deepmerge": "^7.0.0"
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.4.18",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.4.18.tgz",
-      "integrity": "sha512-t3NBd4hgLiROp7G+iuKQbXunLoJBjqR6lI3LcZcQMvmpoqHxysRt5tPrOOrkPkHHiM7CuF7pJ4Pgb4k2kr170g=="
+      "version": "7.4.21",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.4.21.tgz",
+      "integrity": "sha512-ePGlF5MpeqvfewhWM9Olnc+u5WBcmQ9u6sCrjtY2KYrUR7wxBCoamwIiG4BK8MVMPxKc5lAWA91toGJlC6jSMQ=="
     },
     "node_modules/@dcl/linker-dapp": {
       "version": "0.12.0",
@@ -2470,9 +2475,9 @@
       "integrity": "sha512-Z0zpNr2HAxn2cLWUadWGlzaG48Z+N3hg2bI20UH+OT8NJtvCJnAwVBshAG83iAn4BTC+CsUsk4A394jrlv2ZIQ=="
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-8789372854.commit-f692c7a",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-8789372854.commit-f692c7a.tgz",
-      "integrity": "sha512-emLWfF/8Iciz0nnXFShZXBSbpsdbTHAJuh8st3de5C+4hlNV00Gs5pDBehsxENqHiq9yqL8rDng8EzTXhryAXw==",
+      "version": "1.0.0-8758013256.commit-44aab53",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-8758013256.commit-44aab53.tgz",
+      "integrity": "sha512-VbrbfUEOLIOiQjN2c53RSg1lNNkvt0+ow+d27c+O7RSyjqDyZZkX2uMW4kdYN1TOk45OrvxCyrrxdYN0ZXW52Q==",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0"
       }
@@ -2494,19 +2499,19 @@
       "integrity": "sha512-IPB043+NbQB3om2FlmQGmaRxTokHaSM9o3a7sEL0yJgBb60mukCpMdNXxzdIcemixfV3EhIJQ2G8HgK30XKTkA=="
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.4.18",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.4.18.tgz",
-      "integrity": "sha512-EgdMbulO+xw5dDI1g12U0bVM8gkG064CJ8bGmDeDrgg/gqDUygzFIjJVuvl0Xcs6Rdj0zGLVxFFQY1WOt0hPYA==",
+      "version": "7.4.21",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.4.21.tgz",
+      "integrity": "sha512-iPWrSnHOCtk/X5CXTOS1d2JsQj6x6Dm2Eoint75bUaQcr4xgHAWySQXFIS//aw8WIx8nAxQvdNDE+EjTtu3Kgw==",
       "dependencies": {
-        "@dcl/ecs": "7.4.18",
+        "@dcl/ecs": "7.4.21",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
     },
     "node_modules/@dcl/react-ecs/node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2515,24 +2520,24 @@
       }
     },
     "node_modules/@dcl/react-ecs/node_modules/react-reconciler": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.0.tgz",
-      "integrity": "sha512-wa0fGj7Zht1EYMRhKWwoo1H9GApxYLBuhoAuXN0TlltESAjDssB+Apf0T/DngVqaMyPypDmabL37vw/2aRM98Q==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
+      "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
+        "scheduler": "^0.23.2"
       },
       "engines": {
         "node": ">=0.10.0"
       },
       "peerDependencies": {
-        "react": "^18.2.0"
+        "react": "^18.3.1"
       }
     },
     "node_modules/@dcl/react-ecs/node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -2558,31 +2563,31 @@
       }
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.4.18",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.4.18.tgz",
-      "integrity": "sha512-wYurMn7i6RKbD2ZYgsHwLoteFxxdhAjQxqUK8p9vmoIhsU49StzwoUueNz5kiJPFR+uFr/Ot0362kU5Mc5k/jQ==",
+      "version": "7.4.21",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.4.21.tgz",
+      "integrity": "sha512-EmIYPS1crLppSf0eD0ebkuQRYfp86lZoHVYICEW+F12MqAdSEPzj821OT7h5zLdjP4FCKm7M1thzCev0X6v9PA==",
       "dependencies": {
-        "@dcl/ecs": "7.4.18",
+        "@dcl/ecs": "7.4.21",
         "@dcl/ecs-math": "2.0.2",
-        "@dcl/explorer": "1.0.161749-20240401171209.commit-d6d28f4",
-        "@dcl/js-runtime": "7.4.18",
-        "@dcl/react-ecs": "7.4.18",
-        "@dcl/sdk-commands": "7.4.18",
+        "@dcl/explorer": "1.0.162830-20240429195817.commit-25498a3",
+        "@dcl/js-runtime": "7.4.21",
+        "@dcl/react-ecs": "7.4.21",
+        "@dcl/sdk-commands": "7.4.21",
         "text-encoding": "0.7.0"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.4.18",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.4.18.tgz",
-      "integrity": "sha512-T7rhRsPhyMUZW3Wx+oDyRDjFkv8XyP7QzbJp21qTynkFxYwWArrEsXie2EUMYPoC6Ndgsjrjnyj/o3AaAlOzwA==",
+      "version": "7.4.21",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.4.21.tgz",
+      "integrity": "sha512-4wJaiQ5xjsD2JJQF/Xh/yf+SdWdiKXR05VAbjLHszFjwBu38W0DsSGzAi/v42ZCbdYuxwGH5gLER/cL0V/u4uA==",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.4.18",
+        "@dcl/ecs": "7.4.21",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.4.18",
+        "@dcl/inspector": "7.4.21",
         "@dcl/linker-dapp": "^0.12.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "^1.0.0-8691799990.commit-4ba546c",
+        "@dcl/protocol": "1.0.0-8758013256.commit-44aab53",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -19009,9 +19014,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
-      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -23267,9 +23272,9 @@
       }
     },
     "node_modules/ts-proto": {
-      "version": "1.172.0",
-      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.172.0.tgz",
-      "integrity": "sha512-+4myxp5H+qD4r3sQUwvewN3zpdKpApeuUI0+lxfdznvkd2TUFVaeOD0q6dHszEYKTzR7DHu96Z1pqpNSOXF8iQ==",
+      "version": "1.174.0",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.174.0.tgz",
+      "integrity": "sha512-hptQp5Nu5Vj3Mrj70fx5ccw3rTwPPpKXpa5RJ/WlmWiliVMqNPGYzUuBvd9N/EKsxiSQHiw62aGlZezzF19fKA==",
       "dependencies": {
         "case-anything": "^2.1.13",
         "protobufjs": "^7.2.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@dcl/hashing": "^3.0.4",
     "@dcl/mini-rpc": "^1.0.7",
     "@dcl/schemas": "^11.5.0",
-    "@dcl/sdk": "7.4.18",
+    "@dcl/sdk": "^7.4.21",
     "@dcl/single-sign-on-client": "^0.1.0",
     "@dcl/ui-env": "^1.5.0",
     "@sentry/react": "^7.64.0",


### PR DESCRIPTION
This PR upgrades the package `@dcl/sdk` to the version `7.4.21`