### PR TITLE
fix: Mapping type default value icon

### DIFF
--- a/src/components/MappingEditor/MappingEditor.module.css
+++ b/src/components/MappingEditor/MappingEditor.module.css
@@ -42,7 +42,7 @@
 
 /* Mapping type class */
 
-.mappingType :global(.ui.dropdown > .text > img) {
+.mappingType :global(.ui.dropdown):global(> .text:not(.default) > img) {
   margin-top: 3px;
 }
 
@@ -64,7 +64,7 @@
   align-items: center;
 }
 
-.mappingType :global(.default.text)::before {
+.mappingType :global(.default.text):not(:has(> img))::before {
   content: ' ';
   background-size: contain;
   background-repeat: no-repeat;


### PR DESCRIPTION
This PR changes the mapping type default icon styling so it does not appear when clicking on the field.
Before:
<img width="1134" alt="Screenshot 2024-09-02 at 15 28 34" src="https://github.com/user-attachments/assets/6daf3462-97c9-4e9c-b010-03b75a89feba">
After:
<img width="1151" alt="Screenshot 2024-09-02 at 15 33 31" src="https://github.com/user-attachments/assets/052acce5-e6ae-41d0-b79e-5e0f905db19b">
