### PR TITLE
chore: bump decentraland-ui2 to 3.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "decentraland-experiments": "^1.0.2",
         "decentraland-transactions": "^3.0.2",
         "decentraland-ui": "^7.2.0",
-        "decentraland-ui2": "^3.15.0",
+        "decentraland-ui2": "^3.18.0",
         "ethers": "^5.6.8",
         "fast-equals": "^5.3.0",
         "file-saver": "^2.0.1",
@@ -19432,9 +19432,9 @@
       }
     },
     "node_modules/decentraland-ui2": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-3.15.0.tgz",
-      "integrity": "sha512-FrgTwh5XURVateMHR8GBWrjS3WtEl1F5I+GjUl1+hJt7MPI4Lb6ZeHfGde3MezJxIV2BjdGuyR4TdJ1CwZMaDQ==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-3.18.0.tgz",
+      "integrity": "sha512-NG+lyvB3BDYveEJ8ynwpMPWGX+C7prhv8utYA5bOpErxZayoFxaROhzDSm7cs8YuY+2sEcSgHU2WMaISD1bCPg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "11.14.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "decentraland-experiments": "^1.0.2",
     "decentraland-transactions": "^3.0.2",
     "decentraland-ui": "^7.2.0",
-    "decentraland-ui2": "^3.15.0",
+    "decentraland-ui2": "^3.18.0",
     "ethers": "^5.6.8",
     "fast-equals": "^5.3.0",
     "file-saver": "^2.0.1",


### PR DESCRIPTION
Brings the navbar in line with the new shop. Part of the set that lets marketplace, builder and sites all point at it on release.

## Changes

- `decentraland-ui2` `^3.15.0` → `^3.18.0`. Only ui2 moves — no transitive changes.

What the navbar inherits: the **Explore** label (was "What's On"), the Shop menu pointing at `decentraland.org/shop` instead of the legacy marketplace, and the hexagonal **C** as the credits mark. LAND and Merch are unchanged.

## Notes

**Verified the bump actually reaches the navbar.** This app renders it through `decentraland-dapps`' `Navbar2` container, not a direct ui2 import, so dapps shipping its own nested copy of ui2 would have made this a PR that changes nothing visible. There is exactly **one** copy of ui2 in the tree (3.18.0) and dapps declares it as `peerDependency ^3.0.0`, so it resolves to this one.

Three minors, and the diff is ui2 alone, so this is the lower-risk of the two bumps — the marketplace one also moves `@dcl/schemas`.

## Test plan

- [x] `npm run lint`
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 118 suites / 1536 tests passing. A first run reported 2 suites failing with 0 failing tests; a second run was fully green, so that was flakiness under load, not the bump.
- [ ] Visual check on the preview: navbar reads "Explore", the Shop menu goes to `/shop`, credits mark is the C
- [ ] **Release timing:** merging is safe, but releasing points users at `/shop` — worth holding the release until the shop is live