### PR TITLE
fix: Retrieving TP by id

### DIFF
--- a/src/modules/location/selectors.ts
+++ b/src/modules/location/selectors.ts
@@ -80,7 +80,8 @@ export const getSelectedItemId = (state: RootState) => {
   const items = isReviewingTPCollection ? allItems.filter(item => item.isPublished) : allItems
   return getFirstWearableOrItem(items)?.id ?? null
 }
-export const getSelectedCollectionId = (state: RootState) => new URLSearchParams(getSearch(state)).get('collection')
+export const getSelectedCollectionId = (state: RootState) =>
+  new URLSearchParams(getSearch(state)).get('collection') ?? new URLSearchParams(getSearch(state)).get('collectionId')
 export const isReviewing = (state: RootState) => !!new URLSearchParams(getSearch(state)).get('reviewing')
 
 export const ensNameMatchSelector = createMatchSelector<


### PR DESCRIPTION
The Third Parties forum post is done by using the query parameter `collectionId` instead of `collection`, which is the one used for standard collections. This PR is a fix that allows older forum posts to keep linking to the collection.