### PR TITLE
fix: Update smart items upcoming text

### DIFF
--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -1273,7 +1273,7 @@
     "size_subtitle": "Set the parcels size of your new scene",
     "sdk_title": "Experience the new Decentraland Web Editor",
     "sdk_subtitle": "Harness the power of SDK 7 without any code.",
-    "sdk_description": "Enhance your scene-building process with our improved visual editor. All features from the previous Scene Builder are included, while the addition of <b>Smart Items</b> is scheduled for an upcoming update.",
+    "sdk_description": "Enhance your scene-building process with our improved visual editor. All features from the previous Scene Builder are included.",
     "sdk_image_alt": "SDK 7",
     "name_label": "Name",
     "description_label": "Description",

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -1275,7 +1275,7 @@
     "size_subtitle": "Elige el tamaño de tu nueva Escena",
     "sdk_title": "Experimente el nuevo editor de Decentraland",
     "sdk_subtitle": "Aproveche el poder de SDK 7 sin ningún código.",
-    "sdk_description": "Mejore su proceso de construcción de escenas con nuestro editor visual mejorado. Se incluyen todas las características del Builder anterior, mientras que la adición de  <b>smart items</b> está programado para una próxima actualización.",
+    "sdk_description": "Mejore su proceso de construcción de escenas con nuestro editor visual mejorado. Se incluyen todas las características del Builder anterior.",
     "sdk_image_alt": "SDK 7",
     "name_label": "Nombre",
     "description_label": "Descripción",

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -1266,7 +1266,7 @@
     "size_subtitle": "设置新场景的大小",
     "sdk_title": "体验新的分散编辑",
     "sdk_subtitle": "在没有任何代码的情况下利用SDK 7的功率。",
-    "sdk_description": "通过改进的视觉编辑器来增强场景构建过程。包括上一个场景构建器中的所有功能，而添加<b>智能项目的添加</b>是为即将进行更新的。",
+    "sdk_description": "通过改进的视觉编辑器来增强场景构建过程。包括上一个场景构建器中的所有功能。",
     "sdk_image_alt": "SDK 7",
     "name_label": "名称",
     "description_label": "描述",


### PR DESCRIPTION
This PR removes the smart items'(already implemented) upcoming text for the sdk7.

![image](https://github.com/decentraland/builder/assets/3170051/99146ba9-5567-4d02-a966-79e48f416825)

Closes: https://github.com/decentraland/dapps-issues/issues/131