### PR TITLE
chore: Update @dcl/sdk package to version 7.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@dcl/hashing": "^3.0.4",
         "@dcl/mini-rpc": "^1.0.7",
         "@dcl/schemas": "^11.7.0",
-        "@dcl/sdk": "7.5.4",
+        "@dcl/sdk": "7.5.5",
         "@dcl/single-sign-on-client": "^0.1.0",
         "@dcl/ui-env": "^1.5.0",
         "@sentry/react": "^7.64.0",
@@ -1586,7 +1586,8 @@
     "node_modules/@dcl-sdk/utils": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@dcl-sdk/utils/-/utils-1.2.8.tgz",
-      "integrity": "sha512-IOur6rSK5vN/oUpfawW6ax6vXPeADPCB44WNudeIYEYER7kwT2akNKUCLLjR19cLo006i/dkdt6UsTQ677uMxA=="
+      "integrity": "sha512-IOur6rSK5vN/oUpfawW6ax6vXPeADPCB44WNudeIYEYER7kwT2akNKUCLLjR19cLo006i/dkdt6UsTQ677uMxA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/amd": {
       "version": "7.0.0-7784644013.commit-f770b3e",
@@ -1597,6 +1598,7 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.20.0.tgz",
       "integrity": "sha512-N90ZoXORvDyk+BFQPKOdtTpixeTltfa/U1dKmRPRQwAZwmt+C5U+73iJDrd3nyywpgEH6cjhqeatPX/HYL3amg==",
+      "license": "ISC",
       "dependencies": {
         "@dcl-sdk/utils": "^1.2.8",
         "@dcl/js-runtime": "7.5.2",
@@ -1608,6 +1610,7 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.19.0.tgz",
       "integrity": "sha512-mPyjenp8qzqxgQELEDiKSBlKYuUNIKDvM8WlyT2k+YW/ySTv0e57ActCgUQs6ME1olZmjs+uBZtn97NSZGpazA==",
+      "license": "ISC",
       "dependencies": {
         "@dcl-sdk/utils": "^1.2.8",
         "@dcl/js-runtime": "7.4.10",
@@ -1619,6 +1622,7 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-1.16.0.tgz",
       "integrity": "sha512-QOGyEmXj/g+42zMrshDQBYuk8lEuf+85bF92M5QQHeQ29FC2Uavs9HNL7NNz52/wWla5pP88ZlXEYGBezyVuZA==",
+      "license": "ISC",
       "dependencies": {
         "@dcl-sdk/utils": "^1.2.7",
         "@dcl/js-runtime": "7.4.10",
@@ -1629,12 +1633,14 @@
     "node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs/node_modules/@dcl/ecs": {
       "version": "7.4.10",
       "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.10.tgz",
-      "integrity": "sha512-0hpDWGGrFdqbDeFp38h33b4/rzMYceZm4My3bC3JEuUB1L+cnq+F0qZ49BUF699wgWYfyiyAA/I4bs3Nx8RcFw=="
+      "integrity": "sha512-0hpDWGGrFdqbDeFp38h33b4/rzMYceZm4My3bC3JEuUB1L+cnq+F0qZ49BUF699wgWYfyiyAA/I4bs3Nx8RcFw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs/node_modules/@dcl/explorer": {
       "version": "1.0.161055-20240311152126.commit-cae33b0",
       "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.161055-20240311152126.commit-cae33b0.tgz",
-      "integrity": "sha512-iLSXjkGssjKagPAK9ylTO4pzCrao6qlSbBP73PlH4HBFwJXLQuRI0eLTWn2FfAO3UdwoJSsXRoZjwEmsZdML/w=="
+      "integrity": "sha512-iLSXjkGssjKagPAK9ylTO4pzCrao6qlSbBP73PlH4HBFwJXLQuRI0eLTWn2FfAO3UdwoJSsXRoZjwEmsZdML/w==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs/node_modules/@dcl/inspector": {
       "version": "7.4.10",
@@ -1649,6 +1655,7 @@
       "version": "7.4.10",
       "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.4.10.tgz",
       "integrity": "sha512-w8duoBH+byyOc+PL4iUCnVsZxsiJfCDuGeenjrXhTHTf41ErIjAYheZ+3oLDPZWAp3m3y9Mhww01tX9e3bEeCQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ecs": "7.4.10",
         "react": "^18.2.0",
@@ -1659,6 +1666,7 @@
       "version": "7.4.10",
       "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.4.10.tgz",
       "integrity": "sha512-mHErm/5VPaOmUpeIXnTAvccTHAnrFMQ5iKXnLT0RfQM2qXfUZy98yhqx8x2Nwxjn4UtABw7p2tZQZRnO1FCvOQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ecs": "7.4.10",
         "@dcl/ecs-math": "2.0.2",
@@ -1673,6 +1681,7 @@
       "version": "7.4.10",
       "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.4.10.tgz",
       "integrity": "sha512-7OKg5Agqtz4mO3k5IuScm6DLRUCmQyZIYQocAJSKy9zGNdim2siF0vo5nxU8b9KzvxpEb9uySPVkcNBMwyLf+A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
         "@dcl/ecs": "7.4.10",
@@ -1716,12 +1725,14 @@
     "node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs/node_modules/@dcl/ecs": {
       "version": "7.4.15",
       "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.4.15.tgz",
-      "integrity": "sha512-iGetQ19PpHq/NWs5SeqCFShg34iPmYK0IfIch8gmqPjOnLilRIanYg8Q0y1IzsZYs6kJ8sQf435xA76h07btiQ=="
+      "integrity": "sha512-iGetQ19PpHq/NWs5SeqCFShg34iPmYK0IfIch8gmqPjOnLilRIanYg8Q0y1IzsZYs6kJ8sQf435xA76h07btiQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs/node_modules/@dcl/explorer": {
       "version": "1.0.161749-20240401171209.commit-d6d28f4",
       "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.161749-20240401171209.commit-d6d28f4.tgz",
-      "integrity": "sha512-5jji07MVmMiNPY9gIHWrL3Wwh4SpdaUKnzMHMiKy830QJ1Nif9jpi5qcISmoDdXhoEJbC2vM1Gyj5D4rQibHew=="
+      "integrity": "sha512-5jji07MVmMiNPY9gIHWrL3Wwh4SpdaUKnzMHMiKy830QJ1Nif9jpi5qcISmoDdXhoEJbC2vM1Gyj5D4rQibHew==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs/node_modules/@dcl/inspector": {
       "version": "7.4.15",
@@ -1735,12 +1746,14 @@
     "node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs/node_modules/@dcl/js-runtime": {
       "version": "7.4.10",
       "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.4.10.tgz",
-      "integrity": "sha512-h3coABWz24xFZosDh1cj1CVK64IaSq53yfvgXzO6FHrvnTxgHnRd+VRgQtfIBGpI+P4Oy3/XOSXHvrFTW36IYQ=="
+      "integrity": "sha512-h3coABWz24xFZosDh1cj1CVK64IaSq53yfvgXzO6FHrvnTxgHnRd+VRgQtfIBGpI+P4Oy3/XOSXHvrFTW36IYQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs/node_modules/@dcl/protocol": {
       "version": "1.0.0-8299166777.commit-9493ffe",
       "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-8299166777.commit-9493ffe.tgz",
       "integrity": "sha512-QgYSltXnQvDlt66BsxRJ/o77xOPWDH1ku+OE8jchohwyXEY8KD5UV/seNU2u+TM8iPMjE+9a40p2AAtAjBnsJQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0"
       }
@@ -1749,6 +1762,7 @@
       "version": "7.4.15",
       "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.4.15.tgz",
       "integrity": "sha512-FnupG6D+ufu894nOxtrosgC8aKi97VxdyA4bRq4LpfPC0E2RwMb4TqwfQRVQIpYXOyKa/XDzdQbg7lnWAS7qew==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ecs": "7.4.15",
         "react": "^18.2.0",
@@ -1759,6 +1773,7 @@
       "version": "7.4.15",
       "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.4.15.tgz",
       "integrity": "sha512-45LYGhuAmzQmcD+RfdrybSYexA88rkZvTTnag5+v/q31wpXMk46+WMOddy82zl1XRbb9Qo31f/ZlGmzfsJUiMQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ecs": "7.4.15",
         "@dcl/ecs-math": "2.0.2",
@@ -1773,6 +1788,7 @@
       "version": "7.4.15",
       "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.4.15.tgz",
       "integrity": "sha512-U+a2LpEst+8ofOPLh/JAu3sDmNMsZvooRWhnp1r7vENDaYrXe3Kiq+Z09CuZvIB7afvQ6mhrJGWNW12eEYtsyg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
         "@dcl/ecs": "7.4.15",
@@ -1816,22 +1832,26 @@
     "node_modules/@dcl/asset-packs/node_modules/@dcl/asset-packs/node_modules/@dcl/sdk/node_modules/@dcl/js-runtime": {
       "version": "7.4.15",
       "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.4.15.tgz",
-      "integrity": "sha512-GZkr/KNtm6VfcaBSrVO011NMQpHm4sSRWWSZOIOQ1K0wR/k95AbIx+T1efFaGQN2y9n60PUK9cdbAuInBK0RLg=="
+      "integrity": "sha512-GZkr/KNtm6VfcaBSrVO011NMQpHm4sSRWWSZOIOQ1K0wR/k95AbIx+T1efFaGQN2y9n60PUK9cdbAuInBK0RLg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/asset-packs/node_modules/@dcl/ecs": {
       "version": "7.5.2",
       "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.5.2.tgz",
-      "integrity": "sha512-f1+TF2f5Gkg2Xl7bQ+KWNMOYubNdZIVXQC+xU54iH4l8o+a4S2PzI8yzALfvThtXh1PsSrmm/6mOmg0B2O6oJA=="
+      "integrity": "sha512-f1+TF2f5Gkg2Xl7bQ+KWNMOYubNdZIVXQC+xU54iH4l8o+a4S2PzI8yzALfvThtXh1PsSrmm/6mOmg0B2O6oJA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/asset-packs/node_modules/@dcl/explorer": {
       "version": "1.0.163304-20240520163732.commit-e8937d1",
       "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.163304-20240520163732.commit-e8937d1.tgz",
-      "integrity": "sha512-RWnbLM4WocFH02btXVKnAoCzUT+WmQ6evfxrNNp5BpX16yyhvz9VgIx9Gd47Oi7pW6tb/CZgUYuSIPB6TfMY1A=="
+      "integrity": "sha512-RWnbLM4WocFH02btXVKnAoCzUT+WmQ6evfxrNNp5BpX16yyhvz9VgIx9Gd47Oi7pW6tb/CZgUYuSIPB6TfMY1A==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/asset-packs/node_modules/@dcl/hashing": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@dcl/hashing/-/hashing-1.1.3.tgz",
       "integrity": "sha512-mU1+Q8jcFLAR1hSBOd6WcnLwvQmKIPAH8+UPf2DZUk+Ntu7jWqSOqG+PoWRlh7/gPfI/gKofeW0a+HzVUK6N/g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "ethereum-cryptography": "^1.0.3",
         "ipfs-unixfs-importer": "^7.0.3",
@@ -1850,12 +1870,14 @@
     "node_modules/@dcl/asset-packs/node_modules/@dcl/js-runtime": {
       "version": "7.5.2",
       "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.5.2.tgz",
-      "integrity": "sha512-KZbxb2ONV6QlKmCer0gi/1Z0DKD6TcZZK+wfHRPlFrrIwd9ZoYRbKAqZXDChu1ZgWen2k3GwvYCEP7vyI/Ay3Q=="
+      "integrity": "sha512-KZbxb2ONV6QlKmCer0gi/1Z0DKD6TcZZK+wfHRPlFrrIwd9ZoYRbKAqZXDChu1ZgWen2k3GwvYCEP7vyI/Ay3Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/asset-packs/node_modules/@dcl/protocol": {
       "version": "1.0.0-9115457439.commit-926ebd1",
       "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-9115457439.commit-926ebd1.tgz",
       "integrity": "sha512-4MA1sx4cpfapP+EDAZdpdaONthoDlv4VMc0CwAKcmhp0vxGgExeEpLkPh6gvNXmkl8z8z3nEcDOX1X95dvCYuA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0"
       }
@@ -1864,6 +1886,7 @@
       "version": "7.5.2",
       "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.5.2.tgz",
       "integrity": "sha512-O3clRhPYEv91kaFijfLdGjLE7fLiRdxGu1vF5CzirR6cju7UmRi7DPb4BzxdIHQvYYWb+m2JmVNZ8ckz9mvsRw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ecs": "7.5.2",
         "react": "^18.2.0",
@@ -1874,6 +1897,7 @@
       "version": "8.2.3-20230801124703.commit-ade94fc",
       "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-8.2.3-20230801124703.commit-ade94fc.tgz",
       "integrity": "sha512-GP8veICDcxZaxcCbsr8oT0tgOtv3OPN+LJMo3DsNPx1ABe2UhrjJGk5qETfZX5qyTtcKLNMhEMZ3SP11PbU2qg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -1884,6 +1908,7 @@
       "version": "7.5.2",
       "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.5.2.tgz",
       "integrity": "sha512-SlJXEgXdKeZAjQp27b684v6wCSAvu66RcBKdUcQsokkdTuW1Se15c5MhMNGv3KexV75DgTGiQEPVSAnsYJBGhg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ecs": "7.5.2",
         "@dcl/ecs-math": "2.0.2",
@@ -1898,6 +1923,7 @@
       "version": "7.5.2",
       "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.5.2.tgz",
       "integrity": "sha512-bOHTNrIaTQos+9KXCQVq5ER3sGex0DQHzFLy5KlnWZd+bDAys63qfFIp/Igf7qCGBZv4A7MQQmxm0w+9RUGRww==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
         "@dcl/ecs": "7.5.2",
@@ -1942,6 +1968,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
       "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
+      "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
         "inherits": "^2.0.4",
@@ -1953,6 +1980,7 @@
       "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.9.tgz",
       "integrity": "sha512-l11hWRfugIcbGuTZwAM5PwpjPPjyb6UZOGwlHSnOBV5o07XhQ4gNpBN67FbODvpjyHtd+0Xs6KNvUcGBiDRsdg==",
       "deprecated": "This module has been superseded by the multiformats module",
+      "license": "MIT",
       "dependencies": {
         "multibase": "^4.0.1",
         "multicodec": "^3.0.1",
@@ -1967,12 +1995,14 @@
     "node_modules/@dcl/asset-packs/node_modules/err-code": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
-      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==",
+      "license": "MIT"
     },
     "node_modules/@dcl/asset-packs/node_modules/hamt-sharding": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.1.tgz",
       "integrity": "sha512-vnjrmdXG9dDs1m/H4iJ6z0JFI2NtgsW5keRkTcM85NGak69Mkf5PHUqBz+Xs0T4sg0ppvj9O5EGAJo40FTxmmA==",
+      "license": "MIT",
       "dependencies": {
         "sparse-array": "^1.3.1",
         "uint8arrays": "^3.0.0"
@@ -1986,6 +2016,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-4.0.3.tgz",
       "integrity": "sha512-hzJ3X4vlKT8FQ3Xc4M1szaFVjsc1ZydN+E4VQ91aXxfpjFn9G2wsMo1EFdAXNq/BUnN5dgqIOMP5zRYr3DTsAw==",
+      "license": "MIT",
       "dependencies": {
         "err-code": "^3.0.1",
         "protobufjs": "^6.10.2"
@@ -1999,6 +2030,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-7.0.3.tgz",
       "integrity": "sha512-qeFOlD3AQtGzr90sr5Tq1Bi8pT5Nr2tSI8z310m7R4JDYgZc6J1PEZO3XZQ8l1kuGoqlAppBZuOYmPEqaHcVQQ==",
+      "license": "MIT",
       "dependencies": {
         "bl": "^5.0.0",
         "cids": "^1.1.5",
@@ -2024,6 +2056,7 @@
       "version": "2.1.10",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.10.tgz",
       "integrity": "sha512-Q9/hhJa2836nQfEJSZTmr+pg9+cDJS9XEAp7N2Vg5MzL3bK/mkMVfjscRGYruP9jNda6MAdf4QD/y78gSzkp6A==",
+      "license": "MIT",
       "dependencies": {
         "multiformats": "^9.4.2"
       }
@@ -2033,6 +2066,7 @@
       "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.22.3.tgz",
       "integrity": "sha512-dfG5C5OVAR4FEP7Al2CrHWvAyIM7UhAQrjnOYOIxXGQz5NlEj6wGX0XQf6Ru6or1na6upvV3NQfstapQG8X2rg==",
       "deprecated": "This module has been superseded by @ipld/dag-pb and multiformats",
+      "license": "MIT",
       "dependencies": {
         "cids": "^1.0.0",
         "interface-ipld-format": "^1.0.0",
@@ -2051,6 +2085,7 @@
       "version": "2.1.10",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.10.tgz",
       "integrity": "sha512-Q9/hhJa2836nQfEJSZTmr+pg9+cDJS9XEAp7N2Vg5MzL3bK/mkMVfjscRGYruP9jNda6MAdf4QD/y78gSzkp6A==",
+      "license": "MIT",
       "dependencies": {
         "multiformats": "^9.4.2"
       }
@@ -2058,13 +2093,15 @@
     "node_modules/@dcl/asset-packs/node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/asset-packs/node_modules/multibase": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
       "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
       "deprecated": "This module has been superseded by the multiformats module",
+      "license": "MIT",
       "dependencies": {
         "@multiformats/base-x": "^4.0.1"
       },
@@ -2078,6 +2115,7 @@
       "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.2.1.tgz",
       "integrity": "sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==",
       "deprecated": "This module has been superseded by the multiformats module",
+      "license": "MIT",
       "dependencies": {
         "uint8arrays": "^3.0.0",
         "varint": "^6.0.0"
@@ -2086,12 +2124,14 @@
     "node_modules/@dcl/asset-packs/node_modules/multicodec/node_modules/varint": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+      "license": "MIT"
     },
     "node_modules/@dcl/asset-packs/node_modules/multihashes": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
       "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
+      "license": "MIT",
       "dependencies": {
         "multibase": "^4.0.1",
         "uint8arrays": "^3.0.0",
@@ -2106,6 +2146,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.1.4.tgz",
       "integrity": "sha512-sB1MiQXPSBTNRVSJc2zM157PXgDtud2nMFUEIvBrsq5Wv96sUclMRK/ecjoP1T/W61UJBqt4tCTwMkUpt2Gbzg==",
+      "license": "MIT",
       "dependencies": {
         "blakejs": "^1.1.0",
         "err-code": "^3.0.0",
@@ -2124,6 +2165,7 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
       "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -2148,6 +2190,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2159,6 +2202,7 @@
       "version": "0.29.2",
       "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
       "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2174,6 +2218,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -2186,6 +2231,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -2504,19 +2550,22 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.5.4.tgz",
-      "integrity": "sha512-oIFM5G3ncZnJagBBDKqkasxlPl9O2/eN906pB9x2jczWQcKagfXKVxYKIppzofkBfZedlUYfYZ9XRcDQVMcNoQ=="
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.5.5.tgz",
+      "integrity": "sha512-fS7LWBmOlgkdJfM+CdiJnV4Cx3wo4Vg79C8DC5izMfKpG+9wTJHhGAXyPo8RC8ERWmvuHcGwrZXlr9hsPWiMWw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/ecs-math": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@dcl/ecs-math/-/ecs-math-2.0.2.tgz",
-      "integrity": "sha512-w01+a3mpHvxGPHepu0hAAX8OfpBSQEqBbC1+U8o+5SBSQVXHiRwt3P4cK20yM8QCgZe3enPttmpqePnjTliTig=="
+      "integrity": "sha512-w01+a3mpHvxGPHepu0hAAX8OfpBSQEqBbC1+U8o+5SBSQVXHiRwt3P4cK20yM8QCgZe3enPttmpqePnjTliTig==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/explorer": {
-      "version": "1.0.163868-20240619115445.commit-f03c228",
-      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.163868-20240619115445.commit-f03c228.tgz",
-      "integrity": "sha512-xb/0R1fmlLMSS4WYuRFqL5VbT3o/Q5Zuxqv4QTgZMRvbIG9mIruAIdeQC5eh7rR2clcHSxDZ0kliJaBHUy2m3g=="
+      "version": "1.0.163667-20240612172815.commit-85b23a7",
+      "resolved": "https://registry.npmjs.org/@dcl/explorer/-/explorer-1.0.163667-20240612172815.commit-85b23a7.tgz",
+      "integrity": "sha512-R4hja7Bl+GgEBQQuemucFGcx2MRTZTMDhg1vrOZUzgRECWybUN1jnVuwUuJ6nJrmfDXTJOgznJMWqoVGRMq7vw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/hashing": {
       "version": "3.0.4",
@@ -2524,23 +2573,25 @@
       "integrity": "sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg=="
     },
     "node_modules/@dcl/inspector": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.5.4.tgz",
-      "integrity": "sha512-3kD9u5/QVe7B8UQj4ZgmjfzbBTuaODZ/Hyrf6/Qs0gAI4HSj4n3BSzxPay6N1Isir66CyGQ9GJz+D/ZeX2ix2Q==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@dcl/inspector/-/inspector-7.5.5.tgz",
+      "integrity": "sha512-vDQsj/PSgOk3aMI/taX4Fe3FqNeqZ3MQ19BHFP0hGF3oJ75mGhlz+h/N5neLikDJ4L+7IHwmhYgMl3cPDP/bRw==",
       "dependencies": {
         "@dcl/asset-packs": "1.20.0",
         "ts-deepmerge": "^7.0.0"
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.5.4.tgz",
-      "integrity": "sha512-DdsDdg/F51YiaUvCobONWe2hYBSxTRT5dQXOzHx1bVWt8FCwa8E6IxNNp4YbJLV4WroKf3JzmDggGZqIt9vdaA=="
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.5.5.tgz",
+      "integrity": "sha512-wG4+TrBCJLlZSraMAMA0DipwaFMYPTN8wOlm1bn3InqNHptBRdBa1s5hmBe+9YYe4iWfsdC8YnOUEOUsojpb9A==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/linker-dapp": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@dcl/linker-dapp/-/linker-dapp-0.12.0.tgz",
-      "integrity": "sha512-bYxvZ2ljoBuy1KyGugakL9hCRFXjoK55qm40DSfkm5g1o7r2FVEMMVP4e1aSj7IczYrDqp1bibO0+hZF/ddeLg=="
+      "integrity": "sha512-bYxvZ2ljoBuy1KyGugakL9hCRFXjoK55qm40DSfkm5g1o7r2FVEMMVP4e1aSj7IczYrDqp1bibO0+hZF/ddeLg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/mini-comms": {
       "version": "1.0.1-20230216163137.commit-a4c75be",
@@ -2565,6 +2616,7 @@
       "version": "6.19.0",
       "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-6.19.0.tgz",
       "integrity": "sha512-S8lrq8L1vriVXkBzeycxppjbfgJ5XofA9pbCKdteJR+79r6Dn5oLo3t5g7RcMQDihdjWdDLbbwxlEAkPgmvc8w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -2589,6 +2641,7 @@
       "version": "1.0.0-9466805132.commit-365e0bb",
       "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-9466805132.commit-365e0bb.tgz",
       "integrity": "sha512-CMO2/JkdMPLJQj+jdT5yqolKFDPkQF2hkS/HEUtsxCzkLoN3H0xXmDUhRuh2LTmBBl401meH/tJ+fQcPyd9xLQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dcl/ts-proto": "1.154.0"
       }
@@ -2597,6 +2650,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@dcl/quests-client/-/quests-client-1.0.3.tgz",
       "integrity": "sha512-VwZbXuHsRbRcboUUlBrauuR7VQ7IQP31rWI7wNKIYfWroTH4Yw7Bby1au9JBPWPayM/zRDij4uSd9pMJtidsqw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dcl/protocol": "^1.0.0-6160718705.commit-03626d7",
         "@dcl/rpc": "^1.1.2",
@@ -2607,14 +2661,16 @@
     "node_modules/@dcl/quests-manager": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@dcl/quests-manager/-/quests-manager-0.1.4.tgz",
-      "integrity": "sha512-IPB043+NbQB3om2FlmQGmaRxTokHaSM9o3a7sEL0yJgBb60mukCpMdNXxzdIcemixfV3EhIJQ2G8HgK30XKTkA=="
+      "integrity": "sha512-IPB043+NbQB3om2FlmQGmaRxTokHaSM9o3a7sEL0yJgBb60mukCpMdNXxzdIcemixfV3EhIJQ2G8HgK30XKTkA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.5.4.tgz",
-      "integrity": "sha512-VaIOES8EHlOQofy2Cf+FWgKnSrRSOORPmA1SfgJZsRTiA1iN4tBWmiE/BtSbKniH+us7mT1rRYbJs93GeUFMxQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.5.5.tgz",
+      "integrity": "sha512-q4Hia7ky4iNBkhZkBZ2sSO38JAA5nw7l3G9kadfcbv9aPa9nDeG+BttRAv+QHdNCY+FRhHAjCFMNY7UELvk+MQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs": "7.5.4",
+        "@dcl/ecs": "7.5.5",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -2623,6 +2679,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2634,6 +2691,7 @@
       "version": "0.29.2",
       "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
       "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2649,6 +2707,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -2657,6 +2716,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@dcl/rpc/-/rpc-1.1.2.tgz",
       "integrity": "sha512-HgZe9umoD48ZQRaiKTss+vj/War/HjH/DBnb6pzd5fx2OMInaB1YYso3OZ4dCT/OC0AtNny8Tkb3CUJdYAvj/w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "mitt": "^3.0.0",
         "ts-proto": "^1.146.0"
@@ -2674,28 +2734,30 @@
       }
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.5.4.tgz",
-      "integrity": "sha512-Dd8ggTRVsbAXwA25zs5UB0BjP3WCMYiPniJvb+920CtwY+p8Q/qB0FH5jfi7w7qD5Yw4Tl4tmfS4MHaogEo9aw==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.5.5.tgz",
+      "integrity": "sha512-APEGYfOayxM6Ia8OxXYZT8TxTjduS8bz6wzeiMApXsmJWP+1UHyL+FGnLEVQXLO+5qmO1h+gUfo4unX9Fmu5mA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs": "7.5.4",
+        "@dcl/ecs": "7.5.5",
         "@dcl/ecs-math": "2.0.2",
-        "@dcl/explorer": "1.0.163868-20240619115445.commit-f03c228",
-        "@dcl/js-runtime": "7.5.4",
-        "@dcl/react-ecs": "7.5.4",
-        "@dcl/sdk-commands": "7.5.4",
+        "@dcl/explorer": "1.0.163667-20240612172815.commit-85b23a7",
+        "@dcl/js-runtime": "7.5.5",
+        "@dcl/react-ecs": "7.5.5",
+        "@dcl/sdk-commands": "7.5.5",
         "text-encoding": "0.7.0"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.5.4.tgz",
-      "integrity": "sha512-6SGlwsYGz/RveKzKGC8NNj8COJ2qB5sce+fK6pugtTMbUMXJ14ePTE+jOxCZLXd4RvinNZwMGS/TL3Vih2CvDA==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.5.5.tgz",
+      "integrity": "sha512-Rih9z8xQn7YPwLZ15DibBgtKmdQ5k83XSo849GleXhcAP3ozzulwNiSOFZGiPhEPedAYAMCrSsuRIEa0uqdhOw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.5.4",
+        "@dcl/ecs": "7.5.5",
         "@dcl/hashing": "1.1.3",
-        "@dcl/inspector": "7.5.4",
+        "@dcl/inspector": "7.5.5",
         "@dcl/linker-dapp": "^0.12.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
         "@dcl/protocol": "1.0.0-9466805132.commit-365e0bb",
@@ -2735,6 +2797,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@dcl/hashing/-/hashing-1.1.3.tgz",
       "integrity": "sha512-mU1+Q8jcFLAR1hSBOd6WcnLwvQmKIPAH8+UPf2DZUk+Ntu7jWqSOqG+PoWRlh7/gPfI/gKofeW0a+HzVUK6N/g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "ethereum-cryptography": "^1.0.3",
         "ipfs-unixfs-importer": "^7.0.3",
@@ -2745,6 +2808,7 @@
       "version": "8.2.3-20230801124703.commit-ade94fc",
       "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-8.2.3-20230801124703.commit-ade94fc.tgz",
       "integrity": "sha512-GP8veICDcxZaxcCbsr8oT0tgOtv3OPN+LJMo3DsNPx1ABe2UhrjJGk5qETfZX5qyTtcKLNMhEMZ3SP11PbU2qg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -2755,6 +2819,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
       "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
+      "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
         "inherits": "^2.0.4",
@@ -2766,6 +2831,7 @@
       "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.9.tgz",
       "integrity": "sha512-l11hWRfugIcbGuTZwAM5PwpjPPjyb6UZOGwlHSnOBV5o07XhQ4gNpBN67FbODvpjyHtd+0Xs6KNvUcGBiDRsdg==",
       "deprecated": "This module has been superseded by the multiformats module",
+      "license": "MIT",
       "dependencies": {
         "multibase": "^4.0.1",
         "multicodec": "^3.0.1",
@@ -2780,12 +2846,14 @@
     "node_modules/@dcl/sdk-commands/node_modules/err-code": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
-      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==",
+      "license": "MIT"
     },
     "node_modules/@dcl/sdk-commands/node_modules/hamt-sharding": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.1.tgz",
       "integrity": "sha512-vnjrmdXG9dDs1m/H4iJ6z0JFI2NtgsW5keRkTcM85NGak69Mkf5PHUqBz+Xs0T4sg0ppvj9O5EGAJo40FTxmmA==",
+      "license": "MIT",
       "dependencies": {
         "sparse-array": "^1.3.1",
         "uint8arrays": "^3.0.0"
@@ -2799,6 +2867,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-4.0.3.tgz",
       "integrity": "sha512-hzJ3X4vlKT8FQ3Xc4M1szaFVjsc1ZydN+E4VQ91aXxfpjFn9G2wsMo1EFdAXNq/BUnN5dgqIOMP5zRYr3DTsAw==",
+      "license": "MIT",
       "dependencies": {
         "err-code": "^3.0.1",
         "protobufjs": "^6.10.2"
@@ -2812,6 +2881,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-7.0.3.tgz",
       "integrity": "sha512-qeFOlD3AQtGzr90sr5Tq1Bi8pT5Nr2tSI8z310m7R4JDYgZc6J1PEZO3XZQ8l1kuGoqlAppBZuOYmPEqaHcVQQ==",
+      "license": "MIT",
       "dependencies": {
         "bl": "^5.0.0",
         "cids": "^1.1.5",
@@ -2837,6 +2907,7 @@
       "version": "2.1.10",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.10.tgz",
       "integrity": "sha512-Q9/hhJa2836nQfEJSZTmr+pg9+cDJS9XEAp7N2Vg5MzL3bK/mkMVfjscRGYruP9jNda6MAdf4QD/y78gSzkp6A==",
+      "license": "MIT",
       "dependencies": {
         "multiformats": "^9.4.2"
       }
@@ -2846,6 +2917,7 @@
       "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.22.3.tgz",
       "integrity": "sha512-dfG5C5OVAR4FEP7Al2CrHWvAyIM7UhAQrjnOYOIxXGQz5NlEj6wGX0XQf6Ru6or1na6upvV3NQfstapQG8X2rg==",
       "deprecated": "This module has been superseded by @ipld/dag-pb and multiformats",
+      "license": "MIT",
       "dependencies": {
         "cids": "^1.0.0",
         "interface-ipld-format": "^1.0.0",
@@ -2864,6 +2936,7 @@
       "version": "2.1.10",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.10.tgz",
       "integrity": "sha512-Q9/hhJa2836nQfEJSZTmr+pg9+cDJS9XEAp7N2Vg5MzL3bK/mkMVfjscRGYruP9jNda6MAdf4QD/y78gSzkp6A==",
+      "license": "MIT",
       "dependencies": {
         "multiformats": "^9.4.2"
       }
@@ -2871,13 +2944,15 @@
     "node_modules/@dcl/sdk-commands/node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dcl/sdk-commands/node_modules/multibase": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
       "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
       "deprecated": "This module has been superseded by the multiformats module",
+      "license": "MIT",
       "dependencies": {
         "@multiformats/base-x": "^4.0.1"
       },
@@ -2891,6 +2966,7 @@
       "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.2.1.tgz",
       "integrity": "sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==",
       "deprecated": "This module has been superseded by the multiformats module",
+      "license": "MIT",
       "dependencies": {
         "uint8arrays": "^3.0.0",
         "varint": "^6.0.0"
@@ -2899,12 +2975,14 @@
     "node_modules/@dcl/sdk-commands/node_modules/multicodec/node_modules/varint": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+      "license": "MIT"
     },
     "node_modules/@dcl/sdk-commands/node_modules/multihashes": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
       "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
+      "license": "MIT",
       "dependencies": {
         "multibase": "^4.0.1",
         "uint8arrays": "^3.0.0",
@@ -2919,6 +2997,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.1.4.tgz",
       "integrity": "sha512-sB1MiQXPSBTNRVSJc2zM157PXgDtud2nMFUEIvBrsq5Wv96sUclMRK/ecjoP1T/W61UJBqt4tCTwMkUpt2Gbzg==",
+      "license": "MIT",
       "dependencies": {
         "blakejs": "^1.1.0",
         "err-code": "^3.0.0",
@@ -2937,6 +3016,7 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
       "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -2965,6 +3045,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -2982,6 +3063,7 @@
       "version": "1.154.0",
       "resolved": "https://registry.npmjs.org/@dcl/ts-proto/-/ts-proto-1.154.0.tgz",
       "integrity": "sha512-2S5AKMMPVZrVfa/1WRy4/h0niikcbu3Yf6dCoudh7ScG7BsyKAPC3CMg6IJKHzrmWS593UZClq7YJof6Vt4O+w==",
+      "license": "ISC",
       "dependencies": {
         "@types/object-hash": "^3.0.2",
         "case-anything": "^2.1.10",
@@ -4304,6 +4386,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
       "engines": {
         "node": ">=14"
       }
@@ -5043,6 +5126,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
       "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -5051,6 +5135,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
       "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "license": "MIT",
       "dependencies": {
         "@lukeed/csprng": "^1.1.0"
       },
@@ -5274,6 +5359,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5986,6 +6072,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.4.1.tgz",
       "integrity": "sha512-kV0Pf33HnthuBOVdYNani21kYyj118Fn+9757bxqoksiXoZlYvBsFq6giNdCsKcTIE1eAMqNDq3xE1VQ0cfsHA==",
+      "license": "MIT",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
         "@segment/analytics-generic-utils": "1.1.1",
@@ -5997,6 +6084,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.1.1.tgz",
       "integrity": "sha512-THTIzBPHnvu1HYJU3fARdJ3qIkukO3zDXsmDm+kAeUks5R9CBXOQ6rPChiASVzSmwAIIo5uFIXXnCraojlq/Gw==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.1"
       }
@@ -6005,6 +6093,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-1.3.0.tgz",
       "integrity": "sha512-lRLz1WZaDokMoUe299yP5JkInc3OgJuqNNlxb6j0q22umCiq6b5iDo2gRmFn93reirIvJxWIicQsGrHd93q8GQ==",
+      "license": "MIT",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
         "@segment/analytics-core": "1.4.1",
@@ -6913,7 +7002,8 @@
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "license": "MIT"
     },
     "node_modules/@types/http-proxy": {
       "version": "1.17.14",
@@ -7064,7 +7154,8 @@
     "node_modules/@types/object-hash": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-3.0.6.tgz",
-      "integrity": "sha512-fOBV8C1FIu2ELinoILQ+ApxcUKz4ngq+IWUYrxSGjXzzjUALijilampwkMgEtJ+h2njAW3pi853QpzNVCHB73w=="
+      "integrity": "sha512-fOBV8C1FIu2ELinoILQ+ApxcUKz4ngq+IWUYrxSGjXzzjUALijilampwkMgEtJ+h2njAW3pi853QpzNVCHB73w==",
+      "license": "MIT"
     },
     "node_modules/@types/pbkdf2": {
       "version": "3.1.2",
@@ -7257,6 +7348,7 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
       "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -7278,6 +7370,7 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -8140,6 +8233,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@well-known-components/env-config-provider/-/env-config-provider-1.2.0.tgz",
       "integrity": "sha512-QYDL9Uk1zEs5Q4ymgeZo1GVzuHe9Pp/jOLPRIbhwtPOCQ2Bd9yIlUWiFoC36JpcUSIlQ7Fzh8x21v2U95q5/+Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "dotenv": "^16.0.1"
       },
@@ -8160,6 +8254,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@well-known-components/http-server/-/http-server-2.1.0.tgz",
       "integrity": "sha512-IHD7aLTA+9DYEchQubHDBwc4FmVEmQC+2TWbi8Tz+QlkiQdtndcuba8XHH+EwqlB5sna/EAJGZGXPxS7okcHKA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/http-errors": "^2.0.1",
         "destroy": "^1.2.0",
@@ -8185,6 +8280,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@well-known-components/logger/-/logger-3.1.3.tgz",
       "integrity": "sha512-tTjD27CdfU4SVe+kPfjRbPSqdrw0Crg+M31RNejinCuMEBtEGbhYLtB1M4gn+PSTy2Oi3cI3iOdeQ1xVhMSerQ==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@well-known-components/interfaces": "^1.0.0"
       }
@@ -8193,6 +8289,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@well-known-components/metrics/-/metrics-2.1.0.tgz",
       "integrity": "sha512-nJ3TdVMiJN2i7TtelndDtxvZERcSE7dtlmRfRV7yYZZshDZrQTC9EFH2uhmCWDWI0qnonvlq++JRSXBNJJfbvg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "prom-client": "^15.1.0"
       }
@@ -8201,6 +8298,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@well-known-components/pushable-channel/-/pushable-channel-1.0.3.tgz",
       "integrity": "sha512-8ibswJXQx7YfmUgzXp02xsIBTw6zrVXgNybV8asvEr1vE/0m/xmZi41+NwTcZmLCNRzsE/i+aRUzNO+oyq/g2g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "mitt": "^3.0.0"
       }
@@ -8617,6 +8715,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
       "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "license": "MIT",
       "dependencies": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.4",
@@ -8634,6 +8733,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
       "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "license": "MIT",
       "dependencies": {
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
@@ -8654,6 +8754,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -8664,6 +8765,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -8682,12 +8784,14 @@
     "node_modules/archiver-utils/node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/archiver-utils/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -8699,6 +8803,7 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -8712,12 +8817,14 @@
     "node_modules/archiver-utils/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/archiver-utils/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -8725,7 +8832,8 @@
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -8847,7 +8955,8 @@
     "node_modules/async": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
+      "license": "MIT"
     },
     "node_modules/async-each": {
       "version": "1.0.6",
@@ -9391,7 +9500,8 @@
     "node_modules/bintrees": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
-      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/bl": {
       "version": "3.0.1",
@@ -9650,6 +9760,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -9851,6 +9962,7 @@
       "version": "2.1.13",
       "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
       "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "license": "MIT",
       "engines": {
         "node": ">=12.13"
       },
@@ -10276,7 +10388,8 @@
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -10432,6 +10545,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
       "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "license": "MIT",
       "dependencies": {
         "buffer-crc32": "^0.2.13",
         "crc32-stream": "^4.0.2",
@@ -10760,6 +10874,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
       "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
@@ -11089,7 +11204,8 @@
     "node_modules/dataloader": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
-      "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw=="
+      "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/date-fns": {
       "version": "2.30.0",
@@ -11936,6 +12052,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -11966,6 +12083,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
@@ -12143,6 +12261,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/dprint-node/-/dprint-node-1.0.8.tgz",
       "integrity": "sha512-iVKnUtYfGrYcW1ZAlfR/F59cUVL8QIhWoBJoSjkkdua/dkWIgjZfiLMeTjiB06X0ZLkQ0M2C1VbUj/CxkIf1zg==",
+      "license": "MIT",
       "dependencies": {
         "detect-libc": "^1.0.3"
       }
@@ -12156,6 +12275,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
       "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -12174,7 +12294,8 @@
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.646",
@@ -13261,6 +13382,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -13364,6 +13486,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -13967,6 +14090,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -14000,6 +14124,7 @@
       "version": "9.3.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
       "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "minimatch": "^8.0.2",
@@ -14028,6 +14153,7 @@
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
       "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -14414,6 +14540,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
@@ -17068,6 +17195,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
       "dependencies": {
         "readable-stream": "^2.0.5"
       },
@@ -17078,12 +17206,14 @@
     "node_modules/lazystream/node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/lazystream/node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -17097,12 +17227,14 @@
     "node_modules/lazystream/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -17300,17 +17432,20 @@
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
     },
     "node_modules/lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA=="
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "license": "MIT"
     },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "license": "MIT"
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -17345,7 +17480,8 @@
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -17365,7 +17501,8 @@
     "node_modules/lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw=="
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "license": "MIT"
     },
     "node_modules/lodash.unset": {
       "version": "4.5.2",
@@ -17712,6 +17849,7 @@
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
       "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "license": "ISC",
       "engines": {
         "node": ">=8"
       }
@@ -18740,6 +18878,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
@@ -18846,6 +18985,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -19177,6 +19317,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -19192,6 +19333,7 @@
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
       "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
+      "license": "ISC",
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -19200,6 +19342,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -19207,7 +19350,8 @@
     "node_modules/path-to-regexp": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw=="
+      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -19241,7 +19385,8 @@
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -19403,6 +19548,7 @@
       "version": "1.0.32",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
       "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
+      "license": "MIT",
       "dependencies": {
         "async": "^2.6.4",
         "debug": "^3.2.7",
@@ -19416,6 +19562,7 @@
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
       "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -19424,6 +19571,7 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -19730,6 +19878,7 @@
       "version": "15.1.2",
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.2.tgz",
       "integrity": "sha512-on3h1iXb04QFLLThrmVYg1SChBQ9N1c+nKAjebBjokBqipddH3uxmOUcEkTnzmJ8Jh/5TSUnUqS40i2QB2dJHQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.4.0",
         "tdigest": "^0.1.1"
@@ -20870,6 +21019,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
       "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.1.0"
       }
@@ -20878,6 +21028,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -21785,7 +21936,8 @@
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sha.js": {
       "version": "2.4.11",
@@ -22245,6 +22397,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -22623,6 +22776,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -22638,6 +22792,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -22662,6 +22817,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -22671,6 +22827,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
       "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
       "dependencies": {
         "bintrees": "1.0.2"
       }
@@ -22872,7 +23029,8 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
       "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==",
-      "deprecated": "no longer maintained"
+      "deprecated": "no longer maintained",
+      "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/text-encoding-utf-8": {
       "version": "1.0.2",
@@ -23117,6 +23275,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.6"
       }
@@ -23418,6 +23577,7 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.9.0.tgz",
       "integrity": "sha512-roe6W6MeZmCjRmppyfOURklO5tQFQ6Sg7swURKkwYJvV7dbGCrK28um5+51iW3twdPRKtwarqFAVMU6G1mvnuQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "dprint-node": "^1.0.8"
       }
@@ -23426,6 +23586,7 @@
       "version": "1.180.0",
       "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.180.0.tgz",
       "integrity": "sha512-Gx+y1ohKNitnBpoA4ELRPl2nHBa4zUkedj3kHKuwYn0THpLiLVLuzYidlqJVZBDooI+l/EROGGqlCt95FItI9g==",
+      "license": "ISC",
       "dependencies": {
         "case-anything": "^2.1.13",
         "protobufjs": "^7.2.4",
@@ -23440,6 +23601,7 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-1.16.0.tgz",
       "integrity": "sha512-3yKuzMLpltdpcyQji1PJZRfoo4OJjNieKTYkQY8pF7xGKsYz/RHe3aEe4KiRxcinoBmnEhmuI+yJTxLb922ULA==",
+      "license": "ISC",
       "dependencies": {
         "long": "^5.2.3",
         "protobufjs": "^7.2.4"
@@ -23739,6 +23901,7 @@
       "version": "5.28.4",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
       "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -26040,6 +26203,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
@@ -26089,6 +26253,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
       "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "license": "MIT",
       "dependencies": {
         "archiver-utils": "^3.0.4",
         "compress-commons": "^4.1.2",
@@ -26102,6 +26267,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
       "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "license": "MIT",
       "dependencies": {
         "glob": "^7.2.3",
         "graceful-fs": "^4.2.0",
@@ -26122,6 +26288,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -26132,6 +26299,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -26151,6 +26319,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@dcl/hashing": "^3.0.4",
     "@dcl/mini-rpc": "^1.0.7",
     "@dcl/schemas": "^11.7.0",
-    "@dcl/sdk": "7.5.4",
+    "@dcl/sdk": "7.5.5",
     "@dcl/single-sign-on-client": "^0.1.0",
     "@dcl/ui-env": "^1.5.0",
     "@sentry/react": "^7.64.0",


### PR DESCRIPTION
This PR updates the package `@dcl/sdk` to version `7.5.5`.