### PR TITLE
fix: Hide WP when taking screenshot

### DIFF
--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.css
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.css
@@ -226,7 +226,7 @@
   background-color: var(--secondary-text);
 }
 
-.CreateSingleItemModal .importer-thumbnail-container .WearablePreview {
+.CreateSingleItemModal .importer-thumbnail-container #thumbnail-picker {
   display: none;
 }
 


### PR DESCRIPTION
This PR fixes WearablePreview showing on screen when it should be hidden during the wearable thumbnail generation process.