### PR TITLE
fix: Third Party slots loading

### DIFF
--- a/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.tsx
+++ b/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.tsx
@@ -365,7 +365,18 @@ export default function ThirdPartyCollectionDetailPage({
         </>
       )
     },
-    [collection, selectedItems, totalItems, page, handleSearchChange, handleSelectItemChange, areAllSelected, handleClearSelection, filters]
+    [
+      collection,
+      selectedItems,
+      isLoadingAvailableSlots,
+      totalItems,
+      page,
+      handleSearchChange,
+      handleSelectItemChange,
+      areAllSelected,
+      handleClearSelection,
+      filters
+    ]
   )
 
   const shouldRender = hasAccess && collection


### PR DESCRIPTION
This PR fixes an issue where the Third Parties slots number will never stop loading.