### PR TITLE
fix: Deploy to world without complete name

### DIFF
--- a/src/components/Modals/DeployModal/DeployToWorld/DeployToWorld.tsx
+++ b/src/components/Modals/DeployModal/DeployToWorld/DeployToWorld.tsx
@@ -57,7 +57,7 @@ export default function DeployToWorld({
   useEffect(() => {
     const fetchENSList = async () => {
       const ensList = await marketplace.fetchENSList(wallet?.address ?? '', ENS_LIST_PAGE_SIZE, 0)
-      setEnsList(ensList.map(ens => ({ subdomain: ens, name: ens } as ENS)))
+      setEnsList(ensList.map(ens => ({ subdomain: ens + '.dcl.eth', name: ens } as ENS)))
     }
     void fetchENSList()
   }, [])


### PR DESCRIPTION
This PR fixes the subdomain property that is used when deploying DCL names by adding the `dcl.eth` at the end of the domain.