### PR TITLE
fix: unsync collections when changing utility

### DIFF
--- a/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
+++ b/src/components/ItemEditorPage/RightPanel/RightPanel.tsx
@@ -261,7 +261,7 @@ export default class RightPanel extends React.PureComponent<Props, State> {
             itemData.category === WearableCategory.UPPER_BODY || itemData.hides?.includes(WearableCategory.UPPER_BODY)
               ? [BodyPartCategory.HANDS]
               : [],
-          blockVrmExport: itemData.blockVrmExport ?? false
+          ...('blockVrmExport' in itemData ? { blockVrmExport: itemData.blockVrmExport } : {})
         }
       }
       const itemContents = {


### PR DESCRIPTION
When editing a collection it doesn't matter what is changed its causing the collection to be uunsync, this is because the new field `blockVrmExport` is added to the data all the time causing the hash to change. This PR is to add that field only if the data already has it or it has been changed, so when changing only utility in old collections for example it won't trigger the curation process