### PR TITLE
feat: auto-suggest wearable category from model geometry at import

### DIFF
--- a/src/components/Modals/CreateSingleItemModal/CommonFields.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CommonFields.tsx
@@ -180,7 +180,7 @@ export const CommonFields = () => {
         options={categories.map(value => ({ value, text: t(`${type!}.category.${value}`) }))}
         onChange={handleCategoryChange}
       />
-      {type === ItemType.WEARABLE && suggestedCategory && categories.includes(suggestedCategory) ? (
+      {type === ItemType.WEARABLE && suggestedCategory && categories.includes(suggestedCategory) && category === suggestedCategory ? (
         <p className="suggested-category">
           {t('create_single_item_modal.suggested_category', {
             category: t(`${ItemType.WEARABLE}.category.${suggestedCategory}`)

--- a/src/components/Modals/CreateSingleItemModal/CommonFields.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CommonFields.tsx
@@ -123,7 +123,7 @@ export const CommonFields = () => {
     },
     [state, dispatch]
   )
-  const { name, category, rarity, contents, item, type } = state
+  const { name, category, rarity, contents, item, type, suggestedCategory } = state
 
   const belongsToAThirdPartyCollection = collection?.urn && isThirdParty(collection.urn)
   const rarities = Rarity.getRarities()
@@ -180,6 +180,13 @@ export const CommonFields = () => {
         options={categories.map(value => ({ value, text: t(`${type!}.category.${value}`) }))}
         onChange={handleCategoryChange}
       />
+      {type === ItemType.WEARABLE && suggestedCategory && categories.includes(suggestedCategory) ? (
+        <p className="suggested-category">
+          {t('create_single_item_modal.suggested_category', {
+            category: t(`${ItemType.WEARABLE}.category.${suggestedCategory}`)
+          })}
+        </p>
+      ) : null}
       {isThirdPartyV2Enabled && linkedContract && <MappingEditor onChange={handleMappingChange} mapping={getMapping()} />}
     </>
   )

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.css
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.css
@@ -309,6 +309,12 @@
   text-decoration: underline;
 }
 
+.CreateSingleItemModal .suggested-category {
+  margin-top: 4px;
+  font-size: 13px;
+  opacity: 0.7;
+}
+
 .CreateSingleItemModal .outcomes-section {
   display: flex;
   flex-direction: column;

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.reducer.ts
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.reducer.ts
@@ -14,7 +14,7 @@ import { Metrics } from 'modules/models/types'
 import type { ValidationIssue } from 'lib/glbValidation/types'
 import { CreateItemView, State, AcceptedFileProps, CreateSingleItemModalMetadata } from './CreateSingleItemModal.types'
 import { Collection } from 'modules/collection/types'
-import { getBodyShapeType, getMissingBodyShapeType } from 'modules/item/utils'
+import { getBodyShapeType, getMissingBodyShapeType, getWearableCategories } from 'modules/item/utils'
 import { getDefaultMappings, getLinkedContract } from './utils'
 
 // Initial State Creation
@@ -428,8 +428,20 @@ export const createItemReducer = (state: State, action: CreateItemAction | null)
     case CREATE_ITEM_ACTIONS.SET_VIDEO_PREVIEW:
       return { ...state, video: action.payload }
 
-    case CREATE_ITEM_ACTIONS.SET_ACCEPTED_PROPS:
-      return { ...state, ...action.payload }
+    case CREATE_ITEM_ACTIONS.SET_ACCEPTED_PROPS: {
+      const next = { ...state, ...action.payload }
+      // Pre-select the geometry-inferred category when the upload didn't already
+      // declare one (e.g. a bare .glb with no wearable.json). The creator can still
+      // override it in the details step; this only sets the initial default.
+      // Guard against suggesting a category the dropdown won't offer for these contents
+      // (the selectable list is body-shape/contents dependent) so the field never holds
+      // a value that isn't visible to the user.
+      const suggestedCategory = action.payload.suggestedCategory
+      if (!next.category && suggestedCategory && getWearableCategories(next.contents).includes(suggestedCategory)) {
+        next.category = suggestedCategory
+      }
+      return next
+    }
 
     case CREATE_ITEM_ACTIONS.UPDATE_THUMBNAIL_BY_CATEGORY:
       return {

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.types.ts
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.types.ts
@@ -1,7 +1,7 @@
 import { AnimationClip, Object3D } from 'three'
 import { Dispatch } from 'redux'
 import { ModalProps } from 'decentraland-dapps/dist/providers/ModalProvider/ModalProvider.types'
-import { Mappings, OutcomeGroup, Rarity, StartAnimation } from '@dcl/schemas'
+import { Mappings, OutcomeGroup, Rarity, StartAnimation, WearableCategory } from '@dcl/schemas'
 import { Metrics } from 'modules/models/types'
 import type { ValidationIssue } from 'lib/glbValidation/types'
 import { Collection } from 'modules/collection/types'
@@ -65,6 +65,7 @@ export type StateData = {
     armatures: Object3D[]
   }
   validationIssues?: ValidationIssue[]
+  suggestedCategory?: WearableCategory | null
 }
 
 export type State = {
@@ -85,6 +86,7 @@ export type ModelData = {
   model: string
   contents: Record<string, Blob>
   validationIssues?: ValidationIssue[]
+  suggestedCategory?: WearableCategory | null
 }
 
 export type ZipModelData = ModelData & {
@@ -115,6 +117,7 @@ export type AcceptedFileProps = Pick<
   | 'tags'
   | 'blockVrmExport'
   | 'validationIssues'
+  | 'suggestedCategory'
 >
 export type OwnProps = Pick<Props, 'name' | 'onClose'> & { metadata: CreateSingleItemModalMetadata }
 export type MapStateProps = Pick<

--- a/src/components/Modals/CreateSingleItemModal/ImportStep/ImportStep.tsx
+++ b/src/components/Modals/CreateSingleItemModal/ImportStep/ImportStep.tsx
@@ -177,7 +177,7 @@ export default class ImportStep extends React.PureComponent<Props, State> {
       [modelPath]: file
     }
 
-    const { model, contents: proccessedContent, type, validationIssues } = await this.processModel(modelPath, contents)
+    const { model, contents: proccessedContent, type, validationIssues, suggestedCategory } = await this.processModel(modelPath, contents)
 
     if (type === ItemType.EMOTE) {
       const { metrics }: { metrics: AnimationMetrics } = await getEmoteData(URL.createObjectURL(contents[model]))
@@ -196,7 +196,7 @@ export default class ImportStep extends React.PureComponent<Props, State> {
       throw new FileTooBigError(maxFileSize)
     }
 
-    return { model, contents: proccessedContent, type, validationIssues }
+    return { model, contents: proccessedContent, type, validationIssues, suggestedCategory }
   }
 
   handleErrorsOnFile = (error: any) => {
@@ -337,7 +337,7 @@ export default class ImportStep extends React.PureComponent<Props, State> {
 
       if (extension === '.zip') {
         const { modelData, wearable, scene, emote } = await this.handleZippedModelFiles(file)
-        const { type, model, contents, validationIssues } = modelData
+        const { type, model, contents, validationIssues, suggestedCategory } = modelData
 
         if (scene) {
           contents[SCENE_PATH] = new Blob([JSON.stringify(scene)], { type: 'application/json' })
@@ -349,6 +349,7 @@ export default class ImportStep extends React.PureComponent<Props, State> {
           model,
           contents,
           validationIssues,
+          suggestedCategory,
           thumbnail: THUMBNAIL_PATH in modelData.contents ? await blobToDataURL(modelData.contents[THUMBNAIL_PATH]) : undefined
         }
         if (wearable) {
@@ -397,14 +398,15 @@ export default class ImportStep extends React.PureComponent<Props, State> {
           }
         }
       } else {
-        const { type, model, contents, validationIssues } = await this.handleModelFile(file)
+        const { type, model, contents, validationIssues, suggestedCategory } = await this.handleModelFile(file)
 
         acceptedFileProps = {
           ...acceptedFileProps,
           type,
           model,
           contents,
-          validationIssues
+          validationIssues,
+          suggestedCategory
         }
       }
 
@@ -438,6 +440,7 @@ export default class ImportStep extends React.PureComponent<Props, State> {
     const extension = getExtension(model) || undefined
     let isEmote = false
     let validationIssues: ValidationIssue[] | undefined
+    let suggestedCategory: WearableCategory | null = null
 
     if (extension !== '.png') {
       const mappings = rawMappingsToObjectURL(contents)
@@ -457,13 +460,14 @@ export default class ImportStep extends React.PureComponent<Props, State> {
         )
         isEmote = result.isEmote
         validationIssues = result.validationResult.issues
+        suggestedCategory = result.suggestedCategory
       } finally {
         // Clean up blob URLs to prevent memory leaks
         revokeMappingsObjectURL(mappings)
         URL.revokeObjectURL(url)
       }
     }
-    return { model, contents, type: isEmote ? ItemType.EMOTE : ItemType.WEARABLE, validationIssues }
+    return { model, contents, type: isEmote ? ItemType.EMOTE : ItemType.WEARABLE, validationIssues, suggestedCategory }
   }
 
   handleOpenMoreInformation = () => {

--- a/src/lib/getModelData.ts
+++ b/src/lib/getModelData.ts
@@ -12,6 +12,7 @@ import { EMOTE_ERROR, getScreenshot } from './getScreenshot'
 import { validateWearableGLTF, validateEmoteGLTF } from './glbValidation'
 import type { ValidationResult } from './glbValidation'
 import { PROP_ARMATURE_NAME } from './glbValidation/constants'
+import { suggestWearableCategory } from './glbValidation/suggestWearableCategory'
 
 // transparent 1x1 pixel
 export const TRANSPARENT_PIXEL =
@@ -347,22 +348,28 @@ export async function loadAndValidateModel(
 ): Promise<{
   isEmote: boolean
   validationResult: ValidationResult
+  suggestedCategory: WearableCategory | null
 }> {
+  const Three = await import('three')
   const { gltf, renderer } = await loadGltf(url, options)
 
   try {
     const isEmote = gltf.animations.length > 0
 
     let validationResult: ValidationResult
+    let suggestedCategory: WearableCategory | null = null
 
     if (isEmote) {
       const hasProps = gltf.scene.children.some(child => child.name === PROP_ARMATURE_NAME)
       validationResult = await validateEmoteGLTF(gltf, hasProps, contents)
     } else {
       validationResult = await validateWearableGLTF(gltf, category, hides)
+      // Infer the most likely category from the model geometry so the details step
+      // can pre-select it. Suggestion only — the creator can always override.
+      suggestedCategory = suggestWearableCategory(Three, gltf.scene)
     }
 
-    return { isEmote, validationResult }
+    return { isEmote, validationResult, suggestedCategory }
   } finally {
     renderer.dispose()
     if (renderer.domElement.parentNode) {

--- a/src/lib/getModelData.ts
+++ b/src/lib/getModelData.ts
@@ -350,6 +350,9 @@ export async function loadAndValidateModel(
   validationResult: ValidationResult
   suggestedCategory: WearableCategory | null
 }> {
+  // `suggestWearableCategory` needs the Three.js module to run `instanceof` checks
+  // against the same realm. The module is already cached at this point, so this import
+  // is effectively free.
   const Three = await import('three')
   const { gltf, renderer } = await loadGltf(url, options)
 
@@ -366,7 +369,13 @@ export async function loadAndValidateModel(
       validationResult = await validateWearableGLTF(gltf, category, hides)
       // Infer the most likely category from the model geometry so the details step
       // can pre-select it. Suggestion only — the creator can always override.
-      suggestedCategory = suggestWearableCategory(Three, gltf.scene)
+      // This is a pure UX convenience, so a throw on malformed geometry must never
+      // fail the critical import path: swallow any error and fall back to no suggestion.
+      try {
+        suggestedCategory = suggestWearableCategory(Three, gltf.scene)
+      } catch (error) {
+        suggestedCategory = null
+      }
     }
 
     return { isEmote, validationResult, suggestedCategory }

--- a/src/lib/glbValidation/suggestWearableCategory.spec.ts
+++ b/src/lib/glbValidation/suggestWearableCategory.spec.ts
@@ -1,0 +1,224 @@
+import { WearableCategory } from '@dcl/schemas'
+import { suggestWearableCategory } from './suggestWearableCategory'
+
+type ThreeModules = typeof import('three')
+
+// Mock Three.js classes that support instanceof checks, mirroring wearableValidators.spec.ts.
+function createMockThree() {
+  class MockMesh {
+    material: any
+    geometry: any
+    name: string
+    constructor(geometry?: any) {
+      this.geometry = geometry
+      this.name = ''
+    }
+  }
+  class MockSkinnedMesh extends MockMesh {
+    skeleton: any
+  }
+  class MockBone {
+    name = ''
+  }
+
+  return {
+    Mesh: MockMesh,
+    SkinnedMesh: MockSkinnedMesh,
+    Bone: MockBone
+  }
+}
+
+type MockThree = ReturnType<typeof createMockThree>
+
+function asThree(mock: Record<string, unknown>): ThreeModules {
+  return mock as unknown as ThreeModules
+}
+
+function createScene(nodes: unknown[]): THREE.Scene {
+  return {
+    traverse: (callback: (node: unknown) => void) => {
+      nodes.forEach(callback)
+    }
+  } as unknown as THREE.Scene
+}
+
+// Builds a buffer attribute backed by a flat array of `itemSize` components per vertex,
+// exposing the getX/getY/getZ/getW accessors the helper reads.
+function createAttribute(values: number[][], itemSize: number) {
+  return {
+    count: values.length,
+    itemSize,
+    getX: (index: number) => values[index][0],
+    getY: (index: number) => values[index][1],
+    getZ: (index: number) => values[index][2],
+    getW: (index: number) => values[index][3]
+  }
+}
+
+/**
+ * Creates a skinned mesh whose vertices are bound to the given bones.
+ * Each `vertexBindings` entry is the list of bone indices that vertex is fully bound to,
+ * distributing weight equally across those bones.
+ */
+function createSkinnedMesh(Three: MockThree, boneNames: string[], vertexBindings: number[][]) {
+  const bones = boneNames.map(name => {
+    const bone = new Three.Bone()
+    bone.name = name
+    return bone
+  })
+
+  const skinIndexValues: number[][] = []
+  const skinWeightValues: number[][] = []
+  for (const binding of vertexBindings) {
+    const index = [0, 0, 0, 0]
+    const weight = [0, 0, 0, 0]
+    const perBone = 1 / binding.length
+    binding.forEach((boneIdx, slot) => {
+      index[slot] = boneIdx
+      weight[slot] = perBone
+    })
+    skinIndexValues.push(index)
+    skinWeightValues.push(weight)
+  }
+
+  const mesh = new Three.SkinnedMesh({
+    getAttribute: (name: string) => {
+      if (name === 'skinIndex') return createAttribute(skinIndexValues, 4)
+      if (name === 'skinWeight') return createAttribute(skinWeightValues, 4)
+      return null
+    }
+  })
+  mesh.skeleton = { bones }
+  return mesh
+}
+
+describe('suggestWearableCategory', () => {
+  let Three: MockThree
+
+  beforeEach(() => {
+    Three = createMockThree()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('when the geometry is dominantly bound to the head bones', () => {
+    let result: WearableCategory | null
+
+    beforeEach(() => {
+      const mesh = createSkinnedMesh(Three, ['Avatar_Head', 'Avatar_Neck'], [[0], [0], [1]])
+      result = suggestWearableCategory(asThree(Three), createScene([mesh]))
+    })
+
+    it('should suggest the hat category', () => {
+      expect(result).toBe(WearableCategory.HAT)
+    })
+  })
+
+  describe('when the geometry is dominantly bound to the spine and arm bones', () => {
+    let result: WearableCategory | null
+
+    beforeEach(() => {
+      const mesh = createSkinnedMesh(Three, ['Avatar_Spine', 'Avatar_LeftArm', 'Avatar_RightArm'], [[0], [1], [2], [0]])
+      result = suggestWearableCategory(asThree(Three), createScene([mesh]))
+    })
+
+    it('should suggest the upper_body category', () => {
+      expect(result).toBe(WearableCategory.UPPER_BODY)
+    })
+  })
+
+  describe('when the geometry is dominantly bound to the leg bones', () => {
+    let result: WearableCategory | null
+
+    beforeEach(() => {
+      const mesh = createSkinnedMesh(Three, ['Avatar_LeftUpLeg', 'Avatar_RightUpLeg', 'Avatar_LeftLeg'], [[0], [1], [2], [0]])
+      result = suggestWearableCategory(asThree(Three), createScene([mesh]))
+    })
+
+    it('should suggest the lower_body category', () => {
+      expect(result).toBe(WearableCategory.LOWER_BODY)
+    })
+  })
+
+  describe('when the geometry is dominantly bound to the foot bones', () => {
+    let result: WearableCategory | null
+
+    beforeEach(() => {
+      const mesh = createSkinnedMesh(Three, ['Avatar_LeftFoot', 'Avatar_RightFoot', 'Avatar_LeftToeBase'], [[0], [1], [2], [0]])
+      result = suggestWearableCategory(asThree(Three), createScene([mesh]))
+    })
+
+    it('should suggest the feet category', () => {
+      expect(result).toBe(WearableCategory.FEET)
+    })
+  })
+
+  describe('when the geometry is dominantly bound to the hand bones', () => {
+    let result: WearableCategory | null
+
+    beforeEach(() => {
+      const mesh = createSkinnedMesh(Three, ['Avatar_LeftHand', 'Avatar_RightHand', 'Avatar_LeftHandIndex'], [[0], [1], [2], [0]])
+      result = suggestWearableCategory(asThree(Three), createScene([mesh]))
+    })
+
+    it('should suggest the hands_wear category', () => {
+      expect(result).toBe(WearableCategory.HANDS_WEAR)
+    })
+  })
+
+  describe('when the geometry is spread evenly across multiple regions', () => {
+    let result: WearableCategory | null
+
+    beforeEach(() => {
+      // A full-body skin: weight split across head, spine, legs and feet, no dominant region.
+      const mesh = createSkinnedMesh(Three, ['Avatar_Head', 'Avatar_Spine', 'Avatar_LeftUpLeg', 'Avatar_LeftFoot'], [[0], [1], [2], [3]])
+      result = suggestWearableCategory(asThree(Three), createScene([mesh]))
+    })
+
+    it('should return null', () => {
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('when there are no skinned meshes in the scene', () => {
+    let result: WearableCategory | null
+
+    beforeEach(() => {
+      const mesh = new Three.Mesh()
+      result = suggestWearableCategory(asThree(Three), createScene([mesh]))
+    })
+
+    it('should return null', () => {
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('when the skinned mesh has no skin attributes', () => {
+    let result: WearableCategory | null
+
+    beforeEach(() => {
+      const mesh = new Three.SkinnedMesh({ getAttribute: () => null })
+      mesh.skeleton = { bones: [] }
+      result = suggestWearableCategory(asThree(Three), createScene([mesh]))
+    })
+
+    it('should return null', () => {
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('when none of the bound bones match a known avatar region', () => {
+    let result: WearableCategory | null
+
+    beforeEach(() => {
+      const mesh = createSkinnedMesh(Three, ['Prop_Root', 'Some_Other_Bone'], [[0], [1]])
+      result = suggestWearableCategory(asThree(Three), createScene([mesh]))
+    })
+
+    it('should return null', () => {
+      expect(result).toBeNull()
+    })
+  })
+})

--- a/src/lib/glbValidation/suggestWearableCategory.spec.ts
+++ b/src/lib/glbValidation/suggestWearableCategory.spec.ts
@@ -168,6 +168,39 @@ describe('suggestWearableCategory', () => {
     })
   })
 
+  describe('when the geometry is dominantly bound to the forearm bones', () => {
+    let result: WearableCategory | null
+
+    beforeEach(() => {
+      // Documents the intended classification: forearm bones belong to the upper body, so
+      // sleeved garments (shirts, jackets) suggest `upper_body` (see the `forearm` spine token).
+      const mesh = createSkinnedMesh(Three, ['Avatar_LeftForeArm', 'Avatar_RightForeArm'], [[0], [1], [0], [1]])
+      result = suggestWearableCategory(asThree(Three), createScene([mesh]))
+    })
+
+    it('should suggest the upper_body category', () => {
+      expect(result).toBe(WearableCategory.UPPER_BODY)
+    })
+  })
+
+  describe('when the geometry is split across two skinned meshes whose weights accumulate', () => {
+    let result: WearableCategory | null
+
+    beforeEach(() => {
+      // Two separate skinned meshes both contribute spine/arm weight. The suggestion must
+      // aggregate weights across every skinned mesh in the scene, not look at one in isolation:
+      // the second mesh also carries some feet weight, and only the summed spine weight
+      // (5 of 6 total) crosses the dominant-region threshold.
+      const spineMesh = createSkinnedMesh(Three, ['Avatar_Spine', 'Avatar_LeftArm'], [[0], [1], [0]])
+      const armMesh = createSkinnedMesh(Three, ['Avatar_RightArm', 'Avatar_LeftFoot'], [[0], [0], [1]])
+      result = suggestWearableCategory(asThree(Three), createScene([spineMesh, armMesh]))
+    })
+
+    it('should suggest the upper_body category', () => {
+      expect(result).toBe(WearableCategory.UPPER_BODY)
+    })
+  })
+
   describe('when the geometry is spread evenly across multiple regions', () => {
     let result: WearableCategory | null
 

--- a/src/lib/glbValidation/suggestWearableCategory.ts
+++ b/src/lib/glbValidation/suggestWearableCategory.ts
@@ -1,0 +1,170 @@
+import { WearableCategory } from '@dcl/schemas'
+
+type ThreeModules = typeof import('three')
+
+/**
+ * Avatar skeleton landmark body-part tokens used to locate body regions.
+ *
+ * Decentraland base avatars rig their bones with an `Avatar_` prefix and a side
+ * segment, e.g. `Avatar_Head`, `Avatar_Spine`, `Avatar_LeftUpLeg`, `Avatar_RightFoot`,
+ * `Avatar_LeftHandIndex1`. Before matching we strip the `avatar_` prefix and any
+ * leading `left`/`right` side segment (see {@link normalizeBoneName}), so the tokens
+ * below match the body part regardless of side and minor exporter variations.
+ *
+ * Order within each region does not matter, but region precedence does — see the
+ * `order` array in {@link classifyBone}: more specific regions (feet, hands) are
+ * tested before broader ones (legs, spine) so a foot/toe bone is never absorbed by legs.
+ */
+const LANDMARK_BONES = {
+  head: ['head', 'neck'],
+  spine: ['spine', 'chest', 'shoulder', 'arm'],
+  legs: ['upleg', 'leg', 'knee'],
+  feet: ['foot', 'toebase', 'toe'],
+  hands: ['hand', 'finger', 'thumb']
+}
+
+/** The avatar region a piece of geometry is dominantly attached to. */
+type AvatarRegion = keyof typeof LANDMARK_BONES
+
+/**
+ * Minimum share of total skin weight a single region must own for the suggestion
+ * to be considered unambiguous. Below this the geometry spans multiple regions
+ * (e.g. a full-body skin) and we return `null` so the creator picks manually.
+ */
+const DOMINANT_REGION_THRESHOLD = 0.6
+
+/** Maps a winning avatar region to the default wearable category we suggest for it. */
+const REGION_TO_CATEGORY: Record<AvatarRegion, WearableCategory> = {
+  // Default head category is `hat`. We deliberately do NOT over-fit to helmet/top_head/hair:
+  // those are visually distinct sub-types the creator should confirm.
+  head: WearableCategory.HAT,
+  spine: WearableCategory.UPPER_BODY,
+  legs: WearableCategory.LOWER_BODY,
+  feet: WearableCategory.FEET,
+  hands: WearableCategory.HANDS_WEAR
+}
+
+/**
+ * Lowercases the bone name and strips the `avatar_` prefix plus a leading
+ * `left`/`right` side segment so body-part tokens can be matched directly.
+ * e.g. `Avatar_LeftUpLeg` → `upleg`, `Avatar_RightToeBase` → `toebase`, `Avatar_Head` → `head`.
+ */
+function normalizeBoneName(boneName: string): string {
+  return boneName
+    .toLowerCase()
+    .replace(/^avatar[_-]?/, '')
+    .replace(/^(left|right)[_-]?/, '')
+}
+
+/** Returns the region whose landmark tokens match the given bone name, or null. */
+function classifyBone(boneName: string): AvatarRegion | null {
+  const name = normalizeBoneName(boneName)
+  // Feet and hands are checked before legs and spine because a foot/toe or hand/finger
+  // bone must never be absorbed by the broader leg ("upleg" contains "leg") or arm regions.
+  const order: AvatarRegion[] = ['feet', 'hands', 'head', 'legs', 'spine']
+  for (const region of order) {
+    if (LANDMARK_BONES[region].some(pattern => name.includes(pattern))) {
+      return region
+    }
+  }
+  return null
+}
+
+/**
+ * Accumulates, per region, the total skin weight bound to bones of that region.
+ *
+ * For every skinned mesh we read the `skinIndex` (which bone each vertex is bound to)
+ * and `skinWeight` (how strongly) attributes. Each vertex has up to 4 influences.
+ * We resolve the influencing bone via the mesh skeleton and add the weight to its region.
+ */
+function accumulateRegionWeights(Three: ThreeModules, scene: THREE.Scene): Record<AvatarRegion, number> {
+  const weights: Record<AvatarRegion, number> = { head: 0, spine: 0, legs: 0, feet: 0, hands: 0 }
+
+  scene.traverse((node: THREE.Object3D) => {
+    if (!(node instanceof Three.SkinnedMesh) || !node.skeleton) {
+      return
+    }
+
+    const bones = node.skeleton.bones
+    const geometry = node.geometry as THREE.BufferGeometry
+    const skinIndex = geometry.getAttribute('skinIndex')
+    const skinWeight = geometry.getAttribute('skinWeight')
+    if (!skinIndex || !skinWeight) {
+      return
+    }
+
+    // Pre-classify each bone once so the per-vertex loop stays cheap.
+    const boneRegions = bones.map(bone => classifyBone(bone.name))
+
+    // Skin attributes are Vector4 (up to 4 bone influences per vertex). We read each
+    // of the 4 components via getX/getY/getZ/getW, capped by the attribute's itemSize.
+    const indexAccessors = [skinIndex.getX, skinIndex.getY, skinIndex.getZ, skinIndex.getW]
+    const weightAccessors = [skinWeight.getX, skinWeight.getY, skinWeight.getZ, skinWeight.getW]
+
+    const vertexCount = skinIndex.count
+    const componentsPerVertex = Math.min(skinIndex.itemSize, 4)
+    for (let v = 0; v < vertexCount; v++) {
+      for (let c = 0; c < componentsPerVertex; c++) {
+        const boneIdx = indexAccessors[c].call(skinIndex, v)
+        const weight = weightAccessors[c].call(skinWeight, v)
+        if (weight <= 0) {
+          continue
+        }
+        const region = boneRegions[boneIdx]
+        if (region) {
+          weights[region] += weight
+        }
+      }
+    }
+  })
+
+  return weights
+}
+
+/**
+ * Suggests the most likely wearable category for a model based on the body region
+ * its geometry is dominantly skinned to.
+ *
+ * The heuristic, in plain terms:
+ *   - Walk the skinned meshes and tally how much skin weight is bound to each avatar
+ *     region (head, spine/arms, legs, feet, hands).
+ *   - If one region owns at least {@link DOMINANT_REGION_THRESHOLD} of all classified
+ *     weight, suggest that region's default category.
+ *   - Otherwise return `null` (ambiguous / multi-region geometry — let the creator pick).
+ *
+ * Region → category mapping (intentionally conservative):
+ *   - head (Avatar_Head / Avatar_Neck and above) → `hat` (default head category)
+ *   - spine/arms (Avatar_Spine* / Avatar_Arm) → `upper_body`
+ *   - legs (Avatar_*UpLeg / Avatar_*Leg) → `lower_body`
+ *   - feet (Avatar_*Foot / Avatar_*ToeBase) → `feet`
+ *   - hands (Avatar_*Hand / fingers) → `hands_wear`
+ *
+ * Returns `null` (rather than guessing) when there are no skinned meshes, no usable
+ * skin data, or no clearly dominant region.
+ *
+ * @param Three - The Three.js module (passed in to support `instanceof` against the same realm).
+ * @param scene - The parsed GLTF scene.
+ */
+export function suggestWearableCategory(Three: ThreeModules, scene: THREE.Scene): WearableCategory | null {
+  const weights = accumulateRegionWeights(Three, scene)
+
+  const total = Object.values(weights).reduce((sum, w) => sum + w, 0)
+  if (total <= 0) {
+    return null
+  }
+
+  let bestRegion: AvatarRegion | null = null
+  let bestWeight = 0
+  for (const region of Object.keys(weights) as AvatarRegion[]) {
+    if (weights[region] > bestWeight) {
+      bestWeight = weights[region]
+      bestRegion = region
+    }
+  }
+
+  if (!bestRegion || bestWeight / total < DOMINANT_REGION_THRESHOLD) {
+    return null
+  }
+
+  return REGION_TO_CATEGORY[bestRegion]
+}

--- a/src/lib/glbValidation/suggestWearableCategory.ts
+++ b/src/lib/glbValidation/suggestWearableCategory.ts
@@ -17,7 +17,10 @@ type ThreeModules = typeof import('three')
  */
 const LANDMARK_BONES = {
   head: ['head', 'neck'],
-  spine: ['spine', 'chest', 'shoulder', 'arm'],
+  // `forearm` is listed explicitly (rather than relying on `'forearm'.includes('arm')`)
+  // to make the design choice intentional: the forearm is treated as part of the upper
+  // body so sleeved garments like shirts and jackets classify as `upper_body`.
+  spine: ['spine', 'chest', 'shoulder', 'arm', 'forearm'],
   legs: ['upleg', 'leg', 'knee'],
   feet: ['foot', 'toebase', 'toe'],
   hands: ['hand', 'finger', 'thumb']

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -306,6 +306,7 @@
     "name_label": "Enter a name for your item",
     "category_label": "What's the category of this item?",
     "category_placeholder": "Select a category",
+    "suggested_category": "Suggested from your model: {category}. You can change it if it's not right.",
     "play_mode_label": "Play mode",
     "play_mode_placeholder": "Select a play mode",
     "upload_video_label": "Show users a preview of how to use this item",

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -307,6 +307,7 @@
     "name_label": "Ponle un nombre a tu item",
     "category_label": "Cuál es la categoría de este item?",
     "category_placeholder": "Selecciona una categoria",
+    "suggested_category": "Sugerida a partir de tu modelo: {category}. Podés cambiarla si no es la correcta.",
     "play_mode_label": "Modo de ejecución",
     "play_mode_placeholder": "Selecciona un modo de ejecución",
     "upload_video_label": "Mostrar a los usuarios una vista previa de cómo usar este elemento",

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -301,6 +301,7 @@
     "name_label": "给您的新商品起个名字",
     "category_label": "这个项目是什么类别？",
     "category_placeholder": "选择一个类别",
+    "suggested_category": "根据您的模型建议：{category}。如果不正确，您可以更改。",
     "play_mode_label": "游戏模式",
     "play_mode_placeholder": "选择播放模式",
     "upload_video_label": "向用户展示如何使用此项目的预览",


### PR DESCRIPTION
## Why

Analysis of 4,340 real wearable submissions shows **wrong-category is a top curation-feedback reason (11.5% of collections)**. Curators routinely ask creators to fix the category (e.g. *"Making this an upper body means it replaces the torso. Please change the category to Top head."*). Today the category is a manual dropdown with no guidance, so a wrong pick means a full curation round-trip and re-upload.

This change auto-suggests the most likely wearable category from the model geometry at import time and pre-selects it (still fully overridable), removing a whole class of "wrong category → re-upload" loops.

## Changes

- Add a pure helper `suggestWearableCategory(Three, scene)` in `src/lib/glbValidation/suggestWearableCategory.ts`. It walks the GLTF scene's skinned meshes, tallies skin weight per avatar region using the skeleton bone names (`Avatar_Head`/`Avatar_Neck` → head, `Avatar_Spine*`/arms → spine, `Avatar_*UpLeg`/`Avatar_*Leg` → legs, `Avatar_*Foot`/`Avatar_*ToeBase` → feet, hands → hands), and returns a `WearableCategory` only when one region owns ≥60% of the classified weight. Returns `null` when ambiguous (e.g. full-body skins) so the creator picks manually.
  - Region → category mapping is intentionally conservative: head → `hat` (default head category, not over-fit to helmet/top_head), spine → `upper_body`, legs → `lower_body`, feet → `feet`, hands → `hands_wear`.
- Thread the suggestion through `loadAndValidateModel` → `processModel` → `AcceptedFileProps` → modal state (mirrors the existing `validationIssues` flow). No GLTF re-load — reuses the one already loaded for validation.
- Pre-select the suggested category in the reducer's `SET_ACCEPTED_PROPS` **only when no category was already declared** (bare `.glb` with no `wearable.json`), and only when it's part of the body-shape-filtered selectable list. Explicit categories (zip `wearable.json`, change-item-file, representation flows) are never overridden.
- Show a subtle "Suggested from your model: …" hint under the category dropdown in `CommonFields`.
- Add `create_single_item_modal.suggested_category` to `en` / `es` / `zh`.
- Focused unit tests for the helper (head/torso/legs/feet/hands → expected category; ambiguous / no skin data / unknown bones → `null`).

Submission behavior is unchanged beyond the default selection + hint.

## Test plan

- [x] `suggestWearableCategory` unit tests pass (9/9)
- [x] `lint` and `build` pass
- [ ] Import a bare `.glb` skinned to the head → category defaults to `hat`, hint shown
- [ ] Import a `.glb` skinned to legs → defaults to `lower_body`
- [ ] Import a full-body skin → no suggestion, dropdown stays empty
- [ ] Import a zip with `wearable.json` declaring a category → declared category wins, no override