### PR TITLE
Fix: Save button name on creating items

### DIFF
--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
@@ -1306,10 +1306,11 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
 
   renderDetailsView() {
     const { onClose, metadata, error, isLoading, collection } = this.props
-    const { isRepresentation, error: stateError, type, contents, isLoading: isStateLoading } = this.state
+    const { isRepresentation, error: stateError, type, contents, isLoading: isStateLoading, hasScreenshotTaken } = this.state
     const belongsToAThirdPartyCollection = collection?.urn && isThirdParty(collection.urn)
     const isDisabled = this.isDisabled()
     const title = this.renderModalTitle()
+    const hasFinishSteps = (type === ItemType.EMOTE && hasScreenshotTaken) || type === ItemType.WEARABLE
 
     return (
       <>
@@ -1328,7 +1329,7 @@ export default class CreateSingleItemModal extends React.PureComponent<Props, St
                 ) : null}
                 <Column align="right">
                   <Button primary disabled={isDisabled} loading={isLoading || isStateLoading}>
-                    {(metadata && metadata.changeItemFile) || isRepresentation || belongsToAThirdPartyCollection
+                    {(metadata && metadata.changeItemFile) || isRepresentation || belongsToAThirdPartyCollection || hasFinishSteps
                       ? t('global.save')
                       : t('global.next')}
                   </Button>


### PR DESCRIPTION
When creating a wearable, the CTA used to say "Next," even though the actual action was saving the wearable.

Now:

- When adding a wearable, since there is only one step, the button says "Save."
- When adding an emote:
  - If the thumbnail is already taken, the button says "Save."
  - If the thumbnail is not taken yet, the button says "Next."


https://github.com/user-attachments/assets/d4890ed9-671f-4f77-a5f5-133819d824fd

https://github.com/user-attachments/assets/2e75a083-99b6-4b62-a3ad-848ecbfa3d2d

