### PR TITLE
fix: Only use upserted item if FF is enabled

### DIFF
--- a/src/modules/item/sagas.spec.ts
+++ b/src/modules/item/sagas.spec.ts
@@ -28,6 +28,7 @@ import { Collection } from 'modules/collection/types'
 import { MAX_ITEMS } from 'modules/collection/constants'
 import { FromParam } from 'modules/location/types'
 import { getMethodData } from 'modules/wallet/utils'
+import { getIsLinkedWearablesV2Enabled } from 'modules/features/selectors'
 import { mockedItem, mockedItemContents, mockedLocalItem, mockedRemoteItem } from 'specs/item'
 import { getCollections, getCollection } from 'modules/collection/selectors'
 import { updateProgressSaveMultipleItems } from 'modules/ui/createMultipleItems/action'
@@ -141,7 +142,10 @@ describe('when handling the save item request action', () => {
 
     it('should put a saveItemFailure action with invalid character message', () => {
       return expectSaga(itemSaga, builderAPI, builderClient)
-        .provide([[select(getItem, item.id), undefined]])
+        .provide([
+          [select(getItem, item.id), undefined],
+          [select(getIsLinkedWearablesV2Enabled), true]
+        ])
         .put(saveItemFailure(item, contents, 'Invalid character! The ":" is not allowed in names or descriptions'))
         .dispatch(saveItemRequest(item, contents))
         .run({ silenceTimeout: true })
@@ -156,7 +160,10 @@ describe('when handling the save item request action', () => {
 
     it('should put a saveItemFailure action with invalid character message', () => {
       return expectSaga(itemSaga, builderAPI, builderClient)
-        .provide([[select(getItem, item.id), undefined]])
+        .provide([
+          [select(getItem, item.id), undefined],
+          [select(getIsLinkedWearablesV2Enabled), true]
+        ])
         .put(saveItemFailure(item, contents, 'Invalid character! The ":" is not allowed in names or descriptions'))
         .dispatch(saveItemRequest(item, contents))
         .run({ silenceTimeout: true })
@@ -174,6 +181,7 @@ describe('when handling the save item request action', () => {
       return expectSaga(itemSaga, builderAPI, builderClient)
         .provide([
           [select(getItem, item.id), undefined],
+          [select(getIsLinkedWearablesV2Enabled), true],
           [matchers.call.fn(reHashOlderContents), {}],
           [matchers.call.fn(generateCatalystImage), Promise.resolve({ hash: 'someHash', content: blob })],
           [matchers.call.fn(calculateModelFinalSize), Promise.resolve(MAX_WEARABLE_FILE_SIZE + 1)],
@@ -197,6 +205,7 @@ describe('when handling the save item request action', () => {
       return expectSaga(itemSaga, builderAPI, builderClient)
         .provide([
           [select(getItem, item.id), undefined],
+          [select(getIsLinkedWearablesV2Enabled), true],
           [matchers.call.fn(reHashOlderContents), {}],
           [matchers.call.fn(generateCatalystImage), Promise.resolve({ hash: 'someHash', content: blob })],
           [matchers.call.fn(calculateModelFinalSize), Promise.resolve(MAX_SKIN_FILE_SIZE + 1)],
@@ -217,6 +226,7 @@ describe('when handling the save item request action', () => {
       return expectSaga(itemSaga, builderAPI, builderClient)
         .provide([
           [select(getItem, item.id), undefined],
+          [select(getIsLinkedWearablesV2Enabled), true],
           [matchers.call.fn(reHashOlderContents), {}],
           [matchers.call.fn(generateCatalystImage), Promise.resolve({ hash: 'someHash', content: blob })],
           [matchers.call.fn(calculateModelFinalSize), Promise.resolve(MAX_EMOTE_FILE_SIZE + 1)],
@@ -233,6 +243,7 @@ describe('when handling the save item request action', () => {
       return expectSaga(itemSaga, builderAPI, builderClient)
         .provide([
           [select(getItem, item.id), undefined],
+          [select(getIsLinkedWearablesV2Enabled), true],
           [matchers.call.fn(reHashOlderContents), {}],
           [matchers.call.fn(generateCatalystImage), Promise.resolve({ hash: 'someHash', content: blob })],
           [matchers.call.fn(calculateModelFinalSize), Promise.resolve(MAX_WEARABLE_FILE_SIZE)],
@@ -249,6 +260,7 @@ describe('when handling the save item request action', () => {
       return expectSaga(itemSaga, builderAPI, builderClient)
         .provide([
           [select(getItem, item.id), undefined],
+          [select(getIsLinkedWearablesV2Enabled), true],
           [matchers.call.fn(reHashOlderContents), {}],
           [matchers.call.fn(generateCatalystImage), Promise.resolve({ hash: 'someHash', content: blob })],
           [matchers.call.fn(calculateModelFinalSize), Promise.resolve(MAX_WEARABLE_FILE_SIZE)],
@@ -289,6 +301,7 @@ describe('when handling the save item request action', () => {
           [matchers.call.fn(reHashOlderContents), {}],
           [select(getItem, item.id), undefined],
           [select(getCollection, collection.id), collection],
+          [select(getIsLinkedWearablesV2Enabled), true],
           [matchers.call.fn(calculateModelFinalSize), Promise.resolve(1)],
           [matchers.call.fn(calculateFileSize), 1]
         ])
@@ -322,6 +335,7 @@ describe('when handling the save item request action', () => {
             [select(getOpenModals), { EditItemURNModal: true }],
             [select(getItem, item.id), undefined],
             [select(getAddress), mockAddress],
+            [select(getIsLinkedWearablesV2Enabled), true],
             [
               call(generateCatalystImage, item, {
                 thumbnail: contents[THUMBNAIL_PATH]
@@ -357,6 +371,7 @@ describe('when handling the save item request action', () => {
             [getContext('history'), { push: pushMock, location: { pathname: 'notTPdetailPage' } }],
             [select(getOpenModals), { EditItemURNModal: true }],
             [select(getItem, item.id), undefined],
+            [select(getIsLinkedWearablesV2Enabled), true],
             [select(getAddress), mockAddress],
             [
               call(generateCatalystImage, item, {
@@ -390,6 +405,7 @@ describe('when handling the save item request action', () => {
             [select(getOpenModals), { EditItemURNModal: true }],
             [select(getItem, item.id), undefined],
             [select(getAddress), mockAddress],
+            [select(getIsLinkedWearablesV2Enabled), true],
             [call(calculateModelFinalSize, itemContents, modelContents, builderAPI), Promise.resolve(1)],
             [call(calculateFileSize, thumbnailContent), 1],
             [call([builderAPI, 'saveItem'], item, contents), Promise.resolve(item)],
@@ -424,6 +440,7 @@ describe('when handling the save item request action', () => {
               { ...item, contents: { ...item.contents, [IMAGE_PATH]: item.contents[IMAGE_PATH] }, rarity: Rarity.COMMON }
             ],
             [select(getAddress), mockAddress],
+            [select(getIsLinkedWearablesV2Enabled), true],
             [
               call(generateCatalystImage, item, {
                 thumbnail: contents[THUMBNAIL_PATH]
@@ -459,6 +476,7 @@ describe('when handling the save item request action', () => {
             [select(getOpenModals), { EditItemURNModal: true }],
             [select(getItem, item.id), undefined],
             [select(getAddress), mockAddress],
+            [select(getIsLinkedWearablesV2Enabled), true],
             [call(calculateModelFinalSize, itemContents, modelContents, builderAPI), Promise.resolve(1)],
             [call(calculateFileSize, thumbnailContent), 1],
             [call([builderAPI, 'saveItem'], item, contents), Promise.resolve(item)],
@@ -485,6 +503,7 @@ describe('when handling the save item request action', () => {
             [select(getOpenModals), { EditItemURNModal: true }],
             [select(getItem, item.id), undefined],
             [select(getAddress), mockAddress],
+            [select(getIsLinkedWearablesV2Enabled), true],
             [call(calculateModelFinalSize, itemContents, modelContents, builderAPI), Promise.resolve(1)],
             [call(calculateFileSize, thumbnailContent), 1],
             [call([builderAPI, 'saveItem'], item, contents), Promise.resolve(item)],
@@ -509,6 +528,7 @@ describe('when handling the save item request action', () => {
             [select(getOpenModals), { EditItemURNModal: true }],
             [select(getItem, item.id), undefined],
             [select(getAddress), mockAddress],
+            [select(getIsLinkedWearablesV2Enabled), true],
             [call([builderAPI, 'saveItem'], item, {}), Promise.resolve(item)],
             [put(saveItemSuccess(item, {})), undefined]
           ])
@@ -543,6 +563,7 @@ describe('when handling the save item request action', () => {
             [select(getOpenModals), { EditItemURNModal: true }],
             [select(getItem, item.id), item],
             [select(getAddress), mockAddress],
+            [select(getIsLinkedWearablesV2Enabled), true],
             [call(calculateModelFinalSize, itemContents, modelContents, builderAPI), Promise.resolve(1)],
             [call(calculateFileSize, thumbnailContent), 1],
             [call([builderAPI, 'saveItem'], itemWithNewHashes, newContents), Promise.resolve(itemWithNewHashes)],
@@ -579,7 +600,8 @@ describe('when handling the save item success action', () => {
             [getContext('history'), { push: pushMock, location: { pathname: locations.thirdPartyCollectionDetail(item.collectionId) } }],
             [select(getOpenModals), { EditItemURNModal: true }],
             [select(getPaginationData, item.collectionId!), paginationData],
-            [select(getAddress), mockAddress]
+            [select(getAddress), mockAddress],
+            [select(getIsLinkedWearablesV2Enabled), true]
           ])
           .put(fetchCollectionItemsRequest(item.collectionId!, { page: paginationData.currentPage, limit: paginationData.limit }))
           .dispatch(saveItemSuccess(item, contents))
@@ -598,7 +620,8 @@ describe('when handling the save item success action', () => {
             [getContext('history'), { push: pushMock, location: { pathname: locations.thirdPartyCollectionDetail(item.collectionId) } }],
             [select(getOpenModals), { EditItemURNModal: true }],
             [select(getPaginationData, item.collectionId!), paginationData],
-            [select(getAddress), mockAddress]
+            [select(getAddress), mockAddress],
+            [select(getIsLinkedWearablesV2Enabled), true]
           ])
           .dispatch(saveItemSuccess(item, contents))
           .run({ silenceTimeout: true })
@@ -614,7 +637,8 @@ describe('when handling the save item success action', () => {
           .provide([
             [getContext('history'), { push: pushMock, location: { pathname: locations.thirdPartyCollectionDetail(item.collectionId) } }],
             [select(getOpenModals), {}],
-            [select(getAddress), mockAddress]
+            [select(getAddress), mockAddress],
+            [select(getIsLinkedWearablesV2Enabled), true]
           ])
           .not.call.fn(fetchCollectionItemsRequest)
           .dispatch(saveItemSuccess(item, {}, { onlySaveItem: true }))
@@ -649,7 +673,8 @@ describe('when handling the save item success action', () => {
             .provide([
               [getContext('history'), { push: pushMock, location: { pathname: locations.collectionDetail(collection.id) } }],
               [select(getOpenModals), { CreateSingleItemModal: true }],
-              [select(getAddress), mockAddress]
+              [select(getAddress), mockAddress],
+              [select(getIsLinkedWearablesV2Enabled), true]
             ])
             .dispatch(saveItemSuccess(item, {}))
             .run({ silenceTimeout: true })
@@ -788,6 +813,7 @@ describe('when handling the setPriceAndBeneficiaryRequest action', () => {
           [select(getItems), [item]],
           [select(getCollections), [collection]],
           [call(getChainIdByNetwork, Network.MATIC), ChainId.MATIC_MAINNET],
+          [select(getIsLinkedWearablesV2Enabled), true],
           [matchers.call.fn(sendTransaction), Promise.resolve('0xhash')]
         ])
         .put(setPriceAndBeneficiarySuccess({ ...item, price, beneficiary }, ChainId.MATIC_MAINNET, '0xhash'))


### PR DESCRIPTION
This PR changes the way we're saving the upserted item to use the old behavior if the `isLinkedWearablesV2Enabled` FF is active.