### PR TITLE
fix: Item description and utility not breaking

### DIFF
--- a/src/components/ItemDetailPage/ItemDetailPage.css
+++ b/src/components/ItemDetailPage/ItemDetailPage.css
@@ -38,7 +38,12 @@
 .ItemDetailPage .item-data .attribute-row {
   display: flex;
   flex-direction: row;
+  gap: 10px;
   margin-top: 10px;
+}
+
+.ItemDetailPage .item-data .attribute-column .data {
+  word-break: break-word;
 }
 
 .ItemDetailPage .item-data .subtitle {


### PR DESCRIPTION
This PR adds the `word-break` CSS property to the description and utility attributes.
![Screenshot 2024-05-08 at 11 50 00](https://github.com/decentraland/builder/assets/1120791/1a29574d-b64e-45dd-ab0c-f7a2ffca0bdf)
