### PR TITLE
feat: Keep overrides after changing a representation

### DIFF
--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
@@ -356,8 +356,6 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
       const removesDefaultHiding = category === WearableCategory.UPPER_BODY ? [BodyPartCategory.HANDS] : []
       data = {
         ...pristineItem.data,
-        replaces: pristineItem.data.replaces ?? [],
-        hides: pristineItem.data.hides ?? [],
         removesDefaultHiding,
         category: category as WearableCategory,
         requiredPermissions: requiredPermissions || []

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
@@ -356,8 +356,8 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
       const removesDefaultHiding = category === WearableCategory.UPPER_BODY ? [BodyPartCategory.HANDS] : []
       data = {
         ...pristineItem.data,
-        replaces: [],
-        hides: [],
+        replaces: pristineItem.data.replaces ?? [],
+        hides: pristineItem.data.hides ?? [],
         removesDefaultHiding,
         category: category as WearableCategory,
         requiredPermissions: requiredPermissions || []


### PR DESCRIPTION
This PR changes the logic to keep the overrides after modifying the item representations.