### PR TITLE
feat: Show authorization modal for Magic users when publishing on Polygon

### DIFF
--- a/src/components/Modals/PublishWizardCollectionModal/PublishWizardCollectionModal.tsx
+++ b/src/components/Modals/PublishWizardCollectionModal/PublishWizardCollectionModal.tsx
@@ -115,6 +115,7 @@ export const PublishWizardCollectionModal: React.FC<Props & WithAuthorizedAction
       const authorization = buildManaAuthorization(wallet.address, wallet.networks.MATIC.chainId, contractName)
 
       onAuthorizedAction({
+        manual: wallet.network === Network.MATIC,
         authorizedAddress: authorization.authorizedAddress,
         authorizedContractLabel: contractName,
         targetContract: {


### PR DESCRIPTION
When on Polygon, the Magic user must pay for the transaction gas, including the authorization. This PR changes the authorization process so the Authorization modal gets shown when the user is on the Polygon Network.