### PR TITLE
fix: Improve UX when minting more than 50 NFTs in a single transaction

### DIFF
--- a/src/components/Modals/MintItemsModal/MintItemsModal.tsx
+++ b/src/components/Modals/MintItemsModal/MintItemsModal.tsx
@@ -100,8 +100,6 @@ export default class MintItemsModal extends React.PureComponent<Props, State> {
 
     const isEmpty = items.length === 0
     const isFull = items.length === totalCollectionItems
-    const isDisabled = this.isDisabled()
-
     const totalMints = Object.values(itemMints).reduce((accumulator, mints) => {
       const totalMintsPerItem = mints.reduce((acc, mint) => {
         const amount = mint.amount || 0
@@ -109,6 +107,9 @@ export default class MintItemsModal extends React.PureComponent<Props, State> {
       }, 0)
       return accumulator + totalMintsPerItem
     }, 0)
+
+    const exceedsLimit = totalMints > MAX_NFTS_PER_MINT
+    const isDisabled = this.isDisabled() || exceedsLimit
 
     // ! this function goes inside render to re-trigger the rendering of the item dropdown when the selection of items changes
     const filterAddableItems = (item: Item) => {
@@ -211,9 +212,9 @@ export default class MintItemsModal extends React.PureComponent<Props, State> {
                   </Button>
                 )}
               </ModalActions>
-              {error ? (
+              {error || exceedsLimit ? (
                 <Row className="error" align="right">
-                  <p className="danger-text">{error}</p>
+                  <p className="danger-text">{error || t('mint_items_modal.limit_reached', { max: MAX_NFTS_PER_MINT })}</p>
                 </Row>
               ) : null}
             </Form>


### PR DESCRIPTION
Fixes #3365

Previously, users could configure mints exceeding `MAX_NFTS_PER_MINT` in `MintItemsModal` and attempt to submit the transaction, only receiving an error after the fact. The modal had no pre-submission validation against the per-transaction mint limit. `MintItemsModal.tsx` now computes `exceedsLimit` by comparing `totalMints` against `MAX_NFTS_PER_MINT` after the reduce, disables the submit button via `isDisabled`, and surfaces a localized warning via `t('mint_items_modal.limit_reached')` in the existing error row before the user attempts submission. Verified by manually entering mint amounts exceeding 50 and confirming the button disables and the error message renders inline.