### PR TITLE
fix: Collection id in create single item modal

### DIFF
--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.container.ts
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.container.ts
@@ -11,7 +11,7 @@ import { MapStateProps, MapDispatchProps, MapDispatch, OwnProps } from './Create
 import CreateSingleItemModal from './CreateSingleItemModal'
 
 const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
-  const collectionId: string | undefined = ownProps.metadata.item?.collectionId || ownProps.metadata.item?.collectionId
+  const collectionId: string | undefined = ownProps.metadata.collectionId || ownProps.metadata.item?.collectionId
   const collection: Collection | null = collectionId ? getCollection(state, collectionId) : null
   const statusByItemId = getStatusByItemId(state)
   const itemStatus = ownProps.metadata.item ? statusByItemId[ownProps.metadata.item.id] : null


### PR DESCRIPTION
This PR fixes the way we're setting the collection id for the items in the `CreateSingleItemModal` component.