### PR TITLE
fix: Third Party Detail Page not updating when third party is loaded

### DIFF
--- a/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.tsx
+++ b/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.tsx
@@ -395,6 +395,7 @@ export default function ThirdPartyCollectionDetailPage({
       isLoadingAvailableSlots,
       totalItems,
       page,
+      thirdParty,
       handleSelectItemChange,
       areAllSelected,
       handleChangeStatus,


### PR DESCRIPTION
The `thirdParty` is missing from the update variables.