### PR TITLE
fix: non deform bones validation

### DIFF
--- a/src/lib/glbValidation/index.ts
+++ b/src/lib/glbValidation/index.ts
@@ -82,7 +82,7 @@ export async function validateEmoteGLTF(gltf: GLTF, hasProps: boolean, contents?
     validateEmoteMaxFrames(animations),
     validateEmoteAnimationClipCount(animations, hasProps),
     validateEmoteDeformBoneKeyframes(Three, scene, animations),
-    validateNoNonDeformBones(Three, scene),
+    validateNoNonDeformBones(Three, scene, animations),
     validateArmatureNaming(scene),
     validateAnimationNaming(animations, hasProps)
   ]

--- a/src/lib/glbValidation/wearableValidators.spec.ts
+++ b/src/lib/glbValidation/wearableValidators.spec.ts
@@ -503,9 +503,11 @@ describe('validateNoLeafBones', () => {
 })
 
 function createAnimations(trackNames: string[]): THREE.AnimationClip[] {
-  return [{
-    tracks: trackNames.map(name => ({ name }))
-  }] as unknown as THREE.AnimationClip[]
+  return [
+    {
+      tracks: trackNames.map(name => ({ name }))
+    }
+  ] as unknown as THREE.AnimationClip[]
 }
 
 describe('validateNoNonDeformBones', () => {

--- a/src/lib/glbValidation/wearableValidators.spec.ts
+++ b/src/lib/glbValidation/wearableValidators.spec.ts
@@ -502,6 +502,12 @@ describe('validateNoLeafBones', () => {
   })
 })
 
+function createAnimations(trackNames: string[]): THREE.AnimationClip[] {
+  return [{
+    tracks: trackNames.map(name => ({ name }))
+  }] as unknown as THREE.AnimationClip[]
+}
+
 describe('validateNoNonDeformBones', () => {
   let Three: MockThree
 
@@ -513,61 +519,121 @@ describe('validateNoNonDeformBones', () => {
     jest.resetAllMocks()
   })
 
-  describe('when all bones are bound to a skinned mesh', () => {
-    let issues: ValidationIssue[]
+  describe('with skinned mesh (wearable)', () => {
+    describe('when all bones are bound to a skinned mesh', () => {
+      let issues: ValidationIssue[]
 
-    beforeEach(() => {
-      const bone1 = new Three.Bone()
-      bone1.name = 'Hips'
-      const bone2 = new Three.Bone()
-      bone2.name = 'Spine'
-      const skinnedMesh = new Three.SkinnedMesh()
-      ;(skinnedMesh as any).skeleton = { bones: [bone1, bone2] }
-      issues = validateNoNonDeformBones(asThree(Three), createScene([bone1, bone2, skinnedMesh]))
+      beforeEach(() => {
+        const bone1 = new Three.Bone()
+        bone1.name = 'Hips'
+        const bone2 = new Three.Bone()
+        bone2.name = 'Spine'
+        const skinnedMesh = new Three.SkinnedMesh()
+        ;(skinnedMesh as any).skeleton = { bones: [bone1, bone2] }
+        issues = validateNoNonDeformBones(asThree(Three), createScene([bone1, bone2, skinnedMesh]))
+      })
+
+      it('should return no issues', () => {
+        expect(issues).toEqual([])
+      })
     })
 
-    it('should return no issues', () => {
-      expect(issues).toEqual([])
+    describe('when there are bones not bound to any skinned mesh', () => {
+      let issues: ValidationIssue[]
+
+      beforeEach(() => {
+        const deformBone = new Three.Bone()
+        deformBone.name = 'Hips'
+        const controlBone = new Three.Bone()
+        controlBone.name = 'CTRL_IK_Foot'
+        const skinnedMesh = new Three.SkinnedMesh()
+        ;(skinnedMesh as any).skeleton = { bones: [deformBone] }
+        issues = validateNoNonDeformBones(asThree(Three), createScene([deformBone, controlBone, skinnedMesh]))
+      })
+
+      it('should return a warning with the NON_DEFORM_BONES_FOUND code', () => {
+        expect(issues).toHaveLength(1)
+        expect(issues[0].code).toBe('NON_DEFORM_BONES_FOUND')
+        expect(issues[0].severity).toBe(ValidationSeverity.WARNING)
+      })
+
+      it('should report the count and bone names', () => {
+        expect(issues[0].messageParams?.count).toBe(1)
+        expect(issues[0].messageParams?.bones).toContain('CTRL_IK_Foot')
+      })
+    })
+
+    describe('when there are no skinned meshes at all', () => {
+      let issues: ValidationIssue[]
+
+      beforeEach(() => {
+        const bone = new Three.Bone()
+        bone.name = 'OrphanBone'
+        issues = validateNoNonDeformBones(asThree(Three), createScene([bone]))
+      })
+
+      it('should report all bones as non-deformation', () => {
+        expect(issues).toHaveLength(1)
+        expect(issues[0].messageParams?.count).toBe(1)
+      })
     })
   })
 
-  describe('when there are bones not bound to any skinned mesh', () => {
-    let issues: ValidationIssue[]
+  describe('with animations (emote)', () => {
+    describe('when all bones are targeted by animation tracks', () => {
+      let issues: ValidationIssue[]
 
-    beforeEach(() => {
-      const deformBone = new Three.Bone()
-      deformBone.name = 'Hips'
-      const controlBone = new Three.Bone()
-      controlBone.name = 'CTRL_IK_Foot'
-      const skinnedMesh = new Three.SkinnedMesh()
-      ;(skinnedMesh as any).skeleton = { bones: [deformBone] }
-      issues = validateNoNonDeformBones(asThree(Three), createScene([deformBone, controlBone, skinnedMesh]))
+      beforeEach(() => {
+        const bone1 = new Three.Bone()
+        bone1.name = 'Hips'
+        const bone2 = new Three.Bone()
+        bone2.name = 'Spine'
+        const animations = createAnimations(['Hips.position', 'Hips.quaternion', 'Spine.position', 'Spine.quaternion'])
+        issues = validateNoNonDeformBones(asThree(Three), createScene([bone1, bone2]), animations)
+      })
+
+      it('should return no issues', () => {
+        expect(issues).toEqual([])
+      })
     })
 
-    it('should return a warning with the NON_DEFORM_BONES_FOUND code', () => {
-      expect(issues).toHaveLength(1)
-      expect(issues[0].code).toBe('NON_DEFORM_BONES_FOUND')
-      expect(issues[0].severity).toBe(ValidationSeverity.WARNING)
+    describe('when there are bones not targeted by any animation track', () => {
+      let issues: ValidationIssue[]
+
+      beforeEach(() => {
+        const animatedBone = new Three.Bone()
+        animatedBone.name = 'Hips'
+        const controlBone = new Three.Bone()
+        controlBone.name = 'CTRL_IK_Foot'
+        const animations = createAnimations(['Hips.position', 'Hips.quaternion'])
+        issues = validateNoNonDeformBones(asThree(Three), createScene([animatedBone, controlBone]), animations)
+      })
+
+      it('should return a warning with the NON_DEFORM_BONES_FOUND code', () => {
+        expect(issues).toHaveLength(1)
+        expect(issues[0].code).toBe('NON_DEFORM_BONES_FOUND')
+        expect(issues[0].severity).toBe(ValidationSeverity.WARNING)
+      })
+
+      it('should report the count and bone names', () => {
+        expect(issues[0].messageParams?.count).toBe(1)
+        expect(issues[0].messageParams?.bones).toContain('CTRL_IK_Foot')
+      })
     })
 
-    it('should report the count and bone names', () => {
-      expect(issues[0].messageParams?.count).toBe(1)
-      expect(issues[0].messageParams?.bones).toContain('CTRL_IK_Foot')
-    })
-  })
+    describe('when there are no animations', () => {
+      let issues: ValidationIssue[]
 
-  describe('when there are no skinned meshes at all', () => {
-    let issues: ValidationIssue[]
+      beforeEach(() => {
+        const bone = new Three.Bone()
+        bone.name = 'OrphanBone'
+        issues = validateNoNonDeformBones(asThree(Three), createScene([bone]), [])
+      })
 
-    beforeEach(() => {
-      const bone = new Three.Bone()
-      bone.name = 'OrphanBone'
-      issues = validateNoNonDeformBones(asThree(Three), createScene([bone]))
-    })
-
-    it('should report all bones as non-deformation', () => {
-      expect(issues).toHaveLength(1)
-      expect(issues[0].messageParams?.count).toBe(1)
+      it('should report all bones as non-deformation', () => {
+        expect(issues).toHaveLength(1)
+        expect(issues[0].messageParams?.count).toBe(1)
+      })
     })
   })
 

--- a/src/lib/glbValidation/wearableValidators.ts
+++ b/src/lib/glbValidation/wearableValidators.ts
@@ -245,16 +245,16 @@ export function validateNoLeafBones(Three: ThreeModules, scene: THREE.Scene): Va
 
 /**
  * Detects non-deformation bones that were exported with the model.
- * Deformation bones are those bound to a SkinnedMesh skeleton. Any Bone in the
- * scene that is not part of any skeleton is likely a control, IK, or mechanism
+ * Deformation bones are those bound to a SkinnedMesh skeleton or targeted by at least one animation track.
+ * Any Bone in the scene that is not part of any skeleton is likely a control, IK, or mechanism
  * bone that should have been excluded via "Export Deformation Bones Only".
  * Reports WARNING because non-deformation bones increase file size and reduce performance.
  */
-export function validateNoNonDeformBones(Three: ThreeModules, scene: THREE.Scene): ValidationIssue[] {
+export function validateNoNonDeformBones(Three: ThreeModules, scene: THREE.Scene, animations?: THREE.AnimationClip[]): ValidationIssue[] {
   const issues: ValidationIssue[] = []
-
-  // Collect all bone names bound to skinned meshes (deformation bones)
   const deformBoneNames = new Set<string>()
+
+  // Deform bones bound to a SkinnedMesh skeleton
   scene.traverse((node: THREE.Object3D) => {
     if (node instanceof Three.SkinnedMesh && node.skeleton) {
       for (const bone of node.skeleton.bones) {
@@ -262,6 +262,15 @@ export function validateNoNonDeformBones(Three: ThreeModules, scene: THREE.Scene
       }
     }
   })
+
+  // Deform bones targeted by animation tracks
+  for (const clip of animations ?? []) {
+    for (const track of clip.tracks) {
+      // Track names follow the pattern "BoneName.property" (e.g. "Avatar_Hips.position")
+      const boneName = track.name.replace(/\.[^.]+$/, '')
+      if (boneName) deformBoneNames.add(boneName)
+    }
+  }
 
   // Collect all bones in the scene
   const allBones: string[] = []
@@ -271,7 +280,6 @@ export function validateNoNonDeformBones(Three: ThreeModules, scene: THREE.Scene
     }
   })
 
-  // Non-deformation bones are those not bound to any skeleton
   const nonDeformBones = allBones.filter(name => !deformBoneNames.has(name))
 
   if (nonDeformBones.length > 0) {


### PR DESCRIPTION
## Summary

This pull request updates the logic for detecting non-deformation bones in GLTF validation, expanding the definition to include bones targeted by animation tracks (not just those bound to skeletons). It also adds comprehensive tests to ensure this new behavior works for both wearables and emotes.

**Validation logic improvements:**

* The `validateNoNonDeformBones` function now considers bones as deformation bones if they are either bound to a `SkinnedMesh` skeleton or targeted by at least one animation track, making the validation more accurate for emotes and animated assets. [[1]](diffhunk://#diff-817c095ce50825a7b531d3e7283c2e8ff2cad031678f84af3f3d70f81f612e92L248-R257) [[2]](diffhunk://#diff-817c095ce50825a7b531d3e7283c2e8ff2cad031678f84af3f3d70f81f612e92R266-R274)
* The function signature of `validateNoNonDeformBones` is updated to accept an optional `animations` parameter, and the call site in `validateEmoteGLTF` is updated accordingly. [[1]](diffhunk://#diff-d5d5f3b1eb3b2ebf6dfec3faf32d9812a09f9b48a81ea38ec07d7e550fd4d352L85-R85) [[2]](diffhunk://#diff-817c095ce50825a7b531d3e7283c2e8ff2cad031678f84af3f3d70f81f612e92L248-R257)

**Testing enhancements:**

* New test cases are added to `wearableValidators.spec.ts` to verify the updated logic for emotes, including scenarios where bones are targeted by animation tracks, not targeted, or when there are no animations. [[1]](diffhunk://#diff-88f8da45dd15ee901d36172ca3e0d55af87245168910e9a610d827880d6e1afcR524) [[2]](diffhunk://#diff-88f8da45dd15ee901d36172ca3e0d55af87245168910e9a610d827880d6e1afcR582-R640)
* A helper function `createAnimations` is introduced to simplify the creation of animation clips for testing purposes.