### PR TITLE
feat: warn when wearable thumbnail background is not transparent

### DIFF
--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.reducer.ts
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.reducer.ts
@@ -102,7 +102,8 @@ export const CREATE_ITEM_ACTIONS = {
   RESET_STATE: 'RESET_STATE',
   UPDATE_THUMBNAIL_BY_CATEGORY: 'UPDATE_THUMBNAIL_BY_CATEGORY',
   CLEAR_ERROR: 'CLEAR_ERROR',
-  SET_VALIDATION_ISSUES: 'SET_VALIDATION_ISSUES'
+  SET_VALIDATION_ISSUES: 'SET_VALIDATION_ISSUES',
+  SET_THUMBNAIL_NOT_TRANSPARENT: 'SET_THUMBNAIL_NOT_TRANSPARENT'
 } as const
 
 // Action Type Union
@@ -146,6 +147,7 @@ export type CreateItemAction =
   | { type: typeof CREATE_ITEM_ACTIONS.UPDATE_THUMBNAIL_BY_CATEGORY; payload: { thumbnail: string; isLoading: boolean } }
   | { type: typeof CREATE_ITEM_ACTIONS.CLEAR_ERROR }
   | { type: typeof CREATE_ITEM_ACTIONS.SET_VALIDATION_ISSUES; payload: ValidationIssue[] | undefined }
+  | { type: typeof CREATE_ITEM_ACTIONS.SET_THUMBNAIL_NOT_TRANSPARENT; payload: boolean }
 
 // Action Creators
 export const createItemActions = {
@@ -326,6 +328,11 @@ export const createItemActions = {
   setValidationIssues: (issues: ValidationIssue[] | undefined): CreateItemAction => ({
     type: CREATE_ITEM_ACTIONS.SET_VALIDATION_ISSUES,
     payload: issues
+  }),
+
+  setThumbnailNotTransparent: (notTransparent: boolean): CreateItemAction => ({
+    type: CREATE_ITEM_ACTIONS.SET_THUMBNAIL_NOT_TRANSPARENT,
+    payload: notTransparent
   })
 }
 
@@ -342,7 +349,9 @@ export const createItemReducer = (state: State, action: CreateItemAction | null)
       return { ...state, error: action.payload }
 
     case CREATE_ITEM_ACTIONS.SET_THUMBNAIL:
-      return { ...state, thumbnail: action.payload }
+      // Replacing the thumbnail clears any stale transparency warning. Generated/screenshot
+      // thumbnails are always transparent; the manual-upload path re-evaluates and re-sets the flag.
+      return { ...state, thumbnail: action.payload, thumbnailNotTransparent: false }
 
     case CREATE_ITEM_ACTIONS.SET_VIDEO:
       return { ...state, video: action.payload }
@@ -432,10 +441,12 @@ export const createItemReducer = (state: State, action: CreateItemAction | null)
       return { ...state, ...action.payload }
 
     case CREATE_ITEM_ACTIONS.UPDATE_THUMBNAIL_BY_CATEGORY:
+      // A category-regenerated thumbnail is always transparent, so clear any stale warning.
       return {
         ...state,
         thumbnail: action.payload.thumbnail,
-        isLoading: action.payload.isLoading
+        isLoading: action.payload.isLoading,
+        thumbnailNotTransparent: false
       }
 
     case CREATE_ITEM_ACTIONS.CLEAR_ERROR:
@@ -443,6 +454,9 @@ export const createItemReducer = (state: State, action: CreateItemAction | null)
 
     case CREATE_ITEM_ACTIONS.SET_VALIDATION_ISSUES:
       return { ...state, validationIssues: action.payload }
+
+    case CREATE_ITEM_ACTIONS.SET_THUMBNAIL_NOT_TRANSPARENT:
+      return { ...state, thumbnailNotTransparent: action.payload }
 
     case CREATE_ITEM_ACTIONS.RESET_STATE:
       return { ...state, ...action.payload }

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.reducer.ts
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.reducer.ts
@@ -438,7 +438,9 @@ export const createItemReducer = (state: State, action: CreateItemAction | null)
       return { ...state, video: action.payload }
 
     case CREATE_ITEM_ACTIONS.SET_ACCEPTED_PROPS:
-      return { ...state, ...action.payload }
+      // Clear any stale transparency warning before spreading the new props so replacing the file
+      // does not keep a warning from a previous thumbnail. An explicit value in the payload still wins.
+      return { ...state, thumbnailNotTransparent: false, ...action.payload }
 
     case CREATE_ITEM_ACTIONS.UPDATE_THUMBNAIL_BY_CATEGORY:
       // A category-regenerated thumbnail is always transparent, so clear any stale warning.
@@ -459,7 +461,9 @@ export const createItemReducer = (state: State, action: CreateItemAction | null)
       return { ...state, thumbnailNotTransparent: action.payload }
 
     case CREATE_ITEM_ACTIONS.RESET_STATE:
-      return { ...state, ...action.payload }
+      // Clear any stale transparency warning before spreading the new state so re-opening the modal
+      // for a different item does not keep a warning from a previous one. An explicit value still wins.
+      return { ...state, thumbnailNotTransparent: false, ...action.payload }
 
     default:
       return state

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.tsx
@@ -22,7 +22,7 @@ import { WearablePreview } from 'decentraland-ui2'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import Modal from 'decentraland-dapps/dist/containers/Modal'
 import { isErrorWithMessage } from 'decentraland-dapps/dist/lib/error'
-import { getImageType, dataURLToBlob } from 'modules/media/utils'
+import { getImageType, dataURLToBlob, isPngBackgroundTransparent } from 'modules/media/utils'
 import { ImageType } from 'modules/media/types'
 import {
   THUMBNAIL_PATH,
@@ -93,6 +93,7 @@ import { Steps } from './Steps'
 import { CreateSingleItemModalProvider } from './CreateSingleItemModalProvider'
 import { checkTriangleCount } from 'lib/glbValidation'
 import type { ValidationIssue } from 'lib/glbValidation/types'
+import { ValidationSeverity } from 'lib/glbValidation/types'
 import './CreateSingleItemModal.css'
 
 type ItemValidationResult = {
@@ -182,7 +183,7 @@ export const CreateSingleItemModal: React.FC<Props> = props => {
   }, [metadata])
 
   // Merge import-time validation issues with category-dependent triangle check
-  const allValidationIssues = useMemo((): ValidationIssue[] | undefined => {
+  const glbValidationIssues = useMemo((): ValidationIssue[] | undefined => {
     const { metrics, category, type, validationIssues } = state
     if (type !== ItemType.WEARABLE || !metrics || !('triangles' in metrics)) {
       return validationIssues
@@ -200,6 +201,21 @@ export const CreateSingleItemModal: React.FC<Props> = props => {
     }
     return nonTriangleIssues.length > 0 ? nonTriangleIssues : undefined
   }, [state])
+
+  // Append a non-blocking warning when the thumbnail lacks a transparent background. The marketplace
+  // renders the rarity color behind the thumbnail, so an opaque background is the most common
+  // thumbnail-related curation rejection — surfacing it here prevents a multi-day round-trip.
+  const allValidationIssues = useMemo((): ValidationIssue[] | undefined => {
+    if (!state.thumbnailNotTransparent) {
+      return glbValidationIssues
+    }
+    const thumbnailIssue: ValidationIssue = {
+      code: 'THUMBNAIL_NOT_TRANSPARENT',
+      severity: ValidationSeverity.WARNING,
+      messageKey: 'create_single_item_modal.error.thumbnail_not_transparent'
+    }
+    return [...(glbValidationIssues ?? []), thumbnailIssue]
+  }, [glbValidationIssues, state.thumbnailNotTransparent])
 
   const validationResult = useMemo(
     () => validateItemDraft(state, collection, isThirdPartyV2Enabled),
@@ -504,7 +520,12 @@ export const CreateSingleItemModal: React.FC<Props> = props => {
 
         const thumbnail = URL.createObjectURL(smallThumbnailBlob)
 
+        // Check the resized blob that will actually be stored/uploaded, so the warning reflects the
+        // final thumbnail. setThumbnail resets the flag, so dispatch the transparency result after it.
+        const isTransparent = await isPngBackgroundTransparent(bigThumbnailBlob)
+
         dispatch(createItemActions.setThumbnail(thumbnail))
+        dispatch(createItemActions.setThumbnailNotTransparent(!isTransparent))
         dispatch(
           createItemActions.setContents({
             ...contents,

--- a/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.types.ts
+++ b/src/components/Modals/CreateSingleItemModal/CreateSingleItemModal.types.ts
@@ -65,6 +65,7 @@ export type StateData = {
     armatures: Object3D[]
   }
   validationIssues?: ValidationIssue[]
+  thumbnailNotTransparent?: boolean
 }
 
 export type State = {

--- a/src/modules/item/utils.ts
+++ b/src/modules/item/utils.ts
@@ -421,6 +421,9 @@ export async function generateImage(item: Item | Item<ItemType.EMOTE> | LocalIte
 
 export async function resizeImage(image: Blob, width = 256, height = 256) {
   // create canvas
+  // NOTE: the canvas is intentionally left unfilled so the source image's alpha channel is
+  // preserved. Thumbnails must keep a transparent background so the marketplace can render the
+  // item's rarity color behind them — do not add a background fill here.
   const canvas = document.createElement('canvas')
   canvas.width = width
   canvas.height = height

--- a/src/modules/media/utils.spec.ts
+++ b/src/modules/media/utils.spec.ts
@@ -1,11 +1,39 @@
 import * as UPNG from 'upng-js'
-import { compressPngBlob, THUMBNAIL_PALETTE_COLORS } from './utils'
+import {
+  compressPngBlob,
+  isPngBackgroundTransparent,
+  isRgbaBackgroundTransparent,
+  THUMBNAIL_PALETTE_COLORS,
+  TRANSPARENT_ALPHA_THRESHOLD
+} from './utils'
 
 jest.mock('upng-js')
 
 const mockedDecode = UPNG.decode as jest.MockedFunction<typeof UPNG.decode>
 const mockedToRGBA8 = UPNG.toRGBA8 as jest.MockedFunction<typeof UPNG.toRGBA8>
 const mockedEncode = UPNG.encode as jest.MockedFunction<typeof UPNG.encode>
+
+// Builds a width x height RGBA buffer. `border` paints the outer ring, `fill` paints the interior.
+function buildRgba(
+  width: number,
+  height: number,
+  border: [number, number, number, number],
+  fill: [number, number, number, number]
+): Uint8Array {
+  const data = new Uint8Array(width * height * 4)
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const isBorder = x === 0 || y === 0 || x === width - 1 || y === height - 1
+      const [r, g, b, a] = isBorder ? border : fill
+      const offset = (y * width + x) * 4
+      data[offset] = r
+      data[offset + 1] = g
+      data[offset + 2] = b
+      data[offset + 3] = a
+    }
+  }
+  return data
+}
 
 // Builds a deterministic Blob-like with a controlled size and arrayBuffer, avoiding reliance on jsdom internals.
 function buildBlob(size: number, type = 'image/png'): Blob {
@@ -102,6 +130,149 @@ describe('when compressing a PNG blob', () => {
     it('should not attempt to decode it', async () => {
       await compressPngBlob(original)
       expect(mockedDecode).not.toHaveBeenCalled()
+    })
+  })
+})
+
+describe('when checking if RGBA data has a transparent background', () => {
+  const opaque: [number, number, number, number] = [255, 255, 255, 255]
+  const transparent: [number, number, number, number] = [0, 0, 0, 0]
+
+  describe('and the border ring is fully transparent', () => {
+    let data: Uint8Array
+
+    beforeEach(() => {
+      data = buildRgba(8, 8, transparent, opaque)
+    })
+
+    it('should report the background as transparent', () => {
+      expect(isRgbaBackgroundTransparent(data, 8, 8)).toBe(true)
+    })
+  })
+
+  describe('and the border ring is fully opaque', () => {
+    let data: Uint8Array
+
+    beforeEach(() => {
+      data = buildRgba(8, 8, opaque, opaque)
+    })
+
+    it('should report the background as not transparent', () => {
+      expect(isRgbaBackgroundTransparent(data, 8, 8)).toBe(false)
+    })
+  })
+
+  describe('and the border alpha is just below the transparency threshold', () => {
+    let data: Uint8Array
+
+    beforeEach(() => {
+      data = buildRgba(8, 8, [0, 0, 0, TRANSPARENT_ALPHA_THRESHOLD], opaque)
+    })
+
+    it('should report the background as transparent', () => {
+      expect(isRgbaBackgroundTransparent(data, 8, 8)).toBe(true)
+    })
+  })
+
+  describe('and the border alpha is just above the transparency threshold', () => {
+    let data: Uint8Array
+
+    beforeEach(() => {
+      data = buildRgba(8, 8, [0, 0, 0, TRANSPARENT_ALPHA_THRESHOLD + 1], opaque)
+    })
+
+    it('should report the background as not transparent', () => {
+      expect(isRgbaBackgroundTransparent(data, 8, 8)).toBe(false)
+    })
+  })
+
+  describe('and only a few border pixels are opaque', () => {
+    let data: Uint8Array
+
+    beforeEach(() => {
+      // A 10x10 mostly-transparent border with two opaque corner pixels stays above the ratio.
+      data = buildRgba(10, 10, transparent, opaque)
+      data[3] = 255
+      data[7] = 255
+    })
+
+    it('should report the background as transparent', () => {
+      expect(isRgbaBackgroundTransparent(data, 10, 10)).toBe(true)
+    })
+  })
+
+  describe('and the buffer is smaller than the declared dimensions', () => {
+    let data: Uint8Array
+
+    beforeEach(() => {
+      data = new Uint8Array(4)
+    })
+
+    it('should report the background as transparent rather than warn on a bad input', () => {
+      expect(isRgbaBackgroundTransparent(data, 8, 8)).toBe(true)
+    })
+  })
+
+  describe('and the dimensions are zero', () => {
+    it('should report the background as transparent', () => {
+      expect(isRgbaBackgroundTransparent(new Uint8Array(0), 0, 0)).toBe(true)
+    })
+  })
+})
+
+describe('when checking if a PNG blob has a transparent background', () => {
+  let blob: Blob
+
+  beforeEach(() => {
+    blob = { arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)) } as unknown as Blob
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('and the decoded image has a transparent border', () => {
+    beforeEach(() => {
+      mockedDecode.mockReturnValueOnce({ width: 8, height: 8 } as UPNG.Image)
+      mockedToRGBA8.mockReturnValueOnce([buildRgba(8, 8, [0, 0, 0, 0], [255, 255, 255, 255]).buffer as ArrayBuffer])
+    })
+
+    it('should report the background as transparent', async () => {
+      await expect(isPngBackgroundTransparent(blob)).resolves.toBe(true)
+    })
+  })
+
+  describe('and the decoded image has an opaque border', () => {
+    beforeEach(() => {
+      mockedDecode.mockReturnValueOnce({ width: 8, height: 8 } as UPNG.Image)
+      mockedToRGBA8.mockReturnValueOnce([buildRgba(8, 8, [255, 255, 255, 255], [255, 255, 255, 255]).buffer as ArrayBuffer])
+    })
+
+    it('should report the background as not transparent', async () => {
+      await expect(isPngBackgroundTransparent(blob)).resolves.toBe(false)
+    })
+  })
+
+  describe('and decoding produces no frames', () => {
+    beforeEach(() => {
+      mockedDecode.mockReturnValueOnce({ width: 8, height: 8 } as UPNG.Image)
+      mockedToRGBA8.mockReturnValueOnce([])
+    })
+
+    it('should report the background as transparent', async () => {
+      await expect(isPngBackgroundTransparent(blob)).resolves.toBe(true)
+    })
+  })
+
+  describe('and decoding the PNG throws', () => {
+    beforeEach(() => {
+      mockedDecode.mockImplementationOnce(() => {
+        throw new Error('invalid PNG data')
+      })
+    })
+
+    it('should report the background as transparent rather than block on a bad input', async () => {
+      await expect(isPngBackgroundTransparent(blob)).resolves.toBe(true)
     })
   })
 })

--- a/src/modules/media/utils.spec.ts
+++ b/src/modules/media/utils.spec.ts
@@ -191,13 +191,40 @@ describe('when checking if RGBA data has a transparent background', () => {
 
     beforeEach(() => {
       // A 10x10 mostly-transparent border with two opaque corner pixels stays above the ratio.
+      // Alpha bytes: top-left corner (0,0) at index 3, top-right corner (9,0) at index 39.
       data = buildRgba(10, 10, transparent, opaque)
       data[3] = 255
-      data[7] = 255
+      data[39] = 255
     })
 
     it('should report the background as transparent', () => {
       expect(isRgbaBackgroundTransparent(data, 10, 10)).toBe(true)
+    })
+  })
+
+  describe('and the image is a single pixel', () => {
+    describe('and that pixel is transparent', () => {
+      let data: Uint8Array
+
+      beforeEach(() => {
+        data = buildRgba(1, 1, transparent, transparent)
+      })
+
+      it('should report the background as transparent', () => {
+        expect(isRgbaBackgroundTransparent(data, 1, 1)).toBe(true)
+      })
+    })
+
+    describe('and that pixel is opaque', () => {
+      let data: Uint8Array
+
+      beforeEach(() => {
+        data = buildRgba(1, 1, opaque, opaque)
+      })
+
+      it('should report the background as not transparent', () => {
+        expect(isRgbaBackgroundTransparent(data, 1, 1)).toBe(false)
+      })
     })
   })
 

--- a/src/modules/media/utils.ts
+++ b/src/modules/media/utils.ts
@@ -164,3 +164,89 @@ export async function getImageType(image: Blob): Promise<ImageType> {
       return ImageType.UNKNOWN
   }
 }
+
+/**
+ * An alpha value (0-255) at or below this threshold is treated as transparent. Slightly above 0
+ * to tolerate near-transparent edge pixels produced by anti-aliasing / lossless re-encoding.
+ */
+export const TRANSPARENT_ALPHA_THRESHOLD = 8
+
+/**
+ * Fraction of sampled border pixels that must be transparent for the background to be considered
+ * transparent. Logos/badges occasionally bleed into a corner, so we don't require every border
+ * pixel to be transparent.
+ */
+export const TRANSPARENT_BORDER_RATIO = 0.9
+
+/**
+ * Determines whether an RGBA image has a transparent background by sampling its border ring (the
+ * outermost row/column of pixels on each edge). The marketplace renders the item's rarity color
+ * behind the thumbnail, so a non-transparent background hides that color and is the single most
+ * common thumbnail rejection reason in curation. This is a cheap, dependency-free heuristic: a
+ * thumbnail whose subject is centered will have a fully transparent border when exported correctly.
+ *
+ * @param rgba - Raw RGBA pixel data, 4 bytes per pixel (length must be `width * height * 4`).
+ * @param width - Image width in pixels.
+ * @param height - Image height in pixels.
+ * @returns `true` when the border is (mostly) transparent, `false` otherwise. Images too small to
+ *   sample are treated as transparent (no signal, never warn).
+ */
+export function isRgbaBackgroundTransparent(rgba: Uint8Array | Uint8ClampedArray | number[], width: number, height: number): boolean {
+  if (width <= 0 || height <= 0 || rgba.length < width * height * 4) {
+    return true
+  }
+
+  const alphaAt = (x: number, y: number): number => rgba[(y * width + x) * 4 + 3]
+
+  let sampled = 0
+  let transparent = 0
+  const sample = (x: number, y: number): void => {
+    sampled++
+    if (alphaAt(x, y) <= TRANSPARENT_ALPHA_THRESHOLD) {
+      transparent++
+    }
+  }
+
+  // Sample the top and bottom rows.
+  for (let x = 0; x < width; x++) {
+    sample(x, 0)
+    if (height > 1) {
+      sample(x, height - 1)
+    }
+  }
+  // Sample the left and right columns, skipping the corners already sampled above.
+  for (let y = 1; y < height - 1; y++) {
+    sample(0, y)
+    if (width > 1) {
+      sample(width - 1, y)
+    }
+  }
+
+  if (sampled === 0) {
+    return true
+  }
+
+  return transparent / sampled >= TRANSPARENT_BORDER_RATIO
+}
+
+/**
+ * Decodes a PNG blob and checks whether its background is transparent via
+ * {@link isRgbaBackgroundTransparent}. Uses UPNG (already a dependency) so it works without a
+ * canvas, including in tests. Any decode failure is treated as transparent so the check can never
+ * block or wrongly warn on an unexpected input.
+ *
+ * @param blob - The PNG blob to inspect.
+ */
+export async function isPngBackgroundTransparent(blob: Blob): Promise<boolean> {
+  try {
+    const buffer = await blob.arrayBuffer()
+    const image = UPNG.decode(buffer)
+    const [frame] = UPNG.toRGBA8(image)
+    if (!frame) {
+      return true
+    }
+    return isRgbaBackgroundTransparent(new Uint8Array(frame), image.width, image.height)
+  } catch {
+    return true
+  }
+}

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -325,6 +325,7 @@
       "file_too_big": "{title}.{enter}File size limit is {size}. Reduce the size of the file and try again.",
       "file_too_big_title": "The file is too large and can't be uploaded",
       "thumbnail_file_too_big": "The thumbnail file size exceeds the {maxSize} limit.",
+      "thumbnail_not_transparent": "The thumbnail background doesn't look transparent. Marketplaces show the item's rarity color behind the thumbnail, so a transparent background is recommended.",
       "wrong_extension": "The file has an invalid extension.",
       "invalid_files": "Files seem to be invalid or broken, please review them and try again.",
       "missing_model_file": "Couldn't find a valid model file.",

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -324,6 +324,7 @@
       "file_too_big": "{title}.{enter}El límite máximo de tamaño de archivo es {size}. Reduzca el tamaño del archivo e intente nuevamente.",
       "file_too_big_title": "El archivo es demasiado grande y no se puede cargar",
       "thumbnail_file_too_big": "El archivo thumbnail excede el límite de {size}.",
+      "thumbnail_not_transparent": "El fondo del thumbnail no parece transparente. Los mercados muestran el color de rareza del ítem detrás del thumbnail, por lo que se recomienda un fondo transparente.",
       "wrong_extension": "El archivo tiene una extensión inválida.",
       "invalid_files": "Los archivos parecen no ser válidos o estar dañados. Por favor revíselos y vuelva a intentarlo.",
       "missing_model_file": "No se pudo encontrar un archivo de modelo válido.",

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -318,6 +318,7 @@
       "file_too_big": "{title}.{enter}文件大小限制为 {size}。减小文件的大小，然后重试。",
       "file_too_big_title": "文件太大，无法上传",
       "thumbnail_file_too_big": "縮圖檔案大小超過 {maxSize} 限制。",
+      "thumbnail_not_transparent": "縮圖背景看起來不是透明的。市場會在縮圖後方顯示物品的稀有度顏色，因此建議使用透明背景。",
       "wrong_extension": "该文件的扩展名无效。",
       "invalid_files": "文件似乎无效或损坏，请检查并重试。",
       "missing_model_file": "找不到有效的模型文件。",


### PR DESCRIPTION
## Context

Analysis of 4,340 real wearable collection submissions shows that **thumbnail issues are the #2 curation-feedback reason (16.2% of collections)**. Mining the curators' forum shows the dominant sub-issue is by far a **non-transparent thumbnail background** — the marketplace renders the item's rarity color behind the thumbnail, so the background must be transparent for it to show through. Curators repeatedly say things like *"the thumbnail's background should be completely transparent."*

This is trivially detectable client-side and catching it before submission prevents a multi-day curation round-trip.

## Changes

- Add pure, dependency-light utils in `src/modules/media/utils.ts`:
  - `isRgbaBackgroundTransparent(rgba, width, height)` — samples the border ring of an RGBA buffer and decides the background is transparent when most border pixels are (near) fully transparent. Cheap and fully unit-tested.
  - `isPngBackgroundTransparent(blob)` — decodes a PNG via UPNG (already a dependency, no canvas needed) and delegates to the pure function. Any decode failure fails open (treated as transparent) so it can never block or wrongly warn.
- Wire a **non-blocking WARNING** into the Create Single Item flow: when a creator uploads a thumbnail whose background is not transparent, surface it through the existing `ValidationIssuesPanel` (same mechanism as GLB validation warnings). Submission is never blocked.
- The check runs against the resized 1024x1024 blob that is actually stored/uploaded, so the warning reflects the final thumbnail. The warning auto-clears whenever the thumbnail is replaced (manual upload, screenshot, or category regeneration).
- Confirm the auto-generated thumbnail stays transparent: `resizeImage` draws onto an unfilled canvas (alpha preserved) and the preview screenshot uses `disableBackground`. Added a guard comment to `resizeImage` so a future background fill isn't introduced by accident.
- Add `create_single_item_modal.error.thumbnail_not_transparent` to `en` / `es` / `zh` translations.

## Test plan

- [x] Unit tests for `isRgbaBackgroundTransparent` (transparent vs opaque border, alpha threshold boundary, mostly-transparent border, undersized/zero-dimension buffers) and `isPngBackgroundTransparent` (transparent, opaque, no-frame, decode-throws).
- [x] `lint` and `build` (tsc) pass.
- [ ] Manual: upload an opaque-background PNG thumbnail -> warning appears; upload a transparent PNG -> no warning; switch back -> warning clears.