### PR TITLE
fix: ens indefinitely loading

### DIFF
--- a/src/components/ENSDetailPage/ENSDetailPage.container.ts
+++ b/src/components/ENSDetailPage/ENSDetailPage.container.ts
@@ -1,14 +1,15 @@
 import { connect } from 'react-redux'
 import { Dispatch } from 'redux'
+import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
+import { FETCH_ENS_REQUEST, fetchENSRequest } from 'modules/ens/actions'
+import { getAvatar, getName } from 'modules/profile/selectors'
+import { getWallet } from 'modules/wallet/selectors'
 import { openModal } from 'decentraland-dapps/dist/modules/modal/actions'
 import { getENSBySubdomain, getLoading } from 'modules/ens/selectors'
 import { RootState } from 'modules/common/types'
 import { getENSName } from 'modules/location/selectors'
 import { MapStateProps, MapDispatchProps } from './ENSDetailPage.types'
 import ENSDetailPage from './ENSDetailPage'
-import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
-import { FETCH_ENS_REQUEST, fetchENSRequest } from 'modules/ens/actions'
-import { getAvatar, getName } from 'modules/profile/selectors'
 
 const mapState = (state: RootState): MapStateProps => {
   const name = getENSName(state)
@@ -17,7 +18,8 @@ const mapState = (state: RootState): MapStateProps => {
     ens: name ? getENSBySubdomain(state, `${name}.dcl.eth`) : null,
     isLoading: isLoadingType(getLoading(state), FETCH_ENS_REQUEST),
     alias: getName(state),
-    avatar: getAvatar(state)
+    avatar: getAvatar(state),
+    wallet: getWallet(state)
   }
 }
 

--- a/src/components/ENSDetailPage/ENSDetailPage.spec.tsx
+++ b/src/components/ENSDetailPage/ENSDetailPage.spec.tsx
@@ -1,4 +1,5 @@
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
+import { Wallet } from 'decentraland-dapps/dist/modules/wallet'
 import userEvent from '@testing-library/user-event'
 import * as router from 'react-router-dom'
 import { shorten } from 'lib/address'
@@ -23,6 +24,7 @@ function renderENSDetailPage(props: Partial<Props>) {
       isLoading={false}
       onOpenModal={jest.fn()}
       onFetchENS={jest.fn()}
+      wallet={{ address: '0xtest1' } as Wallet}
       {...props}
     />
   )

--- a/src/components/ENSDetailPage/ENSDetailPage.tsx
+++ b/src/components/ENSDetailPage/ENSDetailPage.tsx
@@ -16,7 +16,7 @@ import { Props } from './ENSDetailPage.types'
 import styles from './ENSDetailPage.module.css'
 
 export default function ENSDetailPage(props: Props) {
-  const { ens, isLoading, alias, avatar, name, onOpenModal, onFetchENS } = props
+  const { ens, isLoading, alias, avatar, name, wallet, onOpenModal, onFetchENS } = props
   const history = useHistory()
   const imgUrl = useMemo<string>(
     () => (ens ? `${config.get('MARKETPLACE_API')}/ens/generate?ens=${ens.name}&width=330&height=330` : ''),
@@ -26,10 +26,10 @@ export default function ENSDetailPage(props: Props) {
   const shouldReclaim = ens?.ensOwnerAddress !== ens?.nftOwnerAddress
 
   useEffect(() => {
-    if (name) {
+    if (name && wallet) {
       onFetchENS(name)
     }
-  }, [name, onFetchENS])
+  }, [name, wallet, onFetchENS])
 
   const handleAssignENSAddress = useCallback(() => {
     onOpenModal('EnsMapAddressModal', { ens })

--- a/src/components/ENSDetailPage/ENSDetailPage.types.ts
+++ b/src/components/ENSDetailPage/ENSDetailPage.types.ts
@@ -1,5 +1,6 @@
 import { Avatar } from '@dcl/schemas'
 import { openModal } from 'decentraland-dapps/dist/modules/modal/actions'
+import { Wallet } from 'decentraland-dapps/dist/modules/wallet'
 import { fetchENSRequest } from 'modules/ens/actions'
 import { ENS } from 'modules/ens/types'
 
@@ -9,9 +10,10 @@ export type Props = {
   isLoading: boolean
   alias: string | null
   avatar: Avatar | null
+  wallet: Wallet | null
   onOpenModal: typeof openModal
   onFetchENS: typeof fetchENSRequest
 }
 
-export type MapStateProps = Pick<Props, 'ens' | 'isLoading' | 'alias' | 'avatar' | 'name'>
+export type MapStateProps = Pick<Props, 'ens' | 'isLoading' | 'alias' | 'avatar' | 'name' | 'wallet'>
 export type MapDispatchProps = Pick<Props, 'onOpenModal' | 'onFetchENS'>

--- a/src/modules/ens/selectors.ts
+++ b/src/modules/ens/selectors.ts
@@ -69,7 +69,7 @@ export const getENSForLand = (state: RootState, landId: string) => {
 
 export const getENSBySubdomain = (state: RootState, subdomain = '') => {
   const ensList = getENSList(state)
-  return ensList.find(ens => ens.subdomain === subdomain) as ENS
+  return ensList.find(ens => ens.subdomain.toLowerCase() === subdomain.toLowerCase()) as ENS
 }
 
 export const isWaitingTxReclaim = createSelector<RootState, Transaction[], boolean>(getPendingTransactions, transactions =>


### PR DESCRIPTION
When fetching for names, if the name had any uppercase letter it wasn't able to find the correct ens in the state as it was being saved in lowercase. This PRs adds a fix that compares the subdomains in lowercase when searching for a specific name in the store