### PR TITLE
fix: send video hash for all statuses on modifyItem

### DIFF
--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
@@ -34,7 +34,6 @@ import {
   EmotePlayMode,
   VIDEO_PATH,
   WearableData,
-  SyncStatus,
   EmoteData
 } from 'modules/item/types'
 import { areEmoteMetrics, Metrics } from 'modules/models/types'
@@ -442,13 +441,13 @@ export const CreateSingleItemModal: React.FC<Props> = props => {
         item.data.representations[representationIndex] = representations[0]
       }
 
-      if (itemStatus && [SyncStatus.UNPUBLISHED, SyncStatus.UNDER_REVIEW].includes(itemStatus) && isSmart(item) && VIDEO_PATH in contents) {
+      if (isSmart(item) && VIDEO_PATH in contents) {
         item.video = contents[VIDEO_PATH]
       }
 
       onSave(item as Item, sortedContents.all)
     },
-    [itemStatus, state, onSave]
+    [state, onSave]
   )
 
   // Thumbnail handling


### PR DESCRIPTION
## Summary                                                                                                                                                                                                            

  - Fix smart wearable items showing permanently _UNSYNCED_ after converting a published regular wearable to a smart wearable                                                                                        
  - The `item.video` field was not being updated in `modifyItem` when the item had status _SYNCED_ or _UNSYNCED_, because the assignment was gated behind a condition that only allowed _UNPUBLISHED_ or _UNDER_REVIEW_ statuses 
  - This caused `item.video` to remain `undefined` (inherited from the original non-smart wearable) while `item.contents['video.mp4']` had the correct hash, making `isWearableSynced` always return `false`                   
  - Removed the status check so `item.video` is always set when the item is a smart wearable with a video in its contents, matching the behavior of `createItem`  