### PR TITLE
feat: Remove set price for emotes and show not on sale for max price items

### DIFF
--- a/src/components/ItemDetailPage/ItemDetailPage.css
+++ b/src/components/ItemDetailPage/ItemDetailPage.css
@@ -57,7 +57,6 @@
 }
 
 .ItemDetailPage .item-data .value {
-  margin-top: 5px;
   font-size: 21px;
   text-transform: capitalize;
 }
@@ -158,6 +157,7 @@
   padding: 24px;
   margin-left: 24px;
   margin-bottom: 12px;
+  max-width: 900px;
 }
 
 .ItemDetailPage .card .title {
@@ -188,6 +188,10 @@
   line-height: 30px;
 }
 
+.ItemDetailPage .data .price-container {
+  width: 40%;
+}
+
 .ItemDetailPage .data:not(:last-child) {
   margin-bottom: 24px;
 }
@@ -204,7 +208,6 @@
 
 .ItemDetailPage .card .dcl.section.medium {
   margin-bottom: 0;
-  margin-right: 120px;
 }
 
 .ItemDetailPage input[type='file'] {

--- a/src/components/ItemDetailPage/ItemDetailPage.tsx
+++ b/src/components/ItemDetailPage/ItemDetailPage.tsx
@@ -324,23 +324,38 @@ export default function ItemDetailPage(props: Props) {
                   <div className="title">{t('item_detail_page.selling.title')}</div>
                   <div className="data">
                     {isFree(item) ? (
-                      <Section>
+                      <Section className="price-container">
                         <div className="subtitle">{t('item.price')}</div>
                         <div className="value">{t('global.free')}</div>
                       </Section>
                     ) : item.price ? (
-                      <Section>
+                      <Section className="price-container">
                         <div className="subtitle">{t('item.price')}</div>
                         {item.price ? (
                           <Mana showTooltip network={Network.MATIC}>
-                            {ethers.utils.formatEther(item.price)}
+                            {(() => {
+                              const price = ethers.utils.formatEther(item.price)
+                              return price.length > 10 ? (
+                                <Popup
+                                  content={price}
+                                  position="top center"
+                                  trigger={<span>{`${price.slice(0, 3)}...${price.slice(-4)}`}</span>}
+                                  hideOnScroll
+                                  on="hover"
+                                  inverted
+                                  flowing
+                                />
+                              ) : (
+                                <span>{price}</span>
+                              )
+                            })()}
                           </Mana>
                         ) : (
                           '-'
                         )}
                       </Section>
                     ) : null}
-                    <Section>
+                    <Section className="beneficiary-container">
                       <div className="subtitle">{t('item.beneficiary')}</div>
                       {item.beneficiary ? <div className="value">{shorten(item.beneficiary)}</div> : '-'}
                     </Section>

--- a/src/components/ItemDetailPage/ItemDetailPage.tsx
+++ b/src/components/ItemDetailPage/ItemDetailPage.tsx
@@ -331,7 +331,7 @@ export default function ItemDetailPage(props: Props) {
                     ) : item.price ? (
                       <Section className="price-container">
                         <div className="subtitle">{t('item.price')}</div>
-                        {item.price ? (
+                        {item.price && item.price !== ethers.constants.MaxUint256.toString() ? (
                           <Mana showTooltip network={Network.MATIC}>
                             {(() => {
                               const price = ethers.utils.formatEther(item.price)
@@ -346,10 +346,12 @@ export default function ItemDetailPage(props: Props) {
                                   flowing
                                 />
                               ) : (
-                                <span>{price}</span>
+                                <div className="value">{price}</div>
                               )
                             })()}
                           </Mana>
+                        ) : item.price === ethers.constants.MaxUint256.toString() ? (
+                          <div className="value">{t('item.not_for_sale')}</div>
                         ) : (
                           '-'
                         )}

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
@@ -371,7 +371,7 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
     this.setState({
       item,
       itemSortedContents: sortedContents.all,
-      view: hasScreenshotTaken || type !== ItemType.EMOTE ? CreateItemView.SET_PRICE : CreateItemView.THUMBNAIL,
+      view: CreateItemView.THUMBNAIL,
       fromView: CreateItemView.THUMBNAIL
     })
   }
@@ -521,7 +521,7 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
         } catch (error) {
           this.setState({ error: isErrorWithMessage(error) ? error.message : 'Unknown error' })
         }
-      } else if (this.state.view === CreateItemView.SET_PRICE && !!this.state.item && !!this.state.itemSortedContents) {
+      } else if (!!this.state.item && !!this.state.itemSortedContents) {
         onSave(this.state.item as Item, this.state.itemSortedContents)
       }
     }
@@ -1348,7 +1348,6 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
 
   handleOnScreenshotTaken = async (screenshot: string) => {
     const { fromView, itemSortedContents, item } = this.state
-    const view = fromView === CreateItemView.DETAILS ? CreateItemView.DETAILS : CreateItemView.SET_PRICE
 
     if (item && itemSortedContents) {
       const blob = dataURLToBlob(screenshot)
@@ -1356,9 +1355,19 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
       itemSortedContents[THUMBNAIL_PATH] = blob!
       item.contents = await computeHashes(itemSortedContents)
 
-      this.setState({ itemSortedContents, item, hasScreenshotTaken: true }, () => this.setState({ view }))
+      this.setState({ itemSortedContents, item, hasScreenshotTaken: true }, () => {
+        if (fromView === CreateItemView.DETAILS) {
+          this.setState({ view: CreateItemView.DETAILS })
+        } else {
+          void this.handleSubmit()
+        }
+      })
     } else {
-      this.setState({ thumbnail: screenshot, hasScreenshotTaken: true }, () => this.setState({ view }))
+      this.setState({ thumbnail: screenshot, hasScreenshotTaken: true }, () => {
+        if (fromView === CreateItemView.DETAILS) {
+          this.setState({ view: CreateItemView.DETAILS })
+        }
+      })
     }
   }
 

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
@@ -470,7 +470,7 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
   }
 
   handleSubmit = async () => {
-    const { metadata, onSave } = this.props
+    const { metadata } = this.props
     const { id } = this.state
 
     let changeItemFile = false
@@ -522,7 +522,13 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
           this.setState({ error: isErrorWithMessage(error) ? error.message : 'Unknown error' })
         }
       } else if (!!this.state.item && !!this.state.itemSortedContents) {
-        onSave(this.state.item as Item, this.state.itemSortedContents)
+        const sortedContents = {
+          male: this.state.itemSortedContents,
+          female: this.state.itemSortedContents,
+          all: this.state.itemSortedContents
+        }
+        const representations = this.buildRepresentations(this.state.bodyShape!, this.state.model!, sortedContents)
+        await this.createItem(sortedContents, representations)
       }
     }
   }

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -1763,6 +1763,7 @@
     "rarity": "Rarity",
     "representation": "Representation",
     "price": "Price",
+    "not_for_sale": "Not for sale",
     "beneficiary": "Beneficiary",
     "supply": "Supply",
     "collection": "Collection",

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -1772,6 +1772,7 @@
     "rarity": "Rareza",
     "representation": "Representación",
     "price": "Precio",
+    "not_for_sale": "No está en venta",
     "beneficiary": "Beneficiario",
     "supply": "Suministro",
     "collection": "Colección",

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -1751,6 +1751,7 @@
     "rarity": "稀有度",
     "representation": "表示",
     "price": "价钱",
+    "not_for_sale": "不出售",
     "beneficiary": "受益人",
     "supply": "供应",
     "collection": "采集",


### PR DESCRIPTION
- Remove step to add price to emotes (to be consistent with wearables)
- Display "Not for sale" for items that have max price
- Fix UI layout issues when price has many characters

<img width="1086" alt="Screenshot 2025-07-02 at 18 23 07" src="https://github.com/user-attachments/assets/99d3a74f-51b8-47d5-9707-d094f04dce69" />

https://github.com/user-attachments/assets/299f9e46-070a-4fe5-92a4-cbf93e058ff1

