### PR TITLE
fix: Avoid push thumbnails if they already exist in the path

### DIFF
--- a/src/modules/inspector/sagas.ts
+++ b/src/modules/inspector/sagas.ts
@@ -300,8 +300,13 @@ export function* inspectorSaga(builder: BuilderAPI, store: RootStore) {
 
     const project: Project = yield select(getCurrentProject)
     if (project.thumbnail) {
-      paths.push('assets/scene/thumbnail.png')
-      paths.push('thumbnails/scene/thumbnail.png')
+      // add thumbnail if missing
+      if (!paths.includes('assets/scene/thumbnail.png')) {
+        paths.push('assets/scene/thumbnail.png')
+      }
+      if (!paths.includes('thumbnails/scene/thumbnail.png')) {
+        paths.push('thumbnails/scene/thumbnail.png')
+      }
     }
 
     const files: { name: string; isDirectory: boolean }[] = []


### PR DESCRIPTION
This PR fixes an inspector error when building the scene asset tree and the `thumbnail.png` file is already present.

error:
![image](https://github.com/user-attachments/assets/0b612516-363e-4d97-a325-dd3a7a9126d3)
