### PR TITLE
fix: Update decentraland-dapps to fix CMS banners

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "decentraland-builder-scripts": "^0.24.0",
         "decentraland-connect": "^9.1.0",
         "decentraland-crypto-fetch": "^2.0.1",
-        "decentraland-dapps": "^24.8.0",
+        "decentraland-dapps": "^24.9.1",
         "decentraland-ecs": "6.12.4-7784644013.commit-f770b3e",
         "decentraland-experiments": "^1.0.2",
         "decentraland-transactions": "^2.16.0",
@@ -12514,9 +12514,9 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "24.8.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-24.8.0.tgz",
-      "integrity": "sha512-khxyQnbah6REoIxei54S614i8nrnZP3EeKMmXN+Yr5AZlqnBpwZQJ0muVrQiV6cxZzu2ZAwF9UHdLW2QOMl2xQ==",
+      "version": "24.9.1",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-24.9.1.tgz",
+      "integrity": "sha512-1WOgIBzRVF+YsC+o6QM2qIliOdz68YXwW9g1Hf8iIhTAuKC+XUTnYn9I9dymGa0hpyzIMHHwFfBn6/63zFIVUQ==",
       "dependencies": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
@@ -12536,7 +12536,7 @@
         "decentraland-crypto-fetch": "^2.0.1",
         "decentraland-transactions": "^2.18.3",
         "decentraland-ui": "^6.13.0",
-        "decentraland-ui2": "^0.11.5",
+        "decentraland-ui2": "^0.12.1",
         "ethers": "^5.7.2",
         "events": "^3.3.0",
         "flat": "^5.0.2",
@@ -12598,6 +12598,61 @@
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+    },
+    "node_modules/decentraland-dapps/node_modules/decentraland-ui2": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-0.12.1.tgz",
+      "integrity": "sha512-vTziNPJX+FXwh9BYAl5onCBXTr3XvjNfOxxVXT7Fo+WAHyC/aQ1h3th3EtgCA35uTFyVX9XLy4jD3XUY3ZrFMw==",
+      "dependencies": {
+        "@contentful/rich-text-react-renderer": "^16.0.1",
+        "@dcl/hooks": "^0.0.2",
+        "@dcl/schemas": "^15.6.0",
+        "@dcl/ui-env": "^1.5.1",
+        "@emotion/react": "^11.11.4",
+        "@emotion/styled": "^11.11.5",
+        "@mui/icons-material": "^5.16.0",
+        "@mui/material": "^5.16.0",
+        "autoprefixer": "^10.4.19",
+        "date-fns": "^3.6.0",
+        "ethereum-blockies": "^0.1.1",
+        "radash": "^11.0.0",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
+        "react-tile-map": "^0.4.1",
+        "uuid": "^11.1.0"
+      }
+    },
+    "node_modules/decentraland-dapps/node_modules/decentraland-ui2/node_modules/@dcl/schemas": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-15.8.1.tgz",
+      "integrity": "sha512-XzKOtv0y1i/mVeZqJ8Xr8JCuJjDvmwayPSNLmBiG+VgsbYZ8OCLswGchRi3aIjAh1oSMcth9jevw8dBe5MIJAw==",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-keywords": "^5.1.0",
+        "mitt": "^3.0.1"
+      }
+    },
+    "node_modules/decentraland-dapps/node_modules/decentraland-ui2/node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/decentraland-dapps/node_modules/decentraland-ui2/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/decentraland-dapps/node_modules/react-intl": {
       "version": "5.25.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "decentraland-builder-scripts": "^0.24.0",
     "decentraland-connect": "^9.1.0",
     "decentraland-crypto-fetch": "^2.0.1",
-    "decentraland-dapps": "^24.8.0",
+    "decentraland-dapps": "^24.9.1",
     "decentraland-ecs": "6.12.4-7784644013.commit-f770b3e",
     "decentraland-experiments": "^1.0.2",
     "decentraland-transactions": "^2.16.0",

--- a/src/config/env/dev.json
+++ b/src/config/env/dev.json
@@ -46,8 +46,7 @@
   "MARKETPLACE_SERVER_URL": "https://marketplace-api.decentraland.zone/v1",
   "WERT_PUBLISH_FEES_ENV": "dev",
   "PEER_TESTING_URL": "https://peer-testing.decentraland.org",
-  "CONTENTFUL_ACCESS_TOKEN": "AATjg5ZJgxllQW8PBSQV4ZaY5wh9W_lQSKIiERHY-sc",
-  "CONTENTFUL_ENVIRONMENT": "development",
+  "CONTENTFUL_ENVIRONMENT": "master",
   "CONTENTFUL_SPACE_ID": "ea2ybdmmn1kv",
-  "CONTENTFUL_ADMIN_ENTITY_ID": "3mvjCEsGUUqL22BY1vZLmZ"
+  "CONTENTFUL_ADMIN_ENTITY_ID": "7FJAHnPOiCEHMJhrZ3sRmG"
 }

--- a/src/config/env/prod.json
+++ b/src/config/env/prod.json
@@ -46,7 +46,6 @@
   "MARKETPLACE_SERVER_URL": "https://marketplace-api.decentraland.org/v1",
   "WERT_PUBLISH_FEES_ENV": "prod",
   "PEER_TESTING_URL": "https://peer-testing.decentraland.org",
-  "CONTENTFUL_ACCESS_TOKEN": "J9rlOU4LrSDw4q1rrji_PYn7HdU-ANd5Oi9EF6ioywc",
   "CONTENTFUL_ENVIRONMENT": "master",
   "CONTENTFUL_SPACE_ID": "ea2ybdmmn1kv",
   "CONTENTFUL_ADMIN_ENTITY_ID": "7JRrew0kMt5fkXu45Vbx7e"

--- a/src/config/env/stg.json
+++ b/src/config/env/stg.json
@@ -46,7 +46,6 @@
   "MARKETPLACE_SERVER_URL": "https://marketplace-api.decentraland.today/v1",
   "WERT_PUBLISH_FEES_ENV": "prod",
   "PEER_TESTING_URL": "https://peer-testing.decentraland.org",
-  "CONTENTFUL_ACCESS_TOKEN": "J9rlOU4LrSDw4q1rrji_PYn7HdU-ANd5Oi9EF6ioywc",
   "CONTENTFUL_ENVIRONMENT": "master",
   "CONTENTFUL_SPACE_ID": "ea2ybdmmn1kv",
   "CONTENTFUL_ADMIN_ENTITY_ID": "7JRrew0kMt5fkXu45Vbx7e"

--- a/src/modules/common/sagas.ts
+++ b/src/modules/common/sagas.ts
@@ -83,8 +83,7 @@ export function* rootSaga(
     campaignSagas(contentfulClient, {
       space: config.get('CONTENTFUL_SPACE_ID'),
       environment: config.get('CONTENTFUL_ENVIRONMENT'),
-      id: config.get('CONTENTFUL_ADMIN_ENTITY_ID'),
-      token: config.get('CONTENTFUL_ACCESS_TOKEN')
+      id: config.get('CONTENTFUL_ADMIN_ENTITY_ID')
     }),
     assetPackSaga(builderAPI),
     assetSaga(newBuilderClient),


### PR DESCRIPTION
This PR updates the `decentraland-dapps` dependency to fix the Banners that come from the CMS endpoint.