### PR TITLE
feat: open desktop explorer via deep-link in see-in-world modal

### DIFF
--- a/src/components/Modals/SeeInWorldModal/SeeInWorldModal.tsx
+++ b/src/components/Modals/SeeInWorldModal/SeeInWorldModal.tsx
@@ -1,21 +1,55 @@
 import React from 'react'
 import classNames from 'classnames'
 import { Button, Header, ModalContent, ModalNavigation } from 'decentraland-ui'
+import { DownloadModal } from 'decentraland-ui2'
 import Modal from 'decentraland-dapps/dist/containers/Modal'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
-import { getExplorerURL } from 'modules/collection/utils'
+import { launchExplorerForCollection } from 'modules/collection/explorerDeepLink'
 import styles from './SeeInWorldModal.module.css'
 import { Props } from './SeeInWorldModal.types'
 
-export default class SeeInWorldModal extends React.PureComponent<Props> {
-  handleNavigateToExplorer = (x: number, y: number) => {
+const DOWNLOAD_URL = 'https://decentraland.org/download'
+
+type State = {
+  isDownloadOpen: boolean
+  isLaunching: boolean
+}
+
+export default class SeeInWorldModal extends React.PureComponent<Props, State> {
+  state: State = { isDownloadOpen: false, isLaunching: false }
+
+  handleNavigateToExplorer = async (x: number, y: number) => {
     const { metadata, onClose } = this.props
-    const url = getExplorerURL({ collectionId: metadata.collectionId, item_ids: metadata.itemIds, position: { x, y } })
-    window.open(url, '_blank,noreferrer')
-    onClose()
+    // The deep-link only injects an unreleased collection on a cold start of the desktop
+    // client; the item-set variant (legacy WITH_ITEMS) isn't supported by the modern explorer,
+    // so we bail and close on item-only invocations rather than launch a no-op preview.
+    if (!metadata.collectionId) {
+      onClose()
+      return
+    }
+
+    this.setState({ isLaunching: true })
+    const launched = await launchExplorerForCollection({ collectionId: metadata.collectionId, position: { x, y } })
+    this.setState({ isLaunching: false })
+
+    if (launched) {
+      onClose()
+    } else {
+      this.setState({ isDownloadOpen: true })
+    }
+  }
+
+  handleCloseDownload = () => {
+    this.setState({ isDownloadOpen: false })
+    this.props.onClose()
+  }
+
+  handleDownloadClick = () => {
+    window.open(DOWNLOAD_URL, '_blank', 'noopener,noreferrer')
   }
 
   renderOption = (title: string, subtitle: string, position: { x: number; y: number }, imageClass: string) => {
+    const { isLaunching } = this.state
     return (
       <div className={styles.option}>
         <Header className={styles.headers} as="h2">
@@ -27,7 +61,7 @@ export default class SeeInWorldModal extends React.PureComponent<Props> {
         <div className={styles.imageWrapper}>
           <div className={classNames(styles.image, imageClass)}></div>
         </div>
-        <Button primary fluid size="small" onClick={() => this.handleNavigateToExplorer(position.x, position.y)}>
+        <Button primary fluid size="small" disabled={isLaunching} onClick={() => this.handleNavigateToExplorer(position.x, position.y)}>
           {t('see_in_world_modal.jump_in')}
         </Button>
       </div>
@@ -36,27 +70,38 @@ export default class SeeInWorldModal extends React.PureComponent<Props> {
 
   render() {
     const { onClose } = this.props
+    const { isDownloadOpen } = this.state
 
     return (
-      <Modal size="small" onClose={onClose} aria-modal role="dialog">
-        <ModalNavigation title={t('see_in_world_modal.title')} subtitle={t('see_in_world_modal.subtitle')} onClose={onClose} />
-        <ModalContent>
-          <div className={styles.content}>
-            {this.renderOption(
-              t('see_in_world_modal.empty_parcel.title'),
-              t('see_in_world_modal.empty_parcel.subtitle'),
-              { x: 150, y: -150 },
-              styles.emptyParcel
-            )}
-            {this.renderOption(
-              t('see_in_world_modal.genesis.title'),
-              t('see_in_world_modal.genesis.subtitle'),
-              { x: 0, y: 0 },
-              styles.genesis
-            )}
-          </div>
-        </ModalContent>
-      </Modal>
+      <>
+        <Modal size="small" onClose={onClose} aria-modal role="dialog">
+          <ModalNavigation title={t('see_in_world_modal.title')} subtitle={t('see_in_world_modal.subtitle')} onClose={onClose} />
+          <ModalContent>
+            <div className={styles.content}>
+              {this.renderOption(
+                t('see_in_world_modal.empty_parcel.title'),
+                t('see_in_world_modal.empty_parcel.subtitle'),
+                { x: 150, y: -150 },
+                styles.emptyParcel
+              )}
+              {this.renderOption(
+                t('see_in_world_modal.genesis.title'),
+                t('see_in_world_modal.genesis.subtitle'),
+                { x: 0, y: 0 },
+                styles.genesis
+              )}
+            </div>
+          </ModalContent>
+        </Modal>
+        <DownloadModal
+          open={isDownloadOpen}
+          onClose={this.handleCloseDownload}
+          title={t('see_in_world_modal.download.title')}
+          description={t('see_in_world_modal.download.description')}
+          buttonLabel={t('see_in_world_modal.download.button')}
+          onDownloadClick={this.handleDownloadClick}
+        />
+      </>
     )
   }
 }

--- a/src/modules/collection/explorerDeepLink.ts
+++ b/src/modules/collection/explorerDeepLink.ts
@@ -1,0 +1,108 @@
+import { Env } from '@dcl/ui-env'
+import { config } from 'config'
+
+type ExplorerDeepLinkOptions = {
+  collectionId: string
+  position?: { x: number; y: number }
+  /** Detection window in ms (window focus loss → assume desktop client took over). */
+  timeoutMs?: number
+}
+
+/**
+ * Decentraland environment string forwarded as the `dclenv` deep-link arg so the desktop client
+ * resolves the matching Builder API host (e.g. `builder-api.decentraland.{zone|today|org}`).
+ * Mirrors the env split that `getExplorerURL` already encodes for the /play fallback URL.
+ */
+function resolveDclEnv(): 'zone' | 'today' | 'org' {
+  if (config.is(Env.DEVELOPMENT)) return 'zone'
+  if (config.is(Env.STAGING)) return 'today'
+  return 'org'
+}
+
+/**
+ * Builds a `decentraland://` deep link that opens the desktop explorer with the unreleased
+ * Builder collection injected. Only resolves on a COLD start of the desktop client — the
+ * runtime deep-link handler ignores `self-preview-builder-collections` and re-loading the same
+ * client process won't pick it up. The signed fetch against the Builder API happens inside the
+ * client using the logged-in wallet, so the wallet must own or be whitelisted on the collection.
+ */
+function buildExplorerDeepLink({ collectionId, position }: { collectionId: string; position?: { x: number; y: number } }): string {
+  const params = new URLSearchParams()
+  params.set('self-preview-builder-collections', collectionId)
+  params.set('dclenv', resolveDclEnv())
+  if (position) params.set('position', `${position.x},${position.y}`)
+  return `decentraland://?${params.toString()}`
+}
+
+type WindowWithProcess = Window & { process?: { type?: string } }
+
+function isElectronApp(): boolean {
+  if (typeof window === 'undefined') return false
+  const w = window as unknown as WindowWithProcess
+  if (typeof w.process === 'object' && w.process?.type === 'renderer') return true
+  if (typeof navigator === 'object' && typeof navigator.userAgent === 'string' && navigator.userAgent.includes('Electron')) return true
+  return false
+}
+
+/**
+ * Attempts to open the desktop explorer with the given Builder collection injected. Resolves:
+ *  - `true` when the browser tab loses focus/visibility within `timeoutMs` (best-effort proxy for
+ *    "the OS routed the decentraland:// scheme to an installed handler").
+ *  - `false` when no focus loss is detected (likely not installed) or the env is mobile/Electron.
+ *
+ * IMPORTANT: must be invoked synchronously inside a user gesture (click handler) so the browser
+ * allows the protocol navigation. Replicates the detection pattern used by `launchDesktopApp` in
+ * `decentraland-ui2/src/modules/jumpIn.ts`, kept builder-local because the
+ * `self-preview-builder-collections` arg is builder-specific and shouldn't leak into the shared
+ * ui2 API surface.
+ */
+export function launchExplorerForCollection(opts: ExplorerDeepLinkOptions): Promise<boolean> {
+  const { timeoutMs = 750 } = opts
+
+  if (typeof window === 'undefined' || isElectronApp()) {
+    return Promise.resolve(false)
+  }
+
+  const target = buildExplorerDeepLink(opts)
+  let opened = false
+
+  const onLoseFocus = () => {
+    opened = true
+  }
+
+  const onVisibilityChange = () => {
+    if (document.visibilityState === 'hidden') onLoseFocus()
+  }
+
+  const cleanup = () => {
+    document.removeEventListener('visibilitychange', onVisibilityChange)
+    window.removeEventListener('pagehide', onLoseFocus)
+    window.removeEventListener('blur', onLoseFocus)
+  }
+
+  document.addEventListener('visibilitychange', onVisibilityChange, { passive: true })
+  window.addEventListener('pagehide', onLoseFocus, { passive: true })
+  window.addEventListener('blur', onLoseFocus, { passive: true })
+
+  try {
+    window.location.assign(target)
+  } catch {
+    cleanup()
+    return Promise.resolve(false)
+  }
+
+  return new Promise<boolean>(resolve => {
+    const t = setTimeout(() => {
+      cleanup()
+      resolve(opened)
+    }, timeoutMs)
+
+    if (opened) {
+      clearTimeout(t)
+      cleanup()
+      resolve(true)
+    }
+  })
+}
+
+export { buildExplorerDeepLink, resolveDclEnv }

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -2076,7 +2076,12 @@
       "title": "Empty Parcel",
       "subtitle": "Just run and jump. It loads faster."
     },
-    "jump_in": "Jump In"
+    "jump_in": "Jump In",
+    "download": {
+      "title": "Get Decentraland",
+      "description": "You'll need the Decentraland desktop client to preview your unreleased collection.",
+      "button": "Download"
+    }
   },
   "collection_image": {
     "no_items": "No Items"

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -2090,7 +2090,12 @@
       "title": "Parcela vacía",
       "subtitle": "Sólo correr y saltar. Cargará más rápido"
     },
-    "jump_in": "Ingresar"
+    "jump_in": "Ingresar",
+    "download": {
+      "title": "Descargá Decentraland",
+      "description": "Necesitás la app de escritorio de Decentraland para previsualizar tu colección sin publicar.",
+      "button": "Descargar"
+    }
   },
   "collection_image": {
     "no_items": "No Items"

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -2048,7 +2048,12 @@
       "title": "空地块",
       "subtitle": "只是跑和跳。 它加载速度更快。"
     },
-    "jump_in": "跳进去"
+    "jump_in": "跳进去",
+    "download": {
+      "title": "获取 Decentraland",
+      "description": "您需要 Decentraland 桌面客户端才能预览未发布的收藏品。",
+      "button": "下载"
+    }
   },
   "publish_third_party_collection_modal": {
     "title": "发布链接项目",


### PR DESCRIPTION
When users click Jump In in the See-in-World modal, the builder now tries to launch the desktop client via
  `decentraland://?self-preview-builder-collections=<id>&dclenv=<env>&position=x,y` instead of opening /play in a new tab. Detection uses focus/visibility
  loss within 750ms (consistent with the ui2 `launchDesktopApp` pattern). When the deep link does not resolve, a `DownloadModal` from
  `decentraland-ui2` opens linking to decentraland.org/download. The legacy `getExplorerURL` is untouched so consumers that still need the /play URL keep
   working.

  ## Test plan
  - [ ] With the desktop explorer installed → desktop opens with the unreleased collection injected.
  - [ ] Without it installed → DownloadModal opens; Download button goes to decentraland.org/download.
  - [ ] Item-only invocations (no collectionId) close the modal cleanly without firing the deep link.