### PR TITLE
fix: Multiple items creation with mappings only on LW v2

### DIFF
--- a/src/components/Modals/CreateAndEditMultipleItemsModal/CreateAndEditMultipleItemsModal.container.ts
+++ b/src/components/Modals/CreateAndEditMultipleItemsModal/CreateAndEditMultipleItemsModal.container.ts
@@ -11,6 +11,7 @@ import {
 import { getError } from 'modules/item/selectors'
 import { Collection } from 'modules/collection/types'
 import { getCollection } from 'modules/collection/selectors'
+import { getIsLinkedWearablesV2Enabled } from 'modules/features/selectors'
 import { MapStateProps, MapDispatchProps, MapDispatch, OwnProps } from './CreateAndEditMultipleItemsModal.types'
 import CreateAndEditMultipleItemsModal from './CreateAndEditMultipleItemsModal'
 
@@ -24,6 +25,7 @@ const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
     notSavedItemsFiles: getNotSavedItemsFiles(state),
     cancelledItemsFiles: getCanceledItemsFiles(state),
     saveMultipleItemsState: getMultipleItemsSaveState(state),
+    isLinkedWearablesV2Enabled: getIsLinkedWearablesV2Enabled(state),
     saveItemsProgress: getProgress(state)
   }
 }

--- a/src/components/Modals/CreateAndEditMultipleItemsModal/CreateAndEditMultipleItemsModal.tsx
+++ b/src/components/Modals/CreateAndEditMultipleItemsModal/CreateAndEditMultipleItemsModal.tsx
@@ -115,7 +115,7 @@ export default class CreateAndEditMultipleItemsModal extends React.PureComponent
   }
 
   processAcceptedFile = async (file: File) => {
-    const { collection, metadata } = this.props
+    const { collection, metadata, isLinkedWearablesV2Enabled } = this.props
     try {
       const fileArrayBuffer = await file.arrayBuffer()
       const loadedFile = await loadFile(file.name, new Blob([new Uint8Array(fileArrayBuffer)]))
@@ -186,7 +186,7 @@ export default class CreateAndEditMultipleItemsModal extends React.PureComponent
         }
 
         // In case the collection is linked to a smart contract, the mappings must be present
-        if (collection?.linkedContractAddress && collection.linkedContractNetwork) {
+        if (isLinkedWearablesV2Enabled && collection?.linkedContractAddress && collection.linkedContractNetwork) {
           if (!loadedFile.wearable.mapping) {
             throw new Error(t('create_and_edit_multiple_items_modal.missing_mapping'))
           }

--- a/src/components/Modals/CreateAndEditMultipleItemsModal/CreateAndEditMultipleItemsModal.types.ts
+++ b/src/components/Modals/CreateAndEditMultipleItemsModal/CreateAndEditMultipleItemsModal.types.ts
@@ -62,6 +62,7 @@ export type Props = Omit<ModalProps, 'metadata'> & {
   notSavedItemsFiles: ReturnType<typeof getNotSavedItemsFiles>
   cancelledItemsFiles: ReturnType<typeof getCanceledItemsFiles>
   saveMultipleItemsState: ReturnType<typeof getMultipleItemsSaveState>
+  isLinkedWearablesV2Enabled: boolean
   saveItemsProgress: number
   metadata: CreateAndEditMultipleItemsModalMetadata
 }
@@ -69,7 +70,14 @@ export type Props = Omit<ModalProps, 'metadata'> & {
 export type OwnProps = Pick<Props, 'name' | 'metadata' | 'onClose'>
 export type MapStateProps = Pick<
   Props,
-  'savedItemsFiles' | 'notSavedItemsFiles' | 'cancelledItemsFiles' | 'error' | 'saveMultipleItemsState' | 'saveItemsProgress' | 'collection'
+  | 'savedItemsFiles'
+  | 'notSavedItemsFiles'
+  | 'cancelledItemsFiles'
+  | 'error'
+  | 'saveMultipleItemsState'
+  | 'saveItemsProgress'
+  | 'collection'
+  | 'isLinkedWearablesV2Enabled'
 >
 export type MapDispatchProps = Pick<Props, 'onSaveMultipleItems' | 'onCancelSaveMultipleItems' | 'onModalUnmount'>
 export type MapDispatch = Dispatch<SaveMultipleItemsRequestAction | CancelSaveMultipleItemsAction | ClearStateSaveMultipleItemsAction>


### PR DESCRIPTION
This PR processes the mappings in the `wearable.json` file only if the FF is enabled.