### PR TITLE
fix: Requesting coordines for more than 150 hashes

### DIFF
--- a/src/lib/array.ts
+++ b/src/lib/array.ts
@@ -1,3 +1,6 @@
 export function difference<T = any>(left: T[], right: T[]) {
   return left.filter(x => right.indexOf(x) === -1)
 }
+
+export const chunk = <T>(arr: T[], size: number): T[][] =>
+  Array.from({ length: Math.ceil(arr.length / size) }, (_, i) => arr.slice(i * size, i * size + size))

--- a/src/modules/curations/itemCuration/sagas.ts
+++ b/src/modules/curations/itemCuration/sagas.ts
@@ -4,7 +4,7 @@ import { isErrorWithMessage } from 'decentraland-dapps/dist/lib/error'
 import { BuilderAPI } from 'lib/api/builder'
 import { FetchCollectionItemsSuccessAction, FETCH_COLLECTION_ITEMS_SUCCESS } from 'modules/item/actions'
 import { isThirdParty } from 'lib/urn'
-import { Item } from 'modules/item/types'
+import { chunk } from 'lib/array'
 import {
   fetchItemCurationFailure,
   FetchItemCurationRequestAction,
@@ -20,9 +20,6 @@ import { ItemCuration } from './types'
 
 const MAX_ITEM_CURATIONS = 30
 const REQUESTS_BATCH_SIZE = 10
-
-const chunk = (arr: Item[], size: number) =>
-  Array.from({ length: Math.ceil(arr.length / size) }, (_, i) => arr.slice(i * size, i * size + size))
 
 export function* itemCurationSaga(builder: BuilderAPI) {
   yield takeEvery(FETCH_ITEM_CURATION_REQUEST, handleFetchItemCurationRequest)

--- a/src/modules/ens/utils.ts
+++ b/src/modules/ens/utils.ts
@@ -2,6 +2,7 @@ import { ethers } from 'ethers'
 import { Entity } from '@dcl/schemas'
 import { PEER_URL, getCatalystContentUrl } from 'lib/api/peer'
 import { extractEntityId } from 'lib/urn'
+import { chunk } from 'lib/array'
 import { WorldInfo, WorldsAPI } from 'lib/api/worlds'
 import { Land, LandType } from 'modules/land/types'
 import { ENS, WorldStatus } from './types'
@@ -92,7 +93,11 @@ export async function getLandRedirectionHashes(builderClient: BuilderClient, lan
   const coordsList = lands.map(land => getCenter(getSelection(land))).map(coords => ({ x: coords[0], y: coords[1] }))
   let coordsWithHashesList: (LandCoords & LandHashes)[] = []
   if (coordsList.length > 0) {
-    coordsWithHashesList = await builderClient.getLandRedirectionHashes(coordsList, getCurrentLocale().locale)
+    for (const coordsBatch of chunk(coordsList, 145)) {
+      coordsWithHashesList = coordsWithHashesList.concat(
+        await builderClient.getLandRedirectionHashes(coordsBatch, getCurrentLocale().locale)
+      )
+    }
   }
   const landHashes: { id: string; hash: string }[] = []
 


### PR DESCRIPTION
When the use has more than 150 parcels, the `getLandRedirectionHashes` client call fails because the server can only answer 150 coordinates at a time. This PR fixes that by batching the requests.