### PR TITLE
feat: move pin icon to fit in space

### DIFF
--- a/src/components/ENSListPage/ENSListPage.css
+++ b/src/components/ENSListPage/ENSListPage.css
@@ -114,7 +114,6 @@
 }
 
 .ENSListPage .ens-list-btn .Icon.pin {
-  width: 15px;
   height: 15px;
 }
 

--- a/src/components/Icon/sprite.css
+++ b/src/components/Icon/sprite.css
@@ -317,7 +317,7 @@
 }
 
 .Icon.pin {
-  background: url('icons.svg') 0 70.27027027027027% no-repeat;
+  background: url('icons.svg') 0 69.27027027027027% no-repeat;
   width: 24px;
   height: 24px;
 }


### PR DESCRIPTION
Changing this

<img width="651" alt="Screenshot 2024-10-17 at 6 55 32 PM" src="https://github.com/user-attachments/assets/70cbc27b-f886-4cef-8111-399e06053ae3">


into this

<img width="747" alt="Screenshot 2024-10-17 at 6 54 46 PM" src="https://github.com/user-attachments/assets/f1b2c18d-34b9-4544-bd67-b52c821e9cba">

