### PR TITLE
fix: LW element aligment issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "decentraland-ecs": "6.12.4-7784644013.commit-f770b3e",
         "decentraland-experiments": "^1.0.2",
         "decentraland-transactions": "^2.16.0",
-        "decentraland-ui": "^6.9.2",
+        "decentraland-ui": "^6.9.3",
         "ethers": "^5.6.8",
         "file-saver": "^2.0.1",
         "graphql": "^15.8.0",
@@ -11958,10 +11958,9 @@
       }
     },
     "node_modules/decentraland-ui": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-6.9.2.tgz",
-      "integrity": "sha512-E4Iv7FwdFdGbV3kUcueXrEaXS8k1ODoySxtR1MSL4Ajo+1MV0lhQqnAGya8ocuO4bZCmSWFkpivTTFgSZJ1FyQ==",
-      "license": "MIT",
+      "version": "6.9.3",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-6.9.3.tgz",
+      "integrity": "sha512-qpIORmE1BlRZoQMvM0eCT5QOoM4Fvv2p4xOyDLvyWpDk1BV4Zy3yc+BWjkb3jnzCYrxm7GJ4AKSorvaU9sFVkQ==",
       "dependencies": {
         "@dcl/schemas": "^13.9.0",
         "@dcl/ui-env": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "decentraland-ecs": "6.12.4-7784644013.commit-f770b3e",
     "decentraland-experiments": "^1.0.2",
     "decentraland-transactions": "^2.16.0",
-    "decentraland-ui": "^6.9.2",
+    "decentraland-ui": "^6.9.3",
     "ethers": "^5.6.8",
     "file-saver": "^2.0.1",
     "graphql": "^15.8.0",

--- a/src/components/MappingEditor/MappingEditor.module.css
+++ b/src/components/MappingEditor/MappingEditor.module.css
@@ -41,14 +41,24 @@
   margin-top: 19px;
 }
 
+.readOnly .any,
+.readOnly .none,
+.readOnly .multiple {
+  margin-top: 0 !important;
+}
+
 /* Mapping type class */
 
 .mappingType :global(.ui.dropdown):global(> .text:not(.default) > img) {
-  margin-top: 3px;
+  margin-top: 1px;
 }
 
 .mappingType.compact {
   margin-top: 17px;
+}
+
+.readOnly .mappingType {
+  margin-top: 0 !important;
 }
 
 .mappingType.compact :global(.ui.selection.dropdown) {
@@ -56,7 +66,7 @@
 }
 
 .mappingType :global(.ui.dropdown .menu > .item > img) {
-  margin-top: 0px;
+  margin-top: 1px;
 }
 
 .mappingType :global(.default.text) {
@@ -134,4 +144,9 @@
   display: flex;
   align-items: center;
   gap: 6px;
+}
+
+/* Read only */
+.readOnly p:global(.message) {
+  display: none;
 }

--- a/src/components/MappingEditor/MappingEditor.tsx
+++ b/src/components/MappingEditor/MappingEditor.tsx
@@ -19,7 +19,7 @@ const mappingTypeIcons = {
 }
 
 export const MappingEditor = (props: Props) => {
-  const { mapping, error, loading, disabled, isCompact, onChange } = props
+  const { mapping, readOnly, error, loading, disabled, isCompact, onChange } = props
 
   const [mappingType, mappingValue] = useMemo(() => {
     if (!mapping) {
@@ -116,7 +116,7 @@ export const MappingEditor = (props: Props) => {
   )
 
   return (
-    <div className={classNames(styles.main, isCompact ? styles.compact : styles.full)}>
+    <div className={classNames(styles.main, isCompact ? styles.compact : styles.full, readOnly && styles.readOnly)}>
       <SelectField
         label={
           isCompact ? undefined : (
@@ -128,7 +128,7 @@ export const MappingEditor = (props: Props) => {
         onChange={handleMappingTypeChange}
         placeholder={t('mapping_editor.mapping_type_placeholder')}
         value={mappingType}
-        disabled={disabled}
+        disabled={disabled || readOnly}
         className={classNames(styles.mappingType, isCompact ? styles.compact : styles.full)}
         options={mappingTypeOptions}
       />
@@ -146,20 +146,20 @@ export const MappingEditor = (props: Props) => {
         ) : mappingType === MappingType.SINGLE ? (
           <Field
             label={isCompact ? undefined : t('mapping_editor.mapping_value_label')}
-            disabled={disabled}
+            disabled={disabled || readOnly}
             type="number"
             value={mappingValue}
             loading={loading}
             error={!!error}
             message={error}
             placeholder={'1234567890'}
-            maxLength={78}
+            maxLength={!readOnly ? 78 : undefined}
             onChange={handleSingleMappingValueChange}
           />
         ) : mappingType === MappingType.MULTIPLE ? (
           isCompact ? (
             <Field
-              disabled={disabled}
+              disabled={disabled || readOnly}
               loading={loading}
               error={!!error}
               message={
@@ -173,7 +173,7 @@ export const MappingEditor = (props: Props) => {
           ) : (
             <TextAreaField
               label={t('mapping_editor.mapping_value_multiple_label')}
-              disabled={disabled}
+              disabled={disabled || readOnly}
               loading={loading}
               info={
                 mappingValue.length === 0 && !error
@@ -193,22 +193,22 @@ export const MappingEditor = (props: Props) => {
               label={isCompact ? undefined : t('mapping_editor.mapping_value_from_label')}
               error={!!error}
               message={error}
-              disabled={disabled}
+              disabled={disabled || readOnly}
               type="number"
               placeholder={'1'}
-              maxLength={78}
+              maxLength={!readOnly ? 78 : undefined}
               value={mappingValue.split(',')[0]}
               onChange={handleFromMappingValueChange}
             />
             {isCompact ? <div className={styles.to}>{t('mapping_editor.to')}</div> : null}
             <Field
               label={isCompact ? undefined : t('mapping_editor.mapping_value_to_label')}
-              disabled={disabled}
+              disabled={disabled || readOnly}
               error={!!error}
               message={error}
               type="number"
               placeholder={'4000'}
-              maxLength={78}
+              maxLength={!readOnly ? 78 : undefined}
               value={mappingValue.split(',')[1]}
               onChange={handleToMappingValueChange}
             />

--- a/src/components/MappingEditor/MappingEditor.types.ts
+++ b/src/components/MappingEditor/MappingEditor.types.ts
@@ -6,5 +6,6 @@ export type Props = {
   isCompact?: boolean
   error?: string
   disabled?: boolean
+  readOnly?: boolean
   onChange: (mapping: Mapping) => void
 }

--- a/src/components/Modals/CreateAndEditMultipleItemsModal/CreateAndEditMultipleItemsModal.module.css
+++ b/src/components/Modals/CreateAndEditMultipleItemsModal/CreateAndEditMultipleItemsModal.module.css
@@ -113,7 +113,7 @@
 
 .item img {
   width: 225px;
-  height: 88px;
+  height: 100px;
 }
 
 .description {

--- a/src/components/Modals/PublishWizardCollectionModal/ConfirmCollectionItemsStep/ConfirmCollectionItemsStep.module.css
+++ b/src/components/Modals/PublishWizardCollectionModal/ConfirmCollectionItemsStep/ConfirmCollectionItemsStep.module.css
@@ -92,14 +92,6 @@
   max-width: 150px;
 }
 
-.avatarColumn .avatarContainer .badge {
-  background-color: var(--smart-grey);
-}
-
-.avatarColumn .avatarContainer .badge::before {
-  filter: none;
-}
-
 .priceColumn :global(.ui.mana) {
   font-size: 15px;
 }
@@ -140,4 +132,20 @@
   padding: 2px 12px 2px 12px;
   width: fit-content;
   font-size: 12px;
+  margin-right: 15px;
+}
+
+.badges {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 5px;
+}
+
+.badges .badge {
+  background-color: var(--smart-grey);
+}
+
+.badges .badge::before {
+  filter: none;
 }

--- a/src/components/Modals/PublishWizardCollectionModal/ConfirmCollectionItemsStep/ConfirmCollectionItemsStep.tsx
+++ b/src/components/Modals/PublishWizardCollectionModal/ConfirmCollectionItemsStep/ConfirmCollectionItemsStep.tsx
@@ -58,10 +58,9 @@ export const ConfirmCollectionItemsStep: React.FC<{
       <Table basic="very">
         <Table.Header className={classNames({ [styles.hasScrollBar]: items.length > 5 })}>
           <Table.Row>
+            <Table.HeaderCell width={3}>{t('collection_detail_page.table.item')}</Table.HeaderCell>
             <Table.HeaderCell width={1}></Table.HeaderCell>
-            <Table.HeaderCell width={5}>{t('collection_detail_page.table.item')}</Table.HeaderCell>
-            <Table.HeaderCell width={1}></Table.HeaderCell>
-            <Table.HeaderCell>Linked to</Table.HeaderCell>
+            <Table.HeaderCell width={5}>Linked to</Table.HeaderCell>
           </Table.Row>
         </Table.Header>
         <Table.Body>
@@ -69,25 +68,25 @@ export const ConfirmCollectionItemsStep: React.FC<{
             const itemMapping = getMapping(item)
             return (
               <Table.Row key={item.id}>
-                <Table.Cell width={1}>
-                  <div className={styles.itemNumber}>{index + 1}</div>
-                </Table.Cell>
-                <Table.Cell width={5} className={classNames(styles.column, styles.avatarColumn)}>
+                <Table.Cell width={3} className={classNames(styles.column, styles.avatarColumn)}>
                   <div className={styles.avatarContainer}>
+                    <div className={styles.itemNumber}>{index + 1}</div>
                     <ItemImage className={styles.itemImage} item={item} />
                     <div className={styles.info}>
                       <div className={styles.name} title={item.name}>
                         {item.name}
                       </div>
-                      <ItemBadge className={styles.badge} item={item} size="small" />
                     </div>
                   </div>
                 </Table.Cell>
                 <Table.Cell width={1}>
-                  <IconBadge className={classNames(styles.categoryBadge, styles.thirdParty)} icon={item.data.category} />
+                  <div className={styles.badges}>
+                    <ItemBadge className={styles.badge} size="normal" item={item} />
+                    <IconBadge className={classNames(styles.categoryBadge, styles.thirdParty)} icon={item.data.category} />
+                  </div>
                 </Table.Cell>
-                <Table.Cell className={styles.mapping}>
-                  {itemMapping && <MappingEditor mapping={itemMapping} onChange={() => undefined} disabled isCompact />}
+                <Table.Cell width={5}>
+                  {itemMapping && <MappingEditor mapping={itemMapping} onChange={() => undefined} readOnly isCompact />}
                 </Table.Cell>
               </Table.Row>
             )


### PR DESCRIPTION
This PR solves a couple of reported issues:
- Removes the max length label for read only fields and removes their message, making the fields slimmer.
- Updates the UI package so the select and input field are more aligned.
- Resizes the images in the step to select between programmatic and standard collections (it was not as high as it was needed).
- Groups both the gender and the category badges in the confirm items step so they're now together and aligned.