### PR TITLE
feat: LW improvements and fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@dcl/crypto": "^3.4.5",
         "@dcl/hashing": "^3.0.4",
         "@dcl/mini-rpc": "^1.0.7",
-        "@dcl/schemas": "^13.12.0",
+        "@dcl/schemas": "^14.0.0",
         "@dcl/sdk": "7.5.5",
         "@dcl/single-sign-on-client": "^0.1.0",
         "@dcl/ui-env": "^1.5.0",
@@ -2307,6 +2307,17 @@
         "multiformats": "^9.6.3"
       }
     },
+    "node_modules/@dcl/builder-client/node_modules/@dcl/schemas": {
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-13.13.0.tgz",
+      "integrity": "sha512-UY7YY7pn0TxSrinO5nayBushF5Sf1jcBpbsLdw4wWOq7urhzSQZGjbAomgJZ7UfOMi1C7DD2XaTZ89BCp/4Z9Q==",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-keywords": "^5.1.0",
+        "mitt": "^3.0.1"
+      }
+    },
     "node_modules/@dcl/builder-client/node_modules/bl": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
@@ -2737,9 +2748,9 @@
       }
     },
     "node_modules/@dcl/schemas": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-13.12.0.tgz",
-      "integrity": "sha512-YHfiDSYqSRGXwiBaj5qZPzhhW7agT2bvLmrLvNZe3sFmkJTkOoFjWx5ZsG5V7JmRW6sLpJXxfKMFjcryyGU2IQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-14.0.0.tgz",
+      "integrity": "sha512-w3P/5g/gkYcBUB6+eN1PYdQBaiS8nLh7ldGfUI6GuiHQKvPIC3wS26Dx5i2ukwHrds2koOaqhFdLzHLVDDitQg==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -11604,9 +11615,9 @@
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
     },
     "node_modules/decentraland-dapps/node_modules/@dcl/schemas": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-11.12.0.tgz",
-      "integrity": "sha512-L04KTucvxSnrHDAl3/rnkzhjfZ785dSSPeKarBVfzyuw41uyQ0Mh4HVFWjX9hC+f/nMpM5Adg5udlT5efmepcA==",
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-13.13.0.tgz",
+      "integrity": "sha512-UY7YY7pn0TxSrinO5nayBushF5Sf1jcBpbsLdw4wWOq7urhzSQZGjbAomgJZ7UfOMi1C7DD2XaTZ89BCp/4Z9Q==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -11669,6 +11680,17 @@
         "magic-sdk": "^21.4.1",
         "socket.io-client": "^4.7.2",
         "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/decentraland-dapps/node_modules/decentraland-connect/node_modules/@dcl/schemas": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-11.12.0.tgz",
+      "integrity": "sha512-L04KTucvxSnrHDAl3/rnkzhjfZ785dSSPeKarBVfzyuw41uyQ0Mh4HVFWjX9hC+f/nMpM5Adg5udlT5efmepcA==",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-keywords": "^5.1.0",
+        "mitt": "^3.0.1"
       }
     },
     "node_modules/decentraland-dapps/node_modules/decentraland-connect/node_modules/ethers": {
@@ -11986,6 +12008,17 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decentraland-ui/node_modules/@dcl/schemas": {
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-13.13.0.tgz",
+      "integrity": "sha512-UY7YY7pn0TxSrinO5nayBushF5Sf1jcBpbsLdw4wWOq7urhzSQZGjbAomgJZ7UfOMi1C7DD2XaTZ89BCp/4Z9Q==",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-keywords": "^5.1.0",
+        "mitt": "^3.0.1"
       }
     },
     "node_modules/decentraland-ui/node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@dcl/crypto": "^3.4.5",
     "@dcl/hashing": "^3.0.4",
     "@dcl/mini-rpc": "^1.0.7",
-    "@dcl/schemas": "^13.12.0",
+    "@dcl/schemas": "^14.0.0",
     "@dcl/sdk": "7.5.5",
     "@dcl/single-sign-on-client": "^0.1.0",
     "@dcl/ui-env": "^1.5.0",

--- a/src/components/CollectionsPage/CollectionsPage.tsx
+++ b/src/components/CollectionsPage/CollectionsPage.tsx
@@ -299,7 +299,7 @@ export default function CollectionsPage(props: Props) {
         <EventBanner />
         <div className="filters">
           <Container>
-            {(hasUserOrphanItems || isThirdPartyManager) && (
+            {(hasUserOrphanItems || isThirdPartyManager || isLinkedWearablesPaymentsEnabled) && (
               <div className="action-tabs-container">
                 <img src={collectionsIcon} className="collections-icon" />
                 <Tabs isFullscreen>

--- a/src/components/MappingEditor/MappingEditor.module.css
+++ b/src/components/MappingEditor/MappingEditor.module.css
@@ -25,11 +25,12 @@
 }
 
 .mappings.compact {
-  width: 100%;
+  min-width: 0;
+  flex: 1;
 }
 
 .mappings.compact > div {
-  flex-grow: 1;
+  flex: 1;
 }
 
 /* Input margin */
@@ -94,6 +95,7 @@
 
 .range {
   display: flex;
+  min-width: 0;
 }
 
 .range.compact {

--- a/src/components/Modals/PublishWizardCollectionModal/ConfirmCollectionItemsStep/ConfirmCollectionItemsStep.module.css
+++ b/src/components/Modals/PublishWizardCollectionModal/ConfirmCollectionItemsStep/ConfirmCollectionItemsStep.module.css
@@ -1,4 +1,4 @@
-.ConfirmCollectionItemsStep .details {
+.details {
   background-color: rgba(var(--dark-raw), 0.48);
   border-radius: 8px;
   width: 100%;
@@ -8,13 +8,13 @@
   line-height: 24px;
 }
 
-.ConfirmCollectionItemsStep .details .title {
+.details .title {
   font-size: 18px;
   font-weight: 700;
   line-height: 24px;
 }
 
-.ConfirmCollectionItemsStep .details .subtitle {
+.details .subtitle {
   font-size: 15px;
   font-weight: 600;
   line-height: 24px;
@@ -22,68 +22,68 @@
   margin-bottom: 0px;
 }
 
-.ConfirmCollectionItemsStep .details .description {
+.details .description {
   font-size: 15px;
   font-weight: 400;
   line-height: 24px;
   color: var(--clear-divider);
 }
 
-.ConfirmCollectionItemsStep .details .fields .dcl.field {
+.details :global(.fields .dcl.field) {
   margin-top: 32px;
 }
 
-.ConfirmCollectionItemsStep .actions {
+.actions {
   margin-top: 24px;
   width: 100%;
   justify-content: space-between !important;
 }
 
-.ConfirmCollectionItemsStep .actions .button {
+.actions :global(.button) {
   width: 180px;
 }
 
-.ConfirmCollectionItemsStep .items {
+.items {
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-.ConfirmCollectionItemsStep .items tbody {
+.items tbody {
   display: block;
   max-height: 425px;
   overflow-y: auto;
 }
 
-.ConfirmCollectionItemsStep .items thead,
-.ConfirmCollectionItemsStep .items tbody tr {
+.items thead,
+.items tbody tr {
   display: table;
   width: 100%;
   table-layout: fixed;
 }
 
-.ConfirmCollectionItemsStep .items thead.has-scrollbar {
+.items thead.hasScrollBar {
   width: calc(100% - 10px);
 }
 
-.ConfirmCollectionItemsStep .avatarColumn .avatarContainer {
+.avatarColumn .avatarContainer {
   display: flex;
   align-items: center;
 }
 
-.ConfirmCollectionItemsStep .avatarColumn .avatarContainer .ItemImage {
+.avatarColumn .avatarContainer .itemImage {
   height: 48px;
   width: 48px;
   margin-right: 16px;
 }
 
-.ConfirmCollectionItemsStep .avatarColumn .avatarContainer .info {
+.avatarColumn .avatarContainer .info {
   display: flex;
   align-items: center;
 }
 
-.ConfirmCollectionItemsStep .avatarColumn .avatarContainer .name {
+.avatarColumn .avatarContainer .name {
   margin-right: 8px;
   font-size: 15px;
   white-space: nowrap;
@@ -92,23 +92,23 @@
   max-width: 150px;
 }
 
-.ConfirmCollectionItemsStep .avatarColumn .avatarContainer .badge {
+.avatarColumn .avatarContainer .badge {
   background-color: var(--smart-grey);
 }
 
-.ConfirmCollectionItemsStep .avatarColumn .avatarContainer .badge::before {
+.avatarColumn .avatarContainer .badge::before {
   filter: none;
 }
 
-.ConfirmCollectionItemsStep .column.priceColumn .ui.mana {
+.priceColumn :global(.ui.mana) {
   font-size: 15px;
 }
 
-.ui.visible.popup.price-popup {
+.price-popup:global(.ui.visible.popup) {
   z-index: 4000;
 }
 
-.ConfirmCollectionItemsStep .loading-overlay {
+.loadingOverlay {
   position: absolute;
   top: 0px;
   left: 0px;
@@ -124,4 +124,20 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+}
+
+.categoryBadge {
+  width: fit-content;
+}
+
+.categoryBadge.thirdParty {
+  height: 32px;
+}
+
+.itemNumber {
+  background-color: #43404a;
+  border-radius: 8px;
+  padding: 2px 12px 2px 12px;
+  width: fit-content;
+  font-size: 12px;
 }

--- a/src/components/Modals/PublishWizardCollectionModal/PayPublicationFeeStep/PayPublicationFeeStep.tsx
+++ b/src/components/Modals/PublishWizardCollectionModal/PayPublicationFeeStep/PayPublicationFeeStep.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useMemo } from 'react'
 import { ethers } from 'ethers'
 import { Network } from '@dcl/schemas'
 import { config } from 'config'
-import { Button, Column, Icon, InfoTooltip, Loader, Mana, Modal, Row, Table } from 'decentraland-ui'
+import { AuthorizationStepStatus, Button, Column, Icon, InfoTooltip, Loader, Mana, Modal, Row, Table } from 'decentraland-ui'
 import ItemImage from 'components/ItemImage'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { toFixedMANAValue } from 'decentraland-dapps/dist/lib/mana'
@@ -34,6 +34,7 @@ export const PayPublicationFeeStep: React.FC<
     collectionError,
     unsyncedCollectionError,
     isLoading,
+    publishingStatus,
     thirdParty,
     isPublishCollectionsWertEnabled,
     onNextStep,
@@ -123,7 +124,9 @@ export const PayPublicationFeeStep: React.FC<
           {isLoading && (
             <div className={styles.loadingOverlay}>
               <Loader inline size="massive" />
-              {t('publish_wizard_collection_modal.accept_in_wallet')}
+              {publishingStatus === AuthorizationStepStatus.PROCESSING
+                ? 'Submitting for review'
+                : t('publish_wizard_collection_modal.accept_in_wallet')}
             </div>
           )}
           <Column grow={true}>

--- a/src/components/Modals/PublishWizardCollectionModal/PublishWizardCollectionModal.tsx
+++ b/src/components/Modals/PublishWizardCollectionModal/PublishWizardCollectionModal.tsx
@@ -5,6 +5,7 @@ import { List, ModalNavigation } from 'decentraland-ui'
 import Modal from 'decentraland-dapps/dist/containers/Modal'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { withAuthorizedAction } from 'decentraland-dapps/dist/containers'
+import { WithAuthorizedActionProps } from 'decentraland-dapps/dist/containers/withAuthorizedAction'
 import { AuthorizedAction } from 'decentraland-dapps/dist/containers/withAuthorizedAction/AuthorizationModal'
 import { ContractName } from 'decentraland-transactions'
 import { AuthorizationType } from 'decentraland-dapps/dist/modules/authorization/types'
@@ -14,6 +15,7 @@ import { extractThirdPartyId } from 'lib/urn'
 import { getPublishStatus, getError } from 'modules/collection/selectors'
 import { PaymentMethod } from 'modules/collection/types'
 import { isTPCollection } from 'modules/collection/utils'
+import { getThirdPartyPublishStatus } from 'modules/thirdParty/selectors'
 import { Cheque } from 'modules/thirdParty/types'
 import { getPublishItemsSignature } from 'modules/thirdParty/utils'
 import { Props, PublishWizardCollectionSteps } from './PublishWizardCollectionModal.types'
@@ -24,7 +26,7 @@ import PayPublicationFeeStep from './PayPublicationFeeStep/PayPublicationFeeStep
 import CongratulationsStep from './CongratulationsStep/CongratulationsStep'
 import './PublishWizardCollectionModal.css'
 
-export const PublishWizardCollectionModal: React.FC<Props> = props => {
+export const PublishWizardCollectionModal: React.FC<Props & WithAuthorizedActionProps> = props => {
   const {
     collection,
     itemsToPublish,
@@ -155,6 +157,7 @@ export const PublishWizardCollectionModal: React.FC<Props> = props => {
         return (
           <ConfirmCollectionItemsStep
             isSigningCheque={isSigningCheque}
+            collection={collection}
             items={allItems}
             isThirdParty={isThirdParty}
             onNextStep={handleOnConfirmItemsNextStep}
@@ -220,33 +223,43 @@ export const PublishWizardCollectionModal: React.FC<Props> = props => {
   }, [currentStep])
 
   return (
-    <Modal className="PublishWizardCollectionModal" size="small" onClose={isLoading ? undefined : onClose} closeOnDimmerClick={false}>
-      <ModalNavigation title={stepTitle} onClose={onClose} />
+    <Modal className="PublishWizardCollectionModal" size="large" onClose={isLoading ? undefined : onClose} closeOnDimmerClick={false}>
+      <ModalNavigation title={stepTitle} onClose={isLoading ? undefined : onClose} />
       {stepIndicator}
       {renderStepView()}
     </Modal>
   )
 }
 
-export default withAuthorizedAction(
+const AUTHORIZATION_DATA = {
+  title_action: 'publish_wizard_collection_modal.authorization.title_action',
+  action: 'publish_wizard_collection_modal.authorization.action',
+  confirm_transaction: {
+    title: 'publish_wizard_collection_modal.authorization.confirm_transaction_title'
+  },
+  authorize_mana: {
+    description: 'publish_wizard_collection_modal.authorization.authorize_mana_description'
+  },
+  set_cap: {
+    description: 'publish_wizard_collection_modal.authorization.set_cap_description'
+  },
+  insufficient_amount_error: {
+    message: 'publish_wizard_collection_modal.authorization.insufficient_amount_error_message'
+  }
+}
+
+export const AuthorizedPublishWizardThirdPartyCollectionModal = withAuthorizedAction(
   PublishWizardCollectionModal,
   AuthorizedAction.PUBLISH_COLLECTION,
-  {
-    title_action: 'publish_wizard_collection_modal.authorization.title_action',
-    action: 'publish_wizard_collection_modal.authorization.action',
-    confirm_transaction: {
-      title: 'publish_wizard_collection_modal.authorization.confirm_transaction_title'
-    },
-    authorize_mana: {
-      description: 'publish_wizard_collection_modal.authorization.authorize_mana_description'
-    },
-    set_cap: {
-      description: 'publish_wizard_collection_modal.authorization.set_cap_description'
-    },
-    insufficient_amount_error: {
-      message: 'publish_wizard_collection_modal.authorization.insufficient_amount_error_message'
-    }
-  },
+  AUTHORIZATION_DATA,
+  getThirdPartyPublishStatus,
+  getError
+)
+
+export const AuthorizedPublishWizardCollectionModal = withAuthorizedAction(
+  PublishWizardCollectionModal,
+  AuthorizedAction.PUBLISH_COLLECTION,
+  AUTHORIZATION_DATA,
   getPublishStatus,
   getError
 )

--- a/src/components/Modals/PublishWizardCollectionModal/PublishWizardCollectionModal.types.ts
+++ b/src/components/Modals/PublishWizardCollectionModal/PublishWizardCollectionModal.types.ts
@@ -1,6 +1,6 @@
+import { AuthorizationStepStatus } from 'decentraland-ui'
 import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 import { ModalProps } from 'decentraland-dapps/dist/providers/ModalProvider/ModalProvider.types'
-import { WithAuthorizedActionProps } from 'decentraland-dapps/dist/containers/withAuthorizedAction'
 import { Collection, PaymentMethod } from 'modules/collection/types'
 import { Item } from 'modules/item/types'
 import { Cheque, ThirdParty } from 'modules/thirdParty/types'
@@ -42,9 +42,10 @@ export type Props = Omit<ModalProps, 'metadata'> & {
   isLoading: boolean
   isPublishingFinished: boolean
   isPublishCollectionsWertEnabled: boolean
+  publishingStatus: AuthorizationStepStatus
   onPublish: (email: string, subscribeToNewsletter: boolean, paymentMethod: PaymentMethod, cheque?: Cheque, maxPrice?: string) => unknown
   onFetchPrice: () => unknown
-} & WithAuthorizedActionProps
+}
 
 export type PublishCollectionModalMetadata = {
   collectionId: string

--- a/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.tsx
+++ b/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.tsx
@@ -253,7 +253,7 @@ export default function ThirdPartyCollectionDetailPage({
                 <Header size="large" className={styles.name} onClick={handleEditName}>
                   {collection.name}
                 </Header>
-                <BuilderIcon name="edit" className={styles.editCollectionName} />
+                {!collection.isPublished && <BuilderIcon name="edit" className={styles.editCollectionName} />}
               </div>
               <div className={styles.actions}>
                 {collection.linkedContractAddress && collection.linkedContractNetwork && (

--- a/src/lib/api/builder.ts
+++ b/src/lib/api/builder.ts
@@ -878,7 +878,7 @@ export class BuilderAPI extends BaseAPI {
     }
   }
 
-  async publishTPCollection(collectionId: string, itemIds: string[], cheque: Cheque) {
+  publishTPCollection = async (collectionId: string, itemIds: string[], cheque: Cheque) => {
     const { collection, items, itemCurations }: { collection: RemoteCollection; items: RemoteItem[]; itemCurations: RemoteItemCuration[] } =
       await this.request('post', `/collections/${collectionId}/publish`, {
         params: {
@@ -1052,7 +1052,7 @@ export class BuilderAPI extends BaseAPI {
     )
   }
 
-  async deleteVirtualThirdParty(thirdPartId: string): Promise<void> {
+  deleteVirtualThirdParty = async (thirdPartId: string): Promise<void> => {
     await this.request('delete', `/thirdParties/${thirdPartId}`)
   }
 

--- a/src/modules/collection/selectors.ts
+++ b/src/modules/collection/selectors.ts
@@ -22,7 +22,8 @@ import {
   SET_COLLECTION_MINTERS_SUCCESS,
   APPROVE_COLLECTION_SUCCESS,
   REJECT_COLLECTION_SUCCESS,
-  PUBLISH_COLLECTION_REQUEST
+  PUBLISH_COLLECTION_REQUEST,
+  PUBLISH_COLLECTION_SUCCESS
 } from './actions'
 import { Collection, CollectionType } from './types'
 import { CollectionState } from './reducer'
@@ -170,7 +171,7 @@ export const getPublishStatus = (state: RootState) => {
   }
 
   const pendingActionTypeTransactions = getPendingTransactions(state).filter(
-    transaction => getType({ type: PUBLISH_COLLECTION_REQUEST }) === getType({ type: transaction.actionType })
+    transaction => getType({ type: PUBLISH_COLLECTION_SUCCESS }) === getType({ type: transaction.actionType })
   )
 
   if (isLoadingType(getLoading(state), CREATE_COLLECTION_FORUM_POST_REQUEST) || pendingActionTypeTransactions.length) {

--- a/src/modules/curations/itemCuration/reducer.spec.ts
+++ b/src/modules/curations/itemCuration/reducer.spec.ts
@@ -16,8 +16,8 @@ import {
   pushChangesThirdPartyItemsFailure,
   pushChangesThirdPartyItemsRequest,
   pushChangesThirdPartyItemsSuccess,
-  publishAndPushChangesThirdPartyItemsSuccess,
-  deployBatchedThirdPartyItemsSuccess
+  deployBatchedThirdPartyItemsSuccess,
+  finishPublishAndPushChangesThirdPartyItemsSuccess
 } from 'modules/thirdParty/actions'
 import { CurationStatus } from '../types'
 import { ItemCuration } from './types'
@@ -162,7 +162,12 @@ describe('when an action of type PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCC
     expect(
       itemCurationReducer(
         state,
-        publishAndPushChangesThirdPartyItemsSuccess(thirdParty, collection.id, [], [...itemCurationsFromPublish, ...itemCurationsFromPush])
+        finishPublishAndPushChangesThirdPartyItemsSuccess(
+          thirdParty,
+          collection.id,
+          [],
+          [...itemCurationsFromPublish, ...itemCurationsFromPush]
+        )
       )
     ).toStrictEqual({
       ...state,

--- a/src/modules/curations/itemCuration/reducer.ts
+++ b/src/modules/curations/itemCuration/reducer.ts
@@ -2,11 +2,9 @@ import { loadingReducer, LoadingState } from 'decentraland-dapps/dist/modules/lo
 import {
   DeployBatchedThirdPartyItemsSuccessAction,
   DEPLOY_BATCHED_THIRD_PARTY_ITEMS_SUCCESS,
-  PublishAndPushChangesThirdPartyItemsSuccessAction,
   PublishThirdPartyItemsFailureAction,
   PublishThirdPartyItemsRequestAction,
   PublishThirdPartyItemsSuccessAction,
-  PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS,
   PUBLISH_THIRD_PARTY_ITEMS_FAILURE,
   PUBLISH_THIRD_PARTY_ITEMS_REQUEST,
   PUBLISH_THIRD_PARTY_ITEMS_SUCCESS,
@@ -15,7 +13,9 @@ import {
   PushChangesThirdPartyItemsSuccessAction,
   PUSH_CHANGES_THIRD_PARTY_ITEMS_FAILURE,
   PUSH_CHANGES_THIRD_PARTY_ITEMS_REQUEST,
-  PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS
+  PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS,
+  FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS,
+  FinishPublishAndPushChangesThirdPartyItemsSuccessAction
 } from 'modules/thirdParty/actions'
 import {
   FETCH_ITEM_CURATIONS_REQUEST,
@@ -58,7 +58,7 @@ type CurationReducerAction =
   | PushChangesThirdPartyItemsRequestAction
   | PushChangesThirdPartyItemsSuccessAction
   | PushChangesThirdPartyItemsFailureAction
-  | PublishAndPushChangesThirdPartyItemsSuccessAction
+  | FinishPublishAndPushChangesThirdPartyItemsSuccessAction
   | DeployBatchedThirdPartyItemsSuccessAction
 
 export function itemCurationReducer(state: ItemCurationState = INITIAL_STATE, action: CurationReducerAction): ItemCurationState {
@@ -129,13 +129,12 @@ export function itemCurationReducer(state: ItemCurationState = INITIAL_STATE, ac
       }
     }
     case PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS:
-    case PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS: {
+    case FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS: {
       const { itemCurations: newItemCurations, collectionId } = action.payload
       const oldItemCurations = state.data[collectionId]
       const newCurationsItemIds = newItemCurations.map(newItemCuration => newItemCuration.itemId)
-      const oldCurationsNotIncludedInNewOnes = oldItemCurations.filter(
-        oldItemCuration => !newCurationsItemIds.includes(oldItemCuration.itemId)
-      )
+      const oldCurationsNotIncludedInNewOnes =
+        oldItemCurations?.filter(oldItemCuration => !newCurationsItemIds.includes(oldItemCuration.itemId)) ?? []
 
       return {
         ...state,

--- a/src/modules/item/reducer.spec.ts
+++ b/src/modules/item/reducer.spec.ts
@@ -2,8 +2,8 @@ import { ChainId, ContractAddress, ContractNetwork, Mapping, MappingType } from 
 import { saveCollectionSuccess } from 'modules/collection/actions'
 import { Collection } from 'modules/collection/types'
 import {
-  publishAndPushChangesThirdPartyItemsSuccess,
-  PublishAndPushChangesThirdPartyItemsSuccessAction,
+  finishPublishAndPushChangesThirdPartyItemsSuccess,
+  FinishPublishAndPushChangesThirdPartyItemsSuccessAction,
   publishThirdPartyItemsSuccess,
   PublishThirdPartyItemsSuccessAction,
   pushChangesThirdPartyItemsSuccess,
@@ -441,13 +441,13 @@ describe('when an action of type FETCH_ORPHAN_ITEM_FAILURE is called', () => {
 })
 
 describe.each([
-  ['pushing changes and publishing third party items', publishAndPushChangesThirdPartyItemsSuccess],
+  ['pushing changes and publishing third party items', finishPublishAndPushChangesThirdPartyItemsSuccess],
   ['pushing changes third party items', pushChangesThirdPartyItemsSuccess],
   ['publishing third party items', publishThirdPartyItemsSuccess]
 ])('when reducing the successful action of %s', (_, fn) => {
   let action:
     | PublishThirdPartyItemsSuccessAction
-    | PublishAndPushChangesThirdPartyItemsSuccessAction
+    | FinishPublishAndPushChangesThirdPartyItemsSuccessAction
     | PushChangesThirdPartyItemsSuccessAction
 
   beforeEach(() => {
@@ -467,8 +467,8 @@ describe.each([
       case publishThirdPartyItemsSuccess:
         action = publishThirdPartyItemsSuccess('aThirdPartyId', 'aCollectionId', items, curations)
         break
-      case publishAndPushChangesThirdPartyItemsSuccess:
-        action = publishAndPushChangesThirdPartyItemsSuccess({} as ThirdParty, 'aCollectionId', items, curations)
+      case finishPublishAndPushChangesThirdPartyItemsSuccess:
+        action = finishPublishAndPushChangesThirdPartyItemsSuccess({} as ThirdParty, 'aCollectionId', items, curations)
         break
     }
   })

--- a/src/modules/item/reducer.ts
+++ b/src/modules/item/reducer.ts
@@ -105,10 +105,10 @@ import {
 import {
   PublishThirdPartyItemsSuccessAction,
   PushChangesThirdPartyItemsSuccessAction,
-  PublishAndPushChangesThirdPartyItemsSuccessAction,
-  PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS,
   PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS,
-  PUBLISH_THIRD_PARTY_ITEMS_SUCCESS
+  PUBLISH_THIRD_PARTY_ITEMS_SUCCESS,
+  FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS,
+  FinishPublishAndPushChangesThirdPartyItemsSuccessAction
 } from 'modules/thirdParty/actions'
 import { toItemObject } from './utils'
 import { Item, BlockchainRarity } from './types'
@@ -174,7 +174,7 @@ type ItemReducerAction =
   | FetchRaritiesSuccessAction
   | FetchRaritiesFailureAction
   | PublishThirdPartyItemsSuccessAction
-  | PublishAndPushChangesThirdPartyItemsSuccessAction
+  | FinishPublishAndPushChangesThirdPartyItemsSuccessAction
   | PushChangesThirdPartyItemsSuccessAction
   | RescueItemsRequestAction
   | RescueItemsSuccessAction
@@ -428,7 +428,7 @@ export function itemReducer(state: ItemState = INITIAL_STATE, action: ItemReduce
         error: null
       }
     }
-    case PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS:
+    case FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS:
     case PUBLISH_THIRD_PARTY_ITEMS_SUCCESS:
     case PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS: {
       const { itemCurations } = action.payload

--- a/src/modules/thirdParty/actions.ts
+++ b/src/modules/thirdParty/actions.ts
@@ -122,7 +122,7 @@ export type PushChangesThirdPartyItemsRequestAction = ReturnType<typeof pushChan
 export type PushChangesThirdPartyItemsSuccessAction = ReturnType<typeof pushChangesThirdPartyItemsSuccess>
 export type PushChangesThirdPartyItemsFailureAction = ReturnType<typeof pushChangesThirdPartyItemsFailure>
 
-// Publish & Push changes Third Party Item
+// Publish & Push changes Third Party items
 
 export const PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_REQUEST = '[Request] Publish & Push third party items changes'
 export const PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS = '[Success] Publish & Push third party items changes'
@@ -149,10 +149,23 @@ export const publishAndPushChangesThirdPartyItemsRequest = (
 
 export const publishAndPushChangesThirdPartyItemsSuccess = (
   thirdParty: ThirdParty,
-  collectionId: Collection['id'],
-  items: Item[],
-  itemCurations: ItemCuration[]
-) => action(PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS, { thirdParty, collectionId, items, itemCurations })
+  collection: Collection,
+  itemsToPublish: Item[],
+  itemsWithChanges: Item[],
+  cheque?: Cheque,
+  txHash?: string,
+  chainId?: ChainId
+) =>
+  action(PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS, {
+    thirdParty,
+    collection,
+    itemsToPublish,
+    itemsWithChanges,
+    cheque,
+    txHash,
+    chainId,
+    ...(txHash && chainId ? buildTransactionPayload(chainId, txHash, { thirdPartyId: thirdParty.id, thirdPartyName: thirdParty.name }) : {})
+  })
 
 export const publishAndPushChangesThirdPartyItemsFailure = (error: string) =>
   action(PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_FAILURE, { error })
@@ -160,6 +173,24 @@ export const publishAndPushChangesThirdPartyItemsFailure = (error: string) =>
 export type PublishAndPushChangesThirdPartyItemsRequestAction = ReturnType<typeof publishAndPushChangesThirdPartyItemsRequest>
 export type PublishAndPushChangesThirdPartyItemsSuccessAction = ReturnType<typeof publishAndPushChangesThirdPartyItemsSuccess>
 export type PublishAndPushChangesThirdPartyItemsFailureAction = ReturnType<typeof publishAndPushChangesThirdPartyItemsFailure>
+
+// Finish Publish and Push changes in Third Party items
+
+export const FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_REQUEST = '[Request] Finish Publish & Push third party items changes'
+export const FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS = '[Success] Finish Publish & Push third party items changes'
+export const FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_FAILURE = '[Failure] Finish Publish & Push third party items changes'
+
+export const finishPublishAndPushChangesThirdPartyItemsSuccess = (
+  thirdParty: ThirdParty,
+  collectionId: Collection['id'],
+  items: Item[],
+  itemCurations: ItemCuration[]
+) => action(FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS, { thirdParty, collectionId, items, itemCurations })
+export const finishPublishAndPushChangesThirdPartyItemsFailure = (error: string) =>
+  action(FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_FAILURE, { error })
+
+export type FinishPublishAndPushChangesThirdPartyItemsSuccessAction = ReturnType<typeof finishPublishAndPushChangesThirdPartyItemsSuccess>
+export type FinishPublishAndPushChangesThirdPartyItemsFailureAction = ReturnType<typeof finishPublishAndPushChangesThirdPartyItemsFailure>
 
 // Deploy batched third party items
 
@@ -200,3 +231,11 @@ export const disableThirdPartyFailure = (error: string) => action(DISABLE_THIRD_
 export type DisableThirdPartyRequestAction = ReturnType<typeof disableThirdPartyRequest>
 export type DisableThirdPartySuccessAction = ReturnType<typeof disableThirdPartySuccess>
 export type DisableThirdPartyFailureAction = ReturnType<typeof disableThirdPartyFailure>
+
+// Clear Third Party Errors
+
+export const CLEAR_THIRD_PARTY_ERRORS = '[Request] Clear Third Party Errors'
+
+export const clearThirdPartyErrors = () => action(CLEAR_THIRD_PARTY_ERRORS)
+
+export type ClearThirdPartyErrorsAction = ReturnType<typeof clearThirdPartyErrors>

--- a/src/modules/thirdParty/reducer.spec.ts
+++ b/src/modules/thirdParty/reducer.spec.ts
@@ -20,7 +20,10 @@ import {
   publishAndPushChangesThirdPartyItemsFailure,
   fetchThirdPartyRequest,
   fetchThirdPartySuccess,
-  fetchThirdPartyFailure
+  fetchThirdPartyFailure,
+  FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_REQUEST,
+  finishPublishAndPushChangesThirdPartyItemsSuccess,
+  finishPublishAndPushChangesThirdPartyItemsFailure
 } from './actions'
 import { INITIAL_STATE, thirdPartyReducer, ThirdPartyState } from './reducer'
 import { ThirdParty } from './types'
@@ -218,34 +221,71 @@ describe('when reducing a PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_REQUEST act
 })
 
 describe('when reducing a PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS action', () => {
-  it('should remove the corresponding request action from the loading state, clear the errors and set the third party as published', () => {
-    expect(
-      thirdPartyReducer(
-        {
-          ...state,
-          data: { [thirdParty.id]: { ...thirdParty, published: false } },
-          loading: [publishAndPushChangesThirdPartyItemsRequest(thirdParty, [], [])],
-          error: 'anError'
-        },
-        publishAndPushChangesThirdPartyItemsSuccess(thirdParty, 'aCollectionId', [], [])
-      )
-    ).toEqual({
+  beforeEach(() => {
+    state = {
+      ...state,
+      loading: [publishAndPushChangesThirdPartyItemsRequest(thirdParty, [], [])]
+    }
+  })
+
+  it('should remove the corresponding request action from the loading state and set the finishing action as loading', () => {
+    expect(thirdPartyReducer(state, publishAndPushChangesThirdPartyItemsSuccess(thirdParty, {} as Collection, [], []))).toEqual({
       ...INITIAL_STATE,
-      data: { [thirdParty.id]: { ...thirdParty, published: true } },
+      loading: [{ type: FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_REQUEST }]
+    })
+  })
+})
+
+describe('when reducing a PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_FAILURE action', () => {
+  beforeEach(() => {
+    state = { ...state, loading: [publishAndPushChangesThirdPartyItemsRequest(thirdParty, [], [])] }
+  })
+
+  it('should remove the corresponding request action from the loading state and set the error', () => {
+    expect(thirdPartyReducer(state, publishAndPushChangesThirdPartyItemsFailure('anError'))).toEqual({
+      ...INITIAL_STATE,
+      loading: [],
+      error: 'anError'
+    })
+  })
+})
+
+describe('when reducing a FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS action', () => {
+  beforeEach(() => {
+    state = {
+      ...state,
+      data: { [thirdParty.id]: { ...thirdParty, published: false } },
+      loading: [{ type: FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_REQUEST }],
+      error: 'anError'
+    }
+  })
+
+  it('should remove the corresponding request action, set the third party as published and clear the errors', () => {
+    expect(thirdPartyReducer(state, finishPublishAndPushChangesThirdPartyItemsSuccess(thirdParty, 'aCollectionId', [], []))).toEqual({
+      ...INITIAL_STATE,
+      data: {
+        [thirdParty.id]: {
+          ...thirdParty,
+          published: true
+        }
+      },
       loading: [],
       error: null
     })
   })
 })
 
-describe('when reducing a PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_FAILURE action', () => {
+describe('when reducing a FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_FAILURE action', () => {
+  beforeEach(() => {
+    state = {
+      ...state,
+      loading: [{ type: FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_REQUEST }],
+      error: null
+    }
+  })
+
   it('should remove the corresponding request action from the loading state and set the error', () => {
-    expect(
-      thirdPartyReducer(
-        { ...state, loading: [publishAndPushChangesThirdPartyItemsRequest(thirdParty, [], [])] },
-        publishAndPushChangesThirdPartyItemsFailure('anError')
-      )
-    ).toEqual({
+    expect(thirdPartyReducer(state, finishPublishAndPushChangesThirdPartyItemsFailure('anError'))).toEqual({
       ...INITIAL_STATE,
       loading: [],
       error: 'anError'

--- a/src/modules/thirdParty/reducer.ts
+++ b/src/modules/thirdParty/reducer.ts
@@ -28,7 +28,6 @@ import {
   DISABLE_THIRD_PARTY_FAILURE,
   PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_REQUEST,
   PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_FAILURE,
-  PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS,
   PublishAndPushChangesThirdPartyItemsFailureAction,
   PublishAndPushChangesThirdPartyItemsSuccessAction,
   PublishAndPushChangesThirdPartyItemsRequestAction,
@@ -37,7 +36,13 @@ import {
   FetchThirdPartyFailureAction,
   FETCH_THIRD_PARTY_REQUEST,
   FETCH_THIRD_PARTY_SUCCESS,
-  FETCH_THIRD_PARTY_FAILURE
+  FETCH_THIRD_PARTY_FAILURE,
+  FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS,
+  FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_FAILURE,
+  FinishPublishAndPushChangesThirdPartyItemsSuccessAction,
+  PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS,
+  FinishPublishAndPushChangesThirdPartyItemsFailureAction,
+  FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_REQUEST
 } from './actions'
 import { ThirdParty } from './types'
 
@@ -70,8 +75,10 @@ type ThirdPartyReducerAction =
   | DisableThirdPartyFailureAction
   | DisableThirdPartyRequestAction
   | PublishAndPushChangesThirdPartyItemsRequestAction
-  | PublishAndPushChangesThirdPartyItemsSuccessAction
   | PublishAndPushChangesThirdPartyItemsFailureAction
+  | PublishAndPushChangesThirdPartyItemsSuccessAction
+  | FinishPublishAndPushChangesThirdPartyItemsSuccessAction
+  | FinishPublishAndPushChangesThirdPartyItemsFailureAction
   | FetchThirdPartyRequestAction
   | FetchThirdPartySuccessAction
   | FetchThirdPartyFailureAction
@@ -148,6 +155,12 @@ export function thirdPartyReducer(state: ThirdPartyState = INITIAL_STATE, action
         error: null
       }
     }
+    case PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS:
+      return {
+        ...state,
+        loading: loadingReducer(loadingReducer(state.loading, action), { type: FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_REQUEST })
+      }
+
     case DEPLOY_BATCHED_THIRD_PARTY_ITEMS_SUCCESS: {
       return {
         ...state,
@@ -159,6 +172,7 @@ export function thirdPartyReducer(state: ThirdPartyState = INITIAL_STATE, action
     case DISABLE_THIRD_PARTY_FAILURE:
     case FETCH_THIRD_PARTY_AVAILABLE_SLOTS_FAILURE:
     case PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_FAILURE:
+    case FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_FAILURE:
     case FETCH_THIRD_PARTIES_FAILURE: {
       return {
         ...state,
@@ -174,7 +188,7 @@ export function thirdPartyReducer(state: ThirdPartyState = INITIAL_STATE, action
         error: action.payload.errorMessage || null
       }
     }
-    case PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS: {
+    case FINISH_PUBLISH_AND_PUSH_CHANGES_THIRD_PARTY_ITEMS_SUCCESS: {
       return {
         ...state,
         data: {

--- a/src/specs/item.ts
+++ b/src/specs/item.ts
@@ -25,7 +25,7 @@ export const mockedItem: Item = {
   inCatalyst: false,
   contents: { 'anItemContent.glb': 'theFileHash', 'thumbnail.png': 'theThumbnailHash' },
   blockchainContentHash: null,
-  currentContentHash: null,
+  currentContentHash: 'aContentHash',
   catalystContentHash: null,
   data: {
     category: WearableCategory.HAT,


### PR DESCRIPTION
This PR improves the LW publishing flow by:
- Showing the user the item's mapping when confirming the items to be published.
- Changing the payment sagas to have separated phases, that is, waiting for the transaction to be accepted, processing the transaction and publishing items and changes. This implies a more ordered flow for the users.

And fixes:
- The publishing flow crashing due to lack of retries on the publishing API calls.
- The missing third party publishing status function when wrapping the publishing modal with the withAuthorization wrapper.
- The auto-sizing of the MappingEditor component, which was missing the `min-width` property.
- The edit name icon in the ThirdPartyCollectionDetail page being pushed to the right so much it wasn't visible.
- Removes the capability to change the third party collection name after publishing it.