### PR TITLE
feat: compress generated thumbnails with png quantization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "ts-deepmerge": "^7.0.0",
         "typechain": "^8.1.0",
         "typesafe-actions": "^4.4.2",
+        "upng-js": "^2.1.0",
         "uuid": "^3.3.2"
       },
       "devDependencies": {
@@ -106,6 +107,7 @@
         "@types/redux-logger": "^3.0.6",
         "@types/reselect": "^2.2.0",
         "@types/slug": "^5.0.2",
+        "@types/upng-js": "^2.1.5",
         "@types/uuid": "^3.4.4",
         "@typescript-eslint/eslint-plugin": "^6.19.1",
         "@typescript-eslint/parser": "^6.19.1",
@@ -11281,6 +11283,13 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
     },
+    "node_modules/@types/upng-js": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/upng-js/-/upng-js-2.1.5.tgz",
+      "integrity": "sha512-CzXg1lcCcWzrmYmke9BLbBPzb2DpdC1bXuXf0BtK3Bygvsozslei8S1bheDI1QUfZzZpMeQI5fywfnMj4CxocQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/uuid": {
       "version": "3.4.13",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.13.tgz",
@@ -16177,12 +16186,6 @@
       "dependencies": {
         "pako": "~1.0.5"
       }
-    },
-    "node_modules/browserify-zlib/node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "license": "(MIT AND Zlib)"
     },
     "node_modules/browserslist": {
       "version": "4.28.1",
@@ -26329,12 +26332,6 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
-    "node_modules/jszip/node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "license": "(MIT AND Zlib)"
-    },
     "node_modules/jszip/node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -28809,6 +28806,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parallax-js": {
       "version": "3.1.0",
@@ -34575,6 +34578,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/upng-js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/upng-js/-/upng-js-2.1.0.tgz",
+      "integrity": "sha512-d3xzZzpMP64YkjP5pr8gNyvBt7dLk/uGI67EctzDuVp4lCZyVMo0aJO6l/VDlgbInJYDY6cnClLoBp29eKWI6g==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.5"
       }
     },
     "node_modules/uqr": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "ts-deepmerge": "^7.0.0",
     "typechain": "^8.1.0",
     "typesafe-actions": "^4.4.2",
+    "upng-js": "^2.1.0",
     "uuid": "^3.3.2"
   },
   "devDependencies": {
@@ -100,6 +101,7 @@
     "@types/redux-logger": "^3.0.6",
     "@types/reselect": "^2.2.0",
     "@types/slug": "^5.0.2",
+    "@types/upng-js": "^2.1.5",
     "@types/uuid": "^3.4.4",
     "@typescript-eslint/eslint-plugin": "^6.19.1",
     "@typescript-eslint/parser": "^6.19.1",

--- a/src/modules/item/sagas.spec.ts
+++ b/src/modules/item/sagas.spec.ts
@@ -90,6 +90,8 @@ import {
   VIDEO_PATH,
   WearableRepresentation
 } from './types'
+import { computeHashFromContent } from 'modules/deployment/contentUtils'
+import { compressPngBlob } from 'modules/media/utils'
 import { calculateModelFinalSize, calculateFileSize, reHashOlderContents } from './export'
 import { buildZipContents, generateCatalystImage, groupsOf, MAX_VIDEO_FILE_SIZE } from './utils'
 import { getCollectionItems, getData as getItemsById, getEntityByItemId, getItem, getItems, getPaginationData } from './selectors'
@@ -397,6 +399,45 @@ describe('when handling the save item request action', () => {
           .put(saveItemSuccess(itemWithCatalystImage, contentsToSave))
           .dispatch(saveItemRequest(item, contentsToSave))
           .run({ silenceTimeout: true })
+      })
+    })
+
+    describe('and the new thumbnail can be quantized into a smaller file', () => {
+      let compressedThumbnail: Blob
+      const compressedThumbnailHash = 'compressedThumbnailHash'
+
+      beforeEach(() => {
+        delete item.contents[IMAGE_PATH]
+        compressedThumbnail = new Blob(['compressedThumbnailData'])
+      })
+
+      it('should upload the compressed thumbnail and update its content hash', () => {
+        const contentsToSave = { ...contents, [THUMBNAIL_PATH]: blob }
+        return expectSaga(itemSaga, builderAPI, builderClient, tradeService)
+          .provide([
+            [matchers.call.fn(reHashOlderContents), {}],
+            [getContext('history'), { push: pushMock, location: { pathname: 'notTPdetailPage' } }],
+            [select(getOpenModals), { EditItemURNModal: true }],
+            [select(getItem, item.id), undefined],
+            [select(getAddress), mockAddress],
+            [select(getIsLinkedWearablesV2Enabled), false],
+            [select(hasSpringBoneChanges), false],
+            [matchers.call.fn(generateCatalystImage), Promise.resolve({ hash: catalystImageHash, content: blob })],
+            [matchers.call.fn(compressPngBlob), compressedThumbnail],
+            [matchers.call.fn(computeHashFromContent), compressedThumbnailHash],
+            [matchers.call.fn(calculateModelFinalSize), Promise.resolve(1)],
+            [matchers.call.fn(calculateFileSize), 1],
+            [matchers.call.fn(builderAPI.saveItem), Promise.resolve(item)]
+          ])
+          .dispatch(saveItemRequest(item, contentsToSave))
+          .run({ silenceTimeout: true })
+          .then(({ effects }) => {
+            const successPut = effects.put?.find((p: any) => p.payload.action.type === SAVE_ITEM_SUCCESS)
+            expect(successPut).toBeDefined()
+            const { item: savedItem, contents: savedContents } = successPut!.payload.action.payload
+            expect(savedContents[THUMBNAIL_PATH]).toBe(compressedThumbnail)
+            expect(savedItem.contents[THUMBNAIL_PATH]).toBe(compressedThumbnailHash)
+          })
       })
     })
 

--- a/src/modules/item/sagas.ts
+++ b/src/modules/item/sagas.ts
@@ -149,6 +149,8 @@ import { downloadZip } from 'lib/zip'
 import { isErrorWithCode } from 'lib/error'
 import { getSpringBoneParamsByHash, hasSpringBoneChanges } from 'modules/editor/selectors'
 import { SPRING_BONES_VERSION } from 'lib/springBones'
+import { computeHashFromContent } from 'modules/deployment/contentUtils'
+import { compressPngBlob } from 'modules/media/utils'
 import { calculateModelFinalSize, calculateFileSize, reHashOlderContents } from './export'
 import { Item, BlockchainRarity, CatalystItem, BodyShapeType, IMAGE_PATH, THUMBNAIL_PATH, WearableData, VIDEO_PATH } from './types'
 import { getData as getItemsById, getItems, getEntityByItemId, getCollectionItems, getItem, getPaginationData } from './selectors'
@@ -370,6 +372,15 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
       for (const builtFile of builtFiles) {
         promisesOfItemsToSave.push(async () => {
           try {
+            // Quantize the thumbnail to reduce its uploaded size, keeping its content hash in sync.
+            const thumbnail = builtFile.newContent[THUMBNAIL_PATH]
+            if (thumbnail) {
+              const compressedThumbnail = await compressPngBlob(thumbnail)
+              if (compressedThumbnail !== thumbnail) {
+                builtFile.newContent[THUMBNAIL_PATH] = compressedThumbnail
+                builtFile.item.contents[THUMBNAIL_PATH] = await computeHashFromContent(compressedThumbnail)
+              }
+            }
             const remoteItem: RemoteItem = await builder.upsertItem(builtFile.item, builtFile.newContent)
             fileNamesSucceeded.push(builtFile.fileName)
             remoteItems.push(remoteItem)
@@ -461,6 +472,18 @@ export function* itemSaga(legacyBuilder: LegacyBuilderAPI, builder: BuilderClien
         })
         contents[IMAGE_PATH] = catalystImage.content
         item.contents[IMAGE_PATH] = catalystImage.hash
+      }
+
+      // Quantize the thumbnail to reduce its uploaded size while preserving transparency. This runs
+      // after the catalyst image is built (so it uses the full-quality thumbnail) and before the size
+      // check below (so the compression helps stay under MAX_THUMBNAIL_FILE_SIZE). Uploads are
+      // addressed by content hash, so the item's thumbnail hash is recomputed when the blob changes.
+      if (contents[THUMBNAIL_PATH]) {
+        const compressedThumbnail: Blob = yield call(compressPngBlob, contents[THUMBNAIL_PATH])
+        if (compressedThumbnail !== contents[THUMBNAIL_PATH]) {
+          contents[THUMBNAIL_PATH] = compressedThumbnail
+          item.contents[THUMBNAIL_PATH] = yield call(computeHashFromContent, compressedThumbnail)
+        }
       }
 
       if (Object.keys(contents).length > 0 || shouldValidateCategoryChanged) {

--- a/src/modules/item/utils.spec.ts
+++ b/src/modules/item/utils.spec.ts
@@ -23,8 +23,15 @@ import {
   findOrphanedAuxiliaryFiles,
   isModelPath,
   stripRepresentationContents,
-  stripWrappingFolder
+  stripWrappingFolder,
+  generateImage
 } from './utils'
+import { compressPngBlob } from 'modules/media/utils'
+
+jest.mock('modules/media/utils', () => ({
+  ...jest.requireActual<typeof import('modules/media/utils')>('modules/media/utils'),
+  compressPngBlob: jest.fn()
+}))
 
 describe('when transforming third party items to be sent to a contract method', () => {
   let items: Item[]
@@ -941,5 +948,37 @@ describe('when stripping representation contents', () => {
     const snapshot = JSON.parse(JSON.stringify(representations))
     stripRepresentationContents(representations, new Set(['male/model.glb']))
     expect(representations).toEqual(snapshot)
+  })
+})
+
+describe('when generating the catalyst image', () => {
+  let item: Item
+  let thumbnail: Blob
+  let compressed: Blob
+
+  beforeEach(() => {
+    thumbnail = new Blob(['thumbnail'], { type: 'image/png' })
+    compressed = new Blob(['small'], { type: 'image/png' })
+    ;(compressPngBlob as jest.Mock).mockResolvedValue(compressed)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('and the item has no rarity', () => {
+    beforeEach(() => {
+      item = { rarity: undefined } as unknown as Item
+    })
+
+    it('should compress the provided thumbnail', async () => {
+      await generateImage(item, { thumbnail })
+      expect(compressPngBlob).toHaveBeenCalledWith(thumbnail)
+    })
+
+    it('should return the compressed image', async () => {
+      const result = await generateImage(item, { thumbnail })
+      expect(result).toBe(compressed)
+    })
   })
 })

--- a/src/modules/item/utils.ts
+++ b/src/modules/item/utils.ts
@@ -31,6 +31,7 @@ import { ModelMetrics } from 'modules/models/types'
 import { Collection } from 'modules/collection/types'
 import { ItemCuration } from 'modules/curations/itemCuration/types'
 import { computeHashFromContent } from 'modules/deployment/contentUtils'
+import { compressPngBlob } from 'modules/media/utils'
 import { LinkedContract } from 'modules/thirdParty/types'
 import { canSeeCollection, canMintCollectionItems, canManageCollectionItems } from 'modules/collection/utils'
 import { isEqual } from 'lib/address'
@@ -392,7 +393,7 @@ export async function generateImage(item: Item | Item<ItemType.EMOTE> | LocalIte
   const context = canvas.getContext('2d')
 
   // fail
-  if (!context || !item.rarity) return thumbnail
+  if (!context || !item.rarity) return compressPngBlob(thumbnail)
 
   // render gradient
   const gradient = context.createRadialGradient(width / 2, height / 2, 0, width / 2, height / 2, width / 1.75)
@@ -414,7 +415,8 @@ export async function generateImage(item: Item | Item<ItemType.EMOTE> | LocalIte
 
   const blob = future<Blob>()
   canvas.toBlob(result => (result ? blob.resolve(result) : blob.reject(new Error('Error generating image blob'))))
-  return blob
+  // Quantize the generated catalyst image to reduce its uploaded size (keeps transparency).
+  return compressPngBlob(await blob)
 }
 
 export async function resizeImage(image: Blob, width = 256, height = 256) {

--- a/src/modules/media/utils.spec.ts
+++ b/src/modules/media/utils.spec.ts
@@ -1,0 +1,107 @@
+import * as UPNG from 'upng-js'
+import { compressPngBlob, THUMBNAIL_PALETTE_COLORS } from './utils'
+
+jest.mock('upng-js')
+
+const mockedDecode = UPNG.decode as jest.MockedFunction<typeof UPNG.decode>
+const mockedToRGBA8 = UPNG.toRGBA8 as jest.MockedFunction<typeof UPNG.toRGBA8>
+const mockedEncode = UPNG.encode as jest.MockedFunction<typeof UPNG.encode>
+
+// Builds a deterministic Blob-like with a controlled size and arrayBuffer, avoiding reliance on jsdom internals.
+function buildBlob(size: number, type = 'image/png'): Blob {
+  return {
+    size,
+    type,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(size))
+  } as unknown as Blob
+}
+
+describe('when compressing a PNG blob', () => {
+  let original: Blob
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('and the quantized result is smaller than the original', () => {
+    let encoded: ArrayBuffer
+
+    beforeEach(() => {
+      original = buildBlob(1024)
+      encoded = new ArrayBuffer(128)
+      mockedDecode.mockReturnValueOnce({ width: 1024, height: 1024 } as UPNG.Image)
+      mockedToRGBA8.mockReturnValueOnce([new ArrayBuffer(4)])
+      mockedEncode.mockReturnValueOnce(encoded)
+    })
+
+    it('should return a new PNG blob holding the quantized bytes', async () => {
+      const result = await compressPngBlob(original)
+      expect(result).not.toBe(original)
+      expect(result.size).toBe(encoded.byteLength)
+      expect(result.type).toBe('image/png')
+    })
+
+    it('should quantize using the default palette color count', async () => {
+      await compressPngBlob(original)
+      expect(mockedEncode).toHaveBeenCalledWith([expect.any(ArrayBuffer)], 1024, 1024, THUMBNAIL_PALETTE_COLORS)
+    })
+  })
+
+  describe('and a custom color count is provided', () => {
+    beforeEach(() => {
+      original = buildBlob(1024)
+      mockedDecode.mockReturnValueOnce({ width: 512, height: 512 } as UPNG.Image)
+      mockedToRGBA8.mockReturnValueOnce([new ArrayBuffer(4)])
+      mockedEncode.mockReturnValueOnce(new ArrayBuffer(64))
+    })
+
+    it('should quantize using the provided color count', async () => {
+      await compressPngBlob(original, 64)
+      expect(mockedEncode).toHaveBeenCalledWith([expect.any(ArrayBuffer)], 512, 512, 64)
+    })
+  })
+
+  describe('and the quantized result is not smaller than the original', () => {
+    beforeEach(() => {
+      original = buildBlob(256)
+      mockedDecode.mockReturnValueOnce({ width: 16, height: 16 } as UPNG.Image)
+      mockedToRGBA8.mockReturnValueOnce([new ArrayBuffer(4)])
+      mockedEncode.mockReturnValueOnce(new ArrayBuffer(512))
+    })
+
+    it('should return the original blob untouched by reference', async () => {
+      const result = await compressPngBlob(original)
+      expect(result).toBe(original)
+    })
+  })
+
+  describe('and decoding the PNG throws', () => {
+    beforeEach(() => {
+      original = buildBlob(1024)
+      mockedDecode.mockImplementationOnce(() => {
+        throw new Error('invalid PNG data')
+      })
+    })
+
+    it('should return the original blob untouched by reference', async () => {
+      const result = await compressPngBlob(original)
+      expect(result).toBe(original)
+    })
+  })
+
+  describe('and the blob is not a PNG', () => {
+    beforeEach(() => {
+      original = buildBlob(1024, 'image/jpeg')
+    })
+
+    it('should return the original blob untouched by reference', async () => {
+      const result = await compressPngBlob(original)
+      expect(result).toBe(original)
+    })
+
+    it('should not attempt to decode it', async () => {
+      await compressPngBlob(original)
+      expect(mockedDecode).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/modules/media/utils.ts
+++ b/src/modules/media/utils.ts
@@ -1,8 +1,17 @@
 import { hashV1 } from '@dcl/hashing'
 import { WearableCategory } from '@dcl/schemas'
+import * as UPNG from 'upng-js'
 import { NO_CACHE_HEADERS } from 'lib/headers'
 import { makeContentFile, getCID } from 'modules/deployment/utils'
 import { ImageType } from './types'
+
+/**
+ * Number of colors used to quantize PNG thumbnails into an indexed palette.
+ * 256 is the maximum for an 8-bit palette — the highest-fidelity quantization,
+ * which minimizes banding while still shrinking the file substantially. Lower it
+ * to trade quality for smaller files.
+ */
+export const THUMBNAIL_PALETTE_COLORS = 256
 
 export function isDataUrl(url: string): boolean {
   return url.startsWith('data:')
@@ -51,6 +60,40 @@ export async function blobToDataURL(blob: Blob): Promise<string> {
     }
     reader.readAsDataURL(blob)
   })
+}
+
+/**
+ * Compresses a PNG blob by re-encoding it with a quantized (indexed) palette. Unlike JPEG/WebP
+ * this preserves the alpha channel, so it is safe for the transparent thumbnails the builder
+ * generates while greatly reducing the file size of 3D-rendered images.
+ *
+ * This is a dependency-light alternative to a true pngquant quality floor: there is no perceptual
+ * threshold, so it relies on a *size floor* instead. If the quantized result is not smaller than the
+ * original (e.g. smooth gradients that quantize poorly), or if decoding/encoding fails for any
+ * reason, the original blob is returned **by reference** — callers can treat `result === input` as
+ * "left untouched" (e.g. to skip recomputing its content hash). Non-PNG blobs are returned as-is.
+ *
+ * @param blob - The PNG blob to compress.
+ * @param colors - Max number of palette colors (1-256). Fewer colors = smaller file, more banding.
+ */
+export async function compressPngBlob(blob: Blob, colors: number = THUMBNAIL_PALETTE_COLORS): Promise<Blob> {
+  // Only PNGs can be quantized this way; leave anything else (or unknown types) untouched.
+  if (blob.type && blob.type !== 'image/png') {
+    return blob
+  }
+
+  try {
+    const buffer = await blob.arrayBuffer()
+    const image = UPNG.decode(buffer)
+    const frames = UPNG.toRGBA8(image)
+    const encoded = UPNG.encode(frames, image.width, image.height, colors)
+    const compressed = new Blob([encoded], { type: 'image/png' })
+    // Size floor: never replace the original with a larger (or empty) result.
+    return compressed.size > 0 && compressed.size < blob.size ? compressed : blob
+  } catch {
+    // Compression must never break thumbnail creation/upload — fall back to the original.
+    return blob
+  }
 }
 
 /**


### PR DESCRIPTION
## what

the 1024×1024 `thumbnail.png` images generated for wearables and emotes are heavy because they're encoded as lossless png. this re-encodes them with a quantized (indexed) palette via `upng-js`, which preserves the alpha channel (unlike jpeg/webp) while greatly reducing the file size of 3d-rendered images.

## how

- new `compressPngBlob(blob, colors = 256)` in `modules/media/utils` — decodes the png and re-encodes it with a palette. it has a **size floor**: if the result isn't smaller (e.g. smooth gradients that quantize poorly), or decoding/encoding fails, the original blob is returned **by reference**, so it can never produce a larger or broken file.
- `thumbnail.png` is compressed in both save sagas (`handleSaveItemRequest`, which the reset path also uses, and the bulk `handleSaveMultipleItemsRequest`). uploads are content-hash-addressed, so the thumbnail's content hash is recomputed when the blob changes. it runs after the catalyst image is built (full-quality source) and before the size check, so it also helps stay under `MAX_THUMBNAIL_FILE_SIZE`.
- the catalyst `image.png` is compressed inside `generateImage`, covering the save, bulk and deploy paths. its hash stays consistent because it's computed downstream.
- palette size is configurable via the `colors` argument / `THUMBNAIL_PALETTE_COLORS`.

## notes

- this is a *size* floor, not a perceptual one: `upng-js` has no pngquant-style quality threshold or dithering. the gradient `image.png` is the asset most prone to banding at 256 colors; the size floor keeps the original when it doesn't compress well, but it's worth a visual check.

## tests

- unit tests for `compressPngBlob` (smaller → use it, not-smaller → keep original, decode throws → keep original, non-png → skip).
- a `generateImage` test and a save-saga test asserting the compressed thumbnail and its updated content hash propagate to upload.
- typecheck, eslint and prettier all clean.
