### PR TITLE
feat: LW Header Improvements

### DIFF
--- a/src/components/ActivityPage/Transaction/TransactionDetail/TransactionDetail.tsx
+++ b/src/components/ActivityPage/Transaction/TransactionDetail/TransactionDetail.tsx
@@ -9,7 +9,6 @@ import { Atlas } from 'components/Atlas'
 import CollectionImage from 'components/CollectionImage'
 import ItemImage from 'components/ItemImage'
 import Profile from 'components/Profile'
-import { ThirdPartyImage } from 'components/ThirdPartyImage'
 import { ENSImage } from '../ENSImage'
 import { Props } from './TransactionDetail.types'
 import './TransactionDetail.css'
@@ -23,7 +22,7 @@ const getHref = (tx: Transaction) => {
 }
 
 const Image = (props: Props) => {
-  const { selection, address, collectionId, item, subdomain, slotsToyBuy, thirdPartyId } = props
+  const { selection, address, collectionId, item, subdomain, slotsToyBuy } = props
 
   const set = useMemo(() => new Set((selection || []).map(coord => coordsToId(coord.x, coord.y))), [selection])
   const selectedStrokeLayer: Layer = useCallback((x, y) => (set.has(coordsToId(x, y)) ? { color: '#ff0044', scale: 1.4 } : null), [set])
@@ -42,8 +41,6 @@ const Image = (props: Props) => {
     return <ENSImage subdomain={subdomain} isSmall />
   } else if (slotsToyBuy) {
     return <div className="slot-image" />
-  } else if (thirdPartyId) {
-    return <ThirdPartyImage thirdPartyId={thirdPartyId} />
   } else {
     return null
   }

--- a/src/components/CollectionImage/CollectionImage.tsx
+++ b/src/components/CollectionImage/CollectionImage.tsx
@@ -6,6 +6,7 @@ import { Item } from 'modules/item/types'
 import ItemImage from 'components/ItemImage'
 import { Props } from './CollectionImage.types'
 import './CollectionImage.css'
+import { COLLECTION_IMAGE_DATA_TEST_ID } from './constants'
 
 const MAX_IMAGES_TO_SHOW = 4
 
@@ -64,7 +65,7 @@ export default class CollectionImage extends React.PureComponent<Props> {
     const { items, className, itemCount, isLoading } = this.props
 
     return (
-      <div className={classNames('CollectionImage', 'is-image', className)}>
+      <div className={classNames('CollectionImage', 'is-image', className)} data-testid={COLLECTION_IMAGE_DATA_TEST_ID}>
         {isLoading || itemCount === undefined ? (
           <div className="item-row loading">
             <Loader active size="tiny" inline />

--- a/src/components/CollectionImage/constants.ts
+++ b/src/components/CollectionImage/constants.ts
@@ -1,0 +1,1 @@
+export const COLLECTION_IMAGE_DATA_TEST_ID = 'collection-image-data-test-id'

--- a/src/components/CollectionImage/index.ts
+++ b/src/components/CollectionImage/index.ts
@@ -1,3 +1,4 @@
 import CollectionImage from './CollectionImage.container'
 
+export * from './constants'
 export default CollectionImage

--- a/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.module.css
+++ b/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.module.css
@@ -75,9 +75,12 @@
   flex-direction: row;
   align-items: center;
   gap: 12px;
-  flex: 1 1 auto;
   overflow: hidden;
   margin-right: 20px;
+
+  /* Grow and shrink */
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .editCollectionName {
@@ -89,6 +92,27 @@
   visibility: visible;
 }
 
+.nameAndType {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  /* Grow and shrink */
+  min-width: 0;
+  flex: 1;
+}
+
+.nameWrapper {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 15px;
+
+  /* Grow and shrink */
+  min-width: 0;
+  flex: 1;
+}
+
 .header .title .name {
   margin-top: 0px;
   margin-bottom: 0px;
@@ -96,6 +120,9 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
+
+  /* Grow and shrink */
+  min-width: 0;
   width: fit-content;
 }
 
@@ -232,4 +259,29 @@
 .migrationBanner :global(.icon) {
   height: 18px;
   margin-right: 10px;
+}
+
+/* Badges */
+
+.type {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+}
+
+.linkedWearableBadge {
+  padding: 4px 8px 4px 8px;
+  border-radius: 32px;
+}
+
+.typeBadge {
+  background-color: #00a146;
+}
+
+.programmaticBadge {
+  background-color: #691fa9;
+}
+
+.standardBadge {
+  background-color: #43404a;
 }

--- a/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.tsx
+++ b/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useHistory } from 'react-router'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import classNames from 'classnames'
 import {
   Header,
   Icon,
@@ -24,8 +25,8 @@ import { fetchCollectionItemsRequest } from 'modules/item/actions'
 import LoggedInDetailPage from 'components/LoggedInDetailPage'
 import CollectionProvider from 'components/CollectionProvider'
 import NotFound from 'components/NotFound'
-import BuilderIcon from 'components/Icon'
 import { ThirdPartyImage } from 'components/ThirdPartyImage'
+import BuilderIcon from 'components/Icon'
 import Back from 'components/Back'
 import { shorten } from 'lib/address'
 import { CopyToClipboard } from 'components/CopyToClipboard'
@@ -249,11 +250,23 @@ export default function ThirdPartyCollectionDetailPage({
             <Back absolute onClick={handleGoBack} />
             <div className={styles.content}>
               <div className={styles.title}>
-                <ThirdPartyImage thirdPartyId={thirdParty.id} network={collection.linkedContractNetwork} />
-                <Header size="large" className={styles.name} onClick={handleEditName}>
-                  {collection.name}
-                </Header>
-                {!collection.isPublished && <BuilderIcon name="edit" className={styles.editCollectionName} />}
+                <ThirdPartyImage collectionId={collection.id} />
+                <div className={styles.nameAndType}>
+                  <div className={styles.nameWrapper}>
+                    <Header size="large" className={styles.name} onClick={handleEditName}>
+                      {collection.name}
+                    </Header>
+                    {!collection.isPublished && <BuilderIcon name="edit" className={styles.editCollectionName} />}
+                  </div>
+                  <div className={styles.type}>
+                    <div className={classNames(styles.linkedWearableBadge, styles.typeBadge)}>Linked Wearables</div>
+                    {thirdParty.isProgrammatic ? (
+                      <div className={classNames(styles.linkedWearableBadge, styles.programmaticBadge)}>Programmatic</div>
+                    ) : (
+                      <div className={classNames(styles.linkedWearableBadge, styles.standardBadge)}>Standard</div>
+                    )}
+                  </div>
+                </div>
               </div>
               <div className={styles.actions}>
                 {collection.linkedContractAddress && collection.linkedContractNetwork && (

--- a/src/components/ThirdPartyImage/ThirdPartyImage.container.ts
+++ b/src/components/ThirdPartyImage/ThirdPartyImage.container.ts
@@ -1,0 +1,11 @@
+import { connect } from 'react-redux'
+import { ThirdPartyImage } from './ThirdPartyImage'
+import { RootState } from 'modules/common/types'
+import { getCollection } from 'modules/collection/selectors'
+import { MapStateProps, OwnProps } from './ThirdPartyImage.types'
+
+const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => ({
+  collection: getCollection(state, ownProps.collectionId)
+})
+
+export default connect(mapState)(ThirdPartyImage)

--- a/src/components/ThirdPartyImage/ThirdPartyImage.module.css
+++ b/src/components/ThirdPartyImage/ThirdPartyImage.module.css
@@ -1,14 +1,20 @@
 .image,
 .main {
   position: relative;
-  width: 48px;
-  height: 48px;
+  width: 64px;
+  height: 64px;
+  border-radius: 50% !important;
+}
+
+.image {
+  overflow: hidden;
 }
 
 .network {
   position: absolute;
   bottom: 0;
   right: 0;
-  width: 24px;
-  height: 24px;
+  width: 32px;
+  height: 32px;
+  z-index: 20;
 }

--- a/src/components/ThirdPartyImage/ThirdPartyImage.spec.tsx
+++ b/src/components/ThirdPartyImage/ThirdPartyImage.spec.tsx
@@ -1,10 +1,15 @@
 import { ContractNetwork } from '@dcl/schemas'
 import { render } from '@testing-library/react'
 import { NETWORK_ICON_DATA_TEST_ID } from 'components/NetworkIcon'
+import { Collection } from 'modules/collection/types'
+import { COLLECTION_IMAGE_DATA_TEST_ID } from 'components/CollectionImage'
 import { ThirdPartyImage } from './ThirdPartyImage'
 import { Props } from './ThirdPartyImage.types'
 
-const renderThirdPartyImage = (props: Partial<Props> = {}) => render(<ThirdPartyImage thirdPartyId="aThirdPartyId" {...props} />)
+jest.mock('components/CollectionImage/CollectionImage.container', () => () => <div data-testid={COLLECTION_IMAGE_DATA_TEST_ID} />)
+
+const renderThirdPartyImage = (props: Partial<Props> = {}) =>
+  render(<ThirdPartyImage collection={{ id: 'aCollectionId' } as Collection} collectionId="aCollectionId" {...props} />)
 
 describe('when rendering the component', () => {
   let props: Partial<Props>
@@ -16,7 +21,7 @@ describe('when rendering the component', () => {
 
   describe('without a contract network', () => {
     beforeEach(() => {
-      props.network = undefined
+      props.collection = { id: 'aCollectionId', linkedContractNetwork: undefined } as Collection
       renderedComponent = renderThirdPartyImage(props)
     })
 
@@ -27,12 +32,34 @@ describe('when rendering the component', () => {
 
   describe('with a contract network', () => {
     beforeEach(() => {
-      props.network = ContractNetwork.MAINNET
+      props.collection = { id: 'aCollectionId', linkedContractNetwork: ContractNetwork.MAINNET } as Collection
       renderedComponent = renderThirdPartyImage(props)
     })
 
     it('should render the network image', () => {
       expect(renderedComponent.getByTestId(NETWORK_ICON_DATA_TEST_ID)).toBeInTheDocument()
+    })
+  })
+
+  describe('with an item count as zero', () => {
+    beforeEach(() => {
+      props.collection = { id: 'aCollectionId', itemCount: 0 } as Collection
+      renderedComponent = renderThirdPartyImage(props)
+    })
+
+    it('should not render a collection image', () => {
+      expect(renderedComponent.queryByTestId(COLLECTION_IMAGE_DATA_TEST_ID)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('with an item count greater than zero', () => {
+    beforeEach(() => {
+      props.collection = { id: 'aCollectionId', itemCount: 1 } as Collection
+      renderedComponent = renderThirdPartyImage(props)
+    })
+
+    it('should render a collection image', () => {
+      expect(renderedComponent.getByTestId(COLLECTION_IMAGE_DATA_TEST_ID)).toBeInTheDocument()
     })
   })
 })

--- a/src/components/ThirdPartyImage/ThirdPartyImage.tsx
+++ b/src/components/ThirdPartyImage/ThirdPartyImage.tsx
@@ -1,15 +1,21 @@
 import { Blockie } from 'decentraland-ui'
 import classNames from 'classnames'
 import { NetworkIcon } from 'components/NetworkIcon'
+import CollectionImage from 'components/CollectionImage'
 import styles from './ThirdPartyImage.module.css'
 import { Props } from './ThirdPartyImage.types'
 
 export const ThirdPartyImage = (props: Props) => {
-  const { thirdPartyId, network, className, shape } = props
+  const { collection, collectionId, className, shape } = props
+
   return (
     <div className={classNames(styles.main, className)}>
-      <Blockie className={styles.image} seed={thirdPartyId} size={8} scale={8} shape={shape ?? 'circle'} />
-      {network ? <NetworkIcon network={network} className={styles.network} /> : null}
+      {collection?.itemCount ? (
+        <CollectionImage collectionId={collectionId} className={styles.image} />
+      ) : (
+        <Blockie className={styles.image} seed={collectionId} size={8} scale={8} shape={shape ?? 'circle'} />
+      )}
+      {collection?.linkedContractNetwork ? <NetworkIcon network={collection?.linkedContractNetwork} className={styles.network} /> : null}
     </div>
   )
 }

--- a/src/components/ThirdPartyImage/ThirdPartyImage.types.ts
+++ b/src/components/ThirdPartyImage/ThirdPartyImage.types.ts
@@ -1,8 +1,11 @@
-import { ContractNetwork } from '@dcl/schemas'
+import { Collection } from 'modules/collection/types'
 
 export type Props = {
+  collectionId: string
   className?: string
-  network?: ContractNetwork
-  thirdPartyId: string
+  collection?: Collection | null
   shape?: 'circle' | 'square'
 }
+
+export type MapStateProps = Pick<Props, 'collection'>
+export type OwnProps = Pick<Props, 'collectionId' | 'className' | 'shape'>

--- a/src/components/ThirdPartyImage/index.ts
+++ b/src/components/ThirdPartyImage/index.ts
@@ -1,2 +1,4 @@
-export * from './ThirdPartyImage'
+import ThirdPartyImage from './ThirdPartyImage.container'
+
 export * from './ThirdPartyImage.types'
+export { ThirdPartyImage }

--- a/src/lib/api/builder.ts
+++ b/src/lib/api/builder.ts
@@ -685,7 +685,7 @@ export class BuilderAPI extends BaseAPI {
     return { items: items.map(fromRemotePool), total }
   }
 
-  async fetchPoolGroups(activeOnly = false) {
+  fetchPoolGroups = async (activeOnly = false) => {
     const items: RemotePoolGroup[] = await this.request('get', '/pools/groups', { params: { activeOnly } })
     return items.map(fromPoolGroup)
   }

--- a/src/modules/common/store.ts
+++ b/src/modules/common/store.ts
@@ -192,8 +192,4 @@ window.onbeforeunload = function () {
 
 store.dispatch(fetchTilesRequest())
 
-function initTestStore(preloadedState = {}) {
-  const testEnhancer = composeEnhancers(applyMiddleware(historyMiddleware, sagasMiddleware, storageMiddleware, transactionMiddleware))
-  return createStore(rootReducer, preloadedState, testEnhancer)
-}
-export { store, history, initTestStore }
+export { store, history }

--- a/src/modules/deployment/sagas.spec.ts
+++ b/src/modules/deployment/sagas.spec.ts
@@ -36,6 +36,12 @@ let catalystClient: CatalystClient
 let deployMock: jest.Mock
 let fetchEntitiesByPointersMock: jest.Mock
 
+jest.mock('modules/common/store', () => ({
+  store: {
+    dispatch: jest.fn()
+  }
+}))
+
 jest.mock('@dcl/crypto', () => ({
   Authenticator: { signPayload: jest.fn().mockReturnValue('auth') }
 }))

--- a/src/modules/deployment/sagas.spec.ts
+++ b/src/modules/deployment/sagas.spec.ts
@@ -36,6 +36,7 @@ let catalystClient: CatalystClient
 let deployMock: jest.Mock
 let fetchEntitiesByPointersMock: jest.Mock
 
+// Mocking store as when the store gets loaded, it runs the default sagas
 jest.mock('modules/common/store', () => ({
   store: {
     dispatch: jest.fn()
@@ -45,7 +46,6 @@ jest.mock('modules/common/store', () => ({
 jest.mock('@dcl/crypto', () => ({
   Authenticator: { signPayload: jest.fn().mockReturnValue('auth') }
 }))
-
 jest.mock('dcl-catalyst-client/dist/client/utils/DeploymentBuilder', () => ({
   buildEntity: jest.fn()
 }))

--- a/src/modules/poolGroup/sagas.ts
+++ b/src/modules/poolGroup/sagas.ts
@@ -17,7 +17,7 @@ export function* poolGroupSaga(builder: BuilderAPI) {
 
   function* handleLoadPoolGroups(_action: LoadPoolGroupsRequestAction) {
     try {
-      const poolGroups: PoolGroup[] = yield call(() => builder.fetchPoolGroups())
+      const poolGroups: PoolGroup[] = yield call([builder, 'fetchPoolGroups'])
       const record: ModelById<PoolGroup> = {}
 
       for (const poolGroup of poolGroups) {

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -1642,6 +1642,9 @@
     "slots_short": "Slots",
     "slots_long": "Publishing points",
     "migration_banner": "One or many items in your collection must be migrated to new version",
+    "type": "Linked Wearables",
+    "programmatic": "Programmatic",
+    "standard": "Standard",
     "synced_filter": {
       "all": "All items",
       "synced": "Synced",

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -1649,6 +1649,9 @@
     "slots_short": "Slots",
     "slots_long": "Puntos de publicación",
     "migration_banner": "Uno o múltiples items en tu colección necesitan ser migrados a la nueva versión",
+    "type": "Externamente vinculadas",
+    "programmatic": "Programáticas",
+    "standard": "Estándar",
     "synced_filter": {
       "all": "Todos los items",
       "synced": "Sincronizados",

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -1628,6 +1628,9 @@
     "slots_short": "插槽",
     "slots_long": "出版点",
     "migration_banner": "您收藏中的一个或多个项目必须迁移到新版本",
+    "type": "链接的可穿戴物品",
+    "programmatic": "程序化",
+    "standard": "标准的",
     "synced_filter": {
       "all": "所有项目",
       "synced": "同步的",

--- a/src/specs/utils.tsx
+++ b/src/specs/utils.tsx
@@ -1,4 +1,6 @@
 import { Provider } from 'react-redux'
+import { createBrowserHistory } from 'history'
+import { createStore } from 'redux'
 import flatten from 'flat'
 import { render } from '@testing-library/react'
 import { Store } from 'redux'
@@ -7,9 +9,16 @@ import { en } from 'decentraland-dapps/dist/modules/translation/defaults'
 import { mergeTranslations } from 'decentraland-dapps/dist/modules/translation/utils'
 import TranslationProvider from 'decentraland-dapps/dist/providers/TranslationProvider'
 import * as locales from 'modules/translation/languages'
-import { RootState } from 'modules/common/types'
-import { initTestStore } from 'modules/common/store'
+import { RootState, RootStore } from 'modules/common/types'
 import { ConnectedRouter } from 'connected-react-router'
+import { createRootReducer } from 'modules/common/reducer'
+
+function initTestStore(preloadedState = {}): RootStore {
+  const basename = /^decentraland.(zone|org|today)$/.test(window.location.host) ? '/builder' : undefined
+  const history = createBrowserHistory({ basename })
+  const rootReducer = createRootReducer(history)
+  return createStore(rootReducer, preloadedState) as RootStore
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 const allTranslations = mergeTranslations(flatten(en) as unknown as Record<string, string>, flatten(locales.en))


### PR DESCRIPTION
This PR does two things:
- Improves the LW Header with a new `ThirdPartyImage` that uses the `CollectionImage` and the collection type.
- Changes some tests and mocks in order to avoid loading the sagas or the store when running tests.

![Screenshot 2024-09-30 at 14 31 04](https://github.com/user-attachments/assets/8ca44cc1-38f6-47bc-8b4b-531d77a7b901)
