### PR TITLE
chore: downgrade decentraland-ui2 to 3.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "decentraland-experiments": "^1.0.2",
         "decentraland-transactions": "^3.0.2",
         "decentraland-ui": "^7.2.0",
-        "decentraland-ui2": "^3.7.0",
+        "decentraland-ui2": "^3.4.0",
         "ethers": "^5.6.8",
         "fast-equals": "^5.3.0",
         "file-saver": "^2.0.1",
@@ -19384,9 +19384,9 @@
       }
     },
     "node_modules/decentraland-ui2": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-3.7.0.tgz",
-      "integrity": "sha512-dRKsNGb5w/vIVpwqdHueSxGfD9tJZRY/lQGFR2sL8pFA1hzvsyeg5SAMHM3wPC98LJbH6V7K9DA107oXJ4+tnw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-3.4.0.tgz",
+      "integrity": "sha512-NcI4ujzgF04F+f/4/Dgu44cmXBQ2yOTDlNw3mbbyfbWaRAUDL5eusrP/FiiLeIU1HOt23tC02NWB7LGuYdReHQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "11.14.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "decentraland-experiments": "^1.0.2",
     "decentraland-transactions": "^3.0.2",
     "decentraland-ui": "^7.2.0",
-    "decentraland-ui2": "^3.7.0",
+    "decentraland-ui2": "^3.4.0",
     "ethers": "^5.6.8",
     "fast-equals": "^5.3.0",
     "file-saver": "^2.0.1",


### PR DESCRIPTION
Reverts decentraland-ui2 from 3.7.0 back to 3.4.0.