### PR TITLE
fix: Utility and description sizing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "decentraland-ecs": "6.12.4-7784644013.commit-f770b3e",
         "decentraland-experiments": "^1.0.2",
         "decentraland-transactions": "^2.6.1",
-        "decentraland-ui": "^5.21.0",
+        "decentraland-ui": "^5.23.1",
         "ethers": "^5.6.8",
         "file-saver": "^2.0.1",
         "graphql": "^15.8.0",
@@ -2552,9 +2552,9 @@
       }
     },
     "node_modules/@dcl/schemas": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-11.7.0.tgz",
-      "integrity": "sha512-Gsv4FFnr6vL56k5ozzxH1CcOCzOUHMj602IL5y69q/Iy0rtn+7OF2TckgTDHGeifzakhaVwDOiGFYeJcaMaEXg==",
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-11.9.0.tgz",
+      "integrity": "sha512-IIKsy45VhiB9rD6v1d3UedyApBE8EmtAiIWevXIvam1w9Nsh+w8lWAWtD/HX3fXivBwLDZGrn1IRUK4dI4WlHA==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -11478,11 +11478,11 @@
       }
     },
     "node_modules/decentraland-ui": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-5.21.0.tgz",
-      "integrity": "sha512-enRnOEwrJwNksLd0EReDjsEoG2QQq2a/g8hGpInfd6Tc05Ie40VtaOO0/CrzRA0yI82FEDfdxyFRkl5Wj2YTQg==",
+      "version": "5.23.1",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-5.23.1.tgz",
+      "integrity": "sha512-v0Qfr7zC/nYNNLFSLyAUaqaL3e8xSi80xLNixWXllc1fZEa7DWNQ5qvNACnXKr2R3zC1gcDOUfS4zH32y3eSgw==",
       "dependencies": {
-        "@dcl/schemas": "^11.4.0",
+        "@dcl/schemas": "^11.9.0",
         "@dcl/ui-env": "^1.4.0",
         "balloon-css": "^0.5.0",
         "classnames": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "decentraland-ecs": "6.12.4-7784644013.commit-f770b3e",
     "decentraland-experiments": "^1.0.2",
     "decentraland-transactions": "^2.6.1",
-    "decentraland-ui": "^5.21.0",
+    "decentraland-ui": "^5.23.1",
     "ethers": "^5.6.8",
     "file-saver": "^2.0.1",
     "graphql": "^15.8.0",

--- a/src/components/ItemDetailPage/ItemDetailPage.css
+++ b/src/components/ItemDetailPage/ItemDetailPage.css
@@ -38,8 +38,12 @@
 .ItemDetailPage .item-data .attribute-row {
   display: flex;
   flex-direction: row;
-  gap: 10px;
+  gap: 30px;
   margin-top: 10px;
+}
+
+.ItemDetailPage .item-data .attribute-column {
+  flex: 1 50%;
 }
 
 .ItemDetailPage .item-data .attribute-column .data {


### PR DESCRIPTION
This PR fixes the sizing issues with the utility and the description, which now, occupy the 50% of the container by default.

![Screenshot 2024-05-09 at 10 25 34](https://github.com/decentraland/builder/assets/1120791/9f053b24-ac6f-41e1-89cb-4e9734bd6845)
