### PR TITLE
chore: bump decentraland-dapps so pegged listings can be cancelled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "decentraland-builder-scripts": "^0.24.0",
         "decentraland-connect": "^12.0.0",
         "decentraland-crypto-fetch": "^2.0.1",
-        "decentraland-dapps": "^29.3.0",
+        "decentraland-dapps": "^29.3.1-20260805170817.commit-f4ffa6a",
         "decentraland-ecs": "6.12.4-7784644013.commit-f770b3e",
         "decentraland-experiments": "^1.0.2",
         "decentraland-transactions": "^3.0.2",
@@ -19037,9 +19037,9 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "29.3.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-29.3.0.tgz",
-      "integrity": "sha512-oRPzWYUcSQtijnXXDFC1UmTBmP3x+/O5Ec0OQ2xjwEFtNX45sioPP/9CRiiJ38cAPX3lol0YfHQNDgOcLtviFw==",
+      "version": "29.3.1-20260805170817.commit-f4ffa6a",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-29.3.1-20260805170817.commit-f4ffa6a.tgz",
+      "integrity": "sha512-tXPxJJ8X5TRo3x/nftIrBx88msQEsr84hMA6peJs2JdJug1GCvmRna72MgNmvuZeboM0+laxMkTAedcVHltY6w==",
       "dependencies": {
         "@0xsequence/multicall": "0.25.1",
         "@0xsequence/relayer": "0.25.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "decentraland-builder-scripts": "^0.24.0",
     "decentraland-connect": "^12.0.0",
     "decentraland-crypto-fetch": "^2.0.1",
-    "decentraland-dapps": "^29.3.0",
+    "decentraland-dapps": "^29.3.1-20260805170817.commit-f4ffa6a",
     "decentraland-ecs": "6.12.4-7784644013.commit-f770b3e",
     "decentraland-experiments": "^1.0.2",
     "decentraland-transactions": "^3.0.2",


### PR DESCRIPTION
A creator cannot remove their own USD-pegged listing from the Builder. Observed on `.zone`:

```
Invalid asset type: { assetType: 2, amount: '500000000000000000', … }
  at getValueForTradeAsset → generateTradeValues → getOnChainTrade → cancel

Error when removing order for item
invalid BigNumber string (argument="value", value="", code=INVALID_ARGUMENT, version=bignumber/5.8.0)
```

The whole of that stack lives in **decentraland-dapps** — this app has no copy of those helpers, it consumes
`TradeService`. `getValueForTradeAsset` had no case for `USD_PEGGED_MANA`, so it returned `''`, the rebuilt
trade struct hashed differently than the seller signed, and the on-chain signature check rejected the
cancellation.

Fixed in decentraland/decentraland-dapps#813. This bump is what actually delivers it here.

## Why the version is pinned to a commit build

`master` already declares `^29.3.0`, and the fix shipped as **`29.3.1-20260805170817.commit-f4ffa6a`** — a
prerelease. npm's caret ranges exclude prereleases unless the range itself carries one, so `^29.3.0` would
resolve to 29.3.0 and never pick this up. Worth stating plainly because the trap is quiet: npm's `latest` tag
is *also* still `29.3.0`, so `npm i decentraland-dapps@latest` would look like an upgrade and change nothing.

`f4ffa6a` is the merge commit of #813, and I verified the **published artifact** rather than trusting the
version string — `dist/lib/trades.js` in that tarball contains
`case TradeAssetType.USD_PEGGED_MANA: return asset.amount`.

## What this unblocks here

Removing a listing from the collection page and the item row, for a listing denominated in USD — which is what
every listing created from the shop is. MANA listings were never affected.

## Test plan

- [x] `tsc --noEmit` — **0 errors**, down from 3 on `master` before the bump (`Navbar`'s
      `showManaBalancesInNavbar`, `CreditsResponse.usd`, and the `BuilderAPI`/`BaseAPI` mismatch). Those were
      the builder's source already expecting 29's types while pinned lower; the bump resolves them rather than
      introducing anything.
- [x] `npm test` — 118 suites / 1536 passing
- [x] `npm run prebuild && npm run build:website` — clean
- [x] The diff touches **only** `decentraland-dapps` in `package.json` and the lockfile
- [ ] On `.zone`: cancel a pegged listing from the collection page, and confirm a MANA listing still cancels

## Note for sequencing

The **marketplace** needs the same bump: its accept and cancel also go through `TradeService`, so a pegged
listing there can be neither bought nor cancelled until it lands. decentraland/marketplace#2670 fixed that
repo's own copy of the helper, which feeds gas estimation and trade creation — not the accept path.