### PR TITLE
fix: builder templates local assets tab

### DIFF
--- a/src/components/Modals/CustomLayoutModal/CustomLayoutModal.container.ts
+++ b/src/components/Modals/CustomLayoutModal/CustomLayoutModal.container.ts
@@ -12,13 +12,12 @@ import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors
 import { getLoadingProjectIds } from 'modules/sync/selectors'
 import { SDKVersion } from 'modules/scene/types'
 import { Project } from 'modules/project/types'
-import { getIsCreateSceneOnlySDK7Enabled, getIsSDK7TemplatesEnabled } from 'modules/features/selectors'
+import { getIsCreateSceneOnlySDK7Enabled } from 'modules/features/selectors'
 
 const mapState = (state: RootState): MapStateProps => {
   return {
     isLoading: isLoadingType(getProjectLoading(state), LOAD_MANIFEST_REQUEST) || getLoadingProjectIds(state).length > 0,
     error: getProjectError(state),
-    isSDK7TemplatesEnabled: getIsSDK7TemplatesEnabled(state),
     isCreateSceneOnlySDK7Enabled: getIsCreateSceneOnlySDK7Enabled(state)
   }
 }

--- a/src/components/Modals/CustomLayoutModal/CustomLayoutModal.types.ts
+++ b/src/components/Modals/CustomLayoutModal/CustomLayoutModal.types.ts
@@ -10,7 +10,6 @@ export type Props = ModalProps & {
   error: string | null
   isLoading: boolean
   onCreateProject: (name: string, description: string, template: Template, sdk: SDKVersion) => void
-  isSDK7TemplatesEnabled: boolean
   isCreateSceneOnlySDK7Enabled: boolean
 }
 
@@ -30,6 +29,6 @@ export type State = {
   description: string
 }
 
-export type MapStateProps = Pick<Props, 'error' | 'isLoading' | 'isSDK7TemplatesEnabled' | 'isCreateSceneOnlySDK7Enabled'>
+export type MapStateProps = Pick<Props, 'error' | 'isLoading' | 'isCreateSceneOnlySDK7Enabled'>
 export type MapDispatchProps = Pick<Props, 'onCreateProject'>
 export type MapDispatch = Dispatch<CreateProjectFromTemplateAction | CallHistoryMethodAction>

--- a/src/lib/api/builder.ts
+++ b/src/lib/api/builder.ts
@@ -664,24 +664,6 @@ export class BuilderAPI extends BaseAPI {
     return items.map(fromPoolGroup)
   }
 
-  // TODO: remove this after removing the SDK7_TEMPLATES feature flag
-  async fetchTemplates() {
-    const { items }: { items: RemoteProject[]; total: number } = await this.request('get', '/templates', {
-      retry: retryParams,
-      params: { sort_by: 'created_at', sort_order: 'asc' }
-    })
-    return items.map(fromRemoteProject).sort((template1, template2) => {
-      if (template1.templateStatus === TemplateStatus.COMING_SOON) {
-        return 1
-      }
-
-      if (template2.templateStatus === TemplateStatus.COMING_SOON) {
-        return -1
-      }
-      return 0
-    })
-  }
-
   async saveProject(project: Project, scene: Scene) {
     const manifest = createManifest(toRemoteProject(project), scene)
     await this.request('put', `/projects/${project.id}/manifest`, { params: { manifest } })

--- a/src/modules/features/selectors.spec.ts
+++ b/src/modules/features/selectors.spec.ts
@@ -5,7 +5,6 @@ import {
   getIsCreateSceneOnlySDK7Enabled,
   getIsMaintenanceEnabled,
   getIsPublishCollectionsWertEnabled,
-  getIsSDK7TemplatesEnabled,
   getIsVrmOptOutEnabled,
   getIsWearableUtilityEnabled
 } from './selectors'
@@ -61,7 +60,6 @@ describe('when getting if maintainance is enabled', () => {
 })
 
 const ffSelectors = [
-  { selector: getIsSDK7TemplatesEnabled, app: ApplicationName.BUILDER, feature: FeatureName.SDK7_TEMPLATES },
   { selector: getIsCreateSceneOnlySDK7Enabled, app: ApplicationName.BUILDER, feature: FeatureName.CREATE_SCENE_ONLY_SDK7 },
   { selector: getIsPublishCollectionsWertEnabled, app: ApplicationName.BUILDER, feature: FeatureName.PUBLISH_COLLECTIONS_WERT },
   { selector: getIsVrmOptOutEnabled, app: ApplicationName.BUILDER, feature: FeatureName.VRM_OPTOUT },

--- a/src/modules/features/selectors.ts
+++ b/src/modules/features/selectors.ts
@@ -22,14 +22,6 @@ export const getIsCampaignEnabled = (state: RootState) => {
   }
 }
 
-export const getIsSDK7TemplatesEnabled = (state: RootState) => {
-  try {
-    return getIsFeatureEnabled(state, ApplicationName.BUILDER, FeatureName.SDK7_TEMPLATES)
-  } catch (e) {
-    return false
-  }
-}
-
 export const getIsCreateSceneOnlySDK7Enabled = (state: RootState) => {
   try {
     return getIsFeatureEnabled(state, ApplicationName.BUILDER, FeatureName.CREATE_SCENE_ONLY_SDK7)

--- a/src/modules/inspector/sagas.ts
+++ b/src/modules/inspector/sagas.ts
@@ -291,7 +291,12 @@ export function* inspectorSaga(builder: BuilderAPI, store: RootStore) {
     const { path } = params
 
     const scene: SceneSDK7 = yield getScene()
-    const paths = [...Object.keys(scene.mappings), 'assets/scene/main.composite']
+    const paths = [...Object.keys(scene.mappings)]
+
+    // add main.composite if missing
+    if (!paths.includes('assets/scene/main.composite')) {
+      paths.push('assets/scene/main.composite')
+    }
 
     const project: Project = yield select(getCurrentProject)
     if (project.thumbnail) {

--- a/src/modules/project/sagas.spec.ts
+++ b/src/modules/project/sagas.spec.ts
@@ -1,39 +1,14 @@
 import { expectSaga } from 'redux-saga-test-plan'
-import { call } from 'redux-saga/effects'
 import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 import { AuthIdentity } from '@dcl/crypto'
 import { BuilderAPI } from 'lib/api/builder'
-import { mockTemplate, mockTemplates } from 'specs/project'
 import { loginSuccess } from 'modules/identity/actions'
-import { loadProjectsRequest, loadTemplatesFailure, loadTemplatesRequest, loadTemplatesSuccess } from './actions'
+import { loadProjectsRequest, loadTemplatesRequest } from './actions'
 import { projectSaga } from './sagas'
 
 const builderAPI = {
   fetchTemplates: jest.fn()
 } as unknown as BuilderAPI
-
-// TODO: remove this after removing the SDK7_TEMPLATES feature flag
-describe('when handling the loadTemplatesRequest action', () => {
-  describe('and the request is successful', () => {
-    it('should put a loadTemplatesSuccess action with the project templates', () => {
-      return expectSaga(projectSaga, builderAPI)
-        .provide([[call([builderAPI, 'fetchTemplates']), Promise.resolve([mockTemplate])]])
-        .put(loadTemplatesSuccess(mockTemplates))
-        .dispatch(loadTemplatesRequest())
-        .run({ silenceTimeout: true })
-    })
-  })
-
-  describe('and the request fails', () => {
-    it('should put a loadTemplatesFailure action with the error', () => {
-      return expectSaga(projectSaga, builderAPI)
-        .provide([[call([builderAPI, 'fetchTemplates']), Promise.reject(new Error('error'))]])
-        .put(loadTemplatesFailure('error'))
-        .dispatch(loadTemplatesRequest())
-        .run({ silenceTimeout: true })
-    })
-  })
-})
 
 describe('when handling the loginSuccess action', () => {
   let wallet: Wallet


### PR DESCRIPTION
This PR fixes an issue where opening the Local Assets on a scene created from a template would crash the Web Editor.

The problem was that the `main.composite` file was being returned twice by the file system interface, and that resulted in the directory tree breaking.

I also took the chance to remove an usused feature flag on this PR: `sdk7-templates`