### PR TITLE
feat: add shop announcement bar across the builder

### DIFF
--- a/src/components/AnnouncementBar/AnnouncementBar.module.css
+++ b/src/components/AnnouncementBar/AnnouncementBar.module.css
@@ -1,0 +1,124 @@
+.bar {
+  --announcement-bar-background: #691fa9;
+  --announcement-bar-color: #ffffff;
+
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 46px;
+  /* The ui2 navbar is fixed and 92px tall on desktop, but the container that
+     wraps it only reserves 66px, so the first 26px of the flow sit behind it.
+     Compensating here keeps the bar flush under the navbar instead of below it.
+     Under 992px the navbar is 64px tall and already fits in those 66px. */
+  margin-top: 26px;
+  /* Keeps the centered content from sliding under the absolutely positioned close button */
+  padding: 0 56px;
+  background-color: var(--announcement-bar-background);
+  color: var(--announcement-bar-color);
+  font-family: 'Inter', Helvetica, Arial, sans-serif;
+}
+
+.message {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 400;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.highlight {
+  font-weight: 600;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+  padding: 8px 11px;
+  border-radius: 6px;
+  color: var(--announcement-bar-color);
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 24px;
+  letter-spacing: 0.46px;
+  text-transform: uppercase;
+}
+
+.cta:hover {
+  background-color: rgba(255, 255, 255, 0.08);
+  color: var(--announcement-bar-color);
+}
+
+.ctaLabel {
+  text-decoration: underline;
+  white-space: nowrap;
+}
+
+.ctaIcon {
+  position: relative;
+  flex-shrink: 0;
+  width: 18px;
+  height: 22px;
+}
+
+.ctaIcon img {
+  position: absolute;
+  top: 5px;
+  left: 8.29px;
+  width: 7.41px;
+  height: 12px;
+}
+
+.close {
+  position: absolute;
+  top: 50%;
+  right: 29.23px;
+  transform: translateY(-50%);
+  width: 18.54px;
+  height: 18.54px;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.close img {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.close:focus-visible,
+.cta:focus-visible {
+  outline: 2px solid var(--announcement-bar-color);
+  outline-offset: 2px;
+}
+
+/* Mobile variant: the message keeps the row and wraps internally while the
+   call to action stays on the right. The bar is not dismissable here, the
+   design drops the close button below this breakpoint. */
+@media (max-width: 991px) {
+  .bar {
+    justify-content: flex-start;
+    margin-top: 0;
+    padding: 8px 0 8px 16px;
+  }
+
+  .message {
+    flex: 1 0 0;
+    min-width: 0;
+    font-size: 14px;
+    text-align: left;
+  }
+
+  .cta {
+    font-size: 13px;
+  }
+
+  .close {
+    display: none;
+  }
+}

--- a/src/components/AnnouncementBar/AnnouncementBar.tsx
+++ b/src/components/AnnouncementBar/AnnouncementBar.tsx
@@ -1,31 +1,28 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback } from 'react'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
 import { t, T } from 'decentraland-dapps/dist/modules/translation/utils'
 import { config } from 'config/index'
 import ArrowIcon from './images/arrow.svg'
 import CloseIcon from './images/close.svg'
+import { Props } from './AnnouncementBar.types'
 import styles from './AnnouncementBar.module.css'
 
 // Shared with the marketplace on purpose: both run on the same origin in
 // production, so dismissing the bar in one of them dismisses it everywhere.
 const ANNOUNCEMENT_BAR_KEY = 'shop-announcement-bar'
 
-const AnnouncementBar = () => {
-  const [isDismissed, setIsDismissed] = useState(() => localStorage.getItem(ANNOUNCEMENT_BAR_KEY) !== null)
+export const isAnnouncementBarDismissed = () => localStorage.getItem(ANNOUNCEMENT_BAR_KEY) !== null
 
+const AnnouncementBar = ({ onDismiss }: Props) => {
   const handleDismiss = useCallback(() => {
     localStorage.setItem(ANNOUNCEMENT_BAR_KEY, '1')
-    setIsDismissed(true)
     getAnalytics()?.track('Dismiss Shop Announcement Bar')
-  }, [])
+    onDismiss()
+  }, [onDismiss])
 
   const handleClick = useCallback(() => {
     getAnalytics()?.track('Click Shop Announcement Bar')
   }, [])
-
-  if (isDismissed) {
-    return null
-  }
 
   return (
     <aside className={styles.bar}>

--- a/src/components/AnnouncementBar/AnnouncementBar.tsx
+++ b/src/components/AnnouncementBar/AnnouncementBar.tsx
@@ -1,0 +1,51 @@
+import React, { useCallback, useState } from 'react'
+import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
+import { t, T } from 'decentraland-dapps/dist/modules/translation/utils'
+import { config } from 'config/index'
+import ArrowIcon from './images/arrow.svg'
+import CloseIcon from './images/close.svg'
+import styles from './AnnouncementBar.module.css'
+
+// Shared with the marketplace on purpose: both run on the same origin in
+// production, so dismissing the bar in one of them dismisses it everywhere.
+const ANNOUNCEMENT_BAR_KEY = 'shop-announcement-bar'
+
+const AnnouncementBar = () => {
+  const [isDismissed, setIsDismissed] = useState(() => localStorage.getItem(ANNOUNCEMENT_BAR_KEY) !== null)
+
+  const handleDismiss = useCallback(() => {
+    localStorage.setItem(ANNOUNCEMENT_BAR_KEY, '1')
+    setIsDismissed(true)
+    getAnalytics()?.track('Dismiss Shop Announcement Bar')
+  }, [])
+
+  const handleClick = useCallback(() => {
+    getAnalytics()?.track('Click Shop Announcement Bar')
+  }, [])
+
+  if (isDismissed) {
+    return null
+  }
+
+  return (
+    <aside className={styles.bar}>
+      <p className={styles.message}>
+        <T
+          id="announcement_bar.message"
+          values={{ highlight: <span className={styles.highlight}>{t('announcement_bar.highlight')}</span> }}
+        />
+      </p>
+      <a className={styles.cta} href={config.get('SHOP_URL')} target="_blank" rel="noopener noreferrer" onClick={handleClick}>
+        <span className={styles.ctaLabel}>{t('announcement_bar.cta')}</span>
+        <span className={styles.ctaIcon}>
+          <img src={ArrowIcon} alt="" />
+        </span>
+      </a>
+      <button type="button" className={styles.close} onClick={handleDismiss} aria-label={t('announcement_bar.dismiss')}>
+        <img src={CloseIcon} alt="" />
+      </button>
+    </aside>
+  )
+}
+
+export default React.memo(AnnouncementBar)

--- a/src/components/AnnouncementBar/AnnouncementBar.types.ts
+++ b/src/components/AnnouncementBar/AnnouncementBar.types.ts
@@ -1,0 +1,3 @@
+export type Props = {
+  onDismiss: () => void
+}

--- a/src/components/AnnouncementBar/images/arrow.svg
+++ b/src/components/AnnouncementBar/images/arrow.svg
@@ -1,0 +1,3 @@
+<svg preserveAspectRatio="none" overflow="visible" style="display: block;" width="7.41" height="12" viewBox="0 0 7.41 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="Vector" d="M1.41 0L0 1.41L4.58 6L0 10.59L1.41 12L7.41 6L1.41 0Z" fill="white"/>
+</svg>

--- a/src/components/AnnouncementBar/images/close.svg
+++ b/src/components/AnnouncementBar/images/close.svg
@@ -1,0 +1,12 @@
+<svg preserveAspectRatio="none" overflow="visible" style="display: block;" width="18.5352" height="18.5352" viewBox="0 0 18.5352 18.5352" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="CTAX">
+<g id="Stroke 3">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M13.5352 3L2.53516 14Z" fill="white" fill-opacity="0.1"/>
+<path d="M13.5352 3L2.53516 14" stroke="#ECEBED" stroke-width="1.39014" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<g id="Stroke 4">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M13.5352 14L2.53516 3Z" fill="white" fill-opacity="0.1"/>
+<path d="M13.5352 14L2.53516 3" stroke="#ECEBED" stroke-width="1.39014" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</g>
+</svg>

--- a/src/components/AnnouncementBar/index.ts
+++ b/src/components/AnnouncementBar/index.ts
@@ -1,0 +1,2 @@
+import AnnouncementBar from './AnnouncementBar'
+export default AnnouncementBar

--- a/src/components/AnnouncementBar/index.ts
+++ b/src/components/AnnouncementBar/index.ts
@@ -1,2 +1,3 @@
 import AnnouncementBar from './AnnouncementBar'
+export { isAnnouncementBarDismissed } from './AnnouncementBar'
 export default AnnouncementBar

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import { Navbar2 as BaseNavbar } from 'decentraland-dapps/dist/containers/Navbar'
 import { localStorageGetIdentity } from '@dcl/single-sign-on-client'
 import { config } from 'config/index'
-import AnnouncementBar from 'components/AnnouncementBar'
+import AnnouncementBar, { isAnnouncementBarDismissed } from 'components/AnnouncementBar'
 import { locations } from 'routing/locations'
 import { Props } from './Navbar.types'
 
@@ -12,6 +12,10 @@ const Navbar: React.FC<Props> = ({ address, ...props }: Props) => {
 
   // Credits and MANA balances are only relevant while publishing collections.
   const showBalances = useMemo(() => pathname.startsWith(locations.collections()), [pathname])
+
+  const [isAnnouncementBarVisible, setIsAnnouncementBarVisible] = useState(() => !isAnnouncementBarDismissed())
+
+  const handleAnnouncementBarDismiss = useCallback(() => setIsAnnouncementBarVisible(false), [])
 
   const identity = useMemo(() => {
     if (address) {
@@ -30,7 +34,10 @@ const Navbar: React.FC<Props> = ({ address, ...props }: Props) => {
   }, [])
 
   return (
-    <div style={{ marginBottom: 36 }}>
+    // The fixed navbar is taller than the space its own container reserves, so
+    // this gap is what keeps page content from sliding underneath it. The
+    // announcement bar already provides that separation while it is showing.
+    <div style={{ marginBottom: isAnnouncementBarVisible ? 0 : 36 }}>
       <BaseNavbar
         {...props}
         withChainSelector
@@ -41,7 +48,7 @@ const Navbar: React.FC<Props> = ({ address, ...props }: Props) => {
         identity={identity}
         onSignIn={handleOnSignIn}
       />
-      <AnnouncementBar />
+      {isAnnouncementBarVisible && <AnnouncementBar onDismiss={handleAnnouncementBarDismiss} />}
     </div>
   )
 }

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router-dom'
 import { Navbar2 as BaseNavbar } from 'decentraland-dapps/dist/containers/Navbar'
 import { localStorageGetIdentity } from '@dcl/single-sign-on-client'
 import { config } from 'config/index'
+import AnnouncementBar from 'components/AnnouncementBar'
 import { locations } from 'routing/locations'
 import { Props } from './Navbar.types'
 
@@ -40,6 +41,7 @@ const Navbar: React.FC<Props> = ({ address, ...props }: Props) => {
         identity={identity}
         onSignIn={handleOnSignIn}
       />
+      <AnnouncementBar />
     </div>
   )
 }

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -2608,5 +2608,11 @@
   },
   "credits": {
     "value": "Credits Value"
+  },
+  "announcement_bar": {
+    "highlight": "Meet the new Decentraland Shop,",
+    "message": "{highlight} a simpler way to shop with Credits.",
+    "cta": "Try it now",
+    "dismiss": "Dismiss announcement"
   }
 }

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -2623,5 +2623,11 @@
       "action": "Poner a la venta",
       "confirm_transaction_title": "Poner a la venta"
     }
+  },
+  "announcement_bar": {
+    "highlight": "Descubre la nueva Decentraland Shop,",
+    "message": "{highlight} una forma más simple de comprar con Créditos.",
+    "cta": "Probar ahora",
+    "dismiss": "Cerrar anuncio"
   }
 }

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -2607,5 +2607,11 @@
       "action": "出售",
       "confirm_transaction_title": "出售"
     }
+  },
+  "announcement_bar": {
+    "highlight": "认识全新的 Decentraland Shop，",
+    "message": "{highlight}用 Credits 购物更简单。",
+    "cta": "立即体验",
+    "dismiss": "关闭公告"
   }
 }


### PR DESCRIPTION
## Changes

Brings the Shop announcement bar to the Builder, matching the one already merged in the Marketplace.

- New `AnnouncementBar` component, mounted inside `Navbar` rather than in a page layout. The Builder has no shared layout — each page renders `<Navbar />` on its own — so this is the single place that covers all of them.
- Dismissable, and the choice is persisted in `localStorage` under the same key the Marketplace uses. Both run on the same origin in production, so dismissing the bar in one dismisses it in the other. This is intentional and noted in the code.
- Reuses the existing `SHOP_URL` config entry, so no config changes.
- Copy added in the three supported locales (en / es / zh).
- Two Segment events: click and dismiss.

### Note on the vertical offset

The ui2 navbar is `position: fixed` and 92px tall on desktop, but the container that wraps it only reserves 66px of flow, so the first 26px of the bar would render behind it. The component offsets those 26px above `992px`, where the navbar shrinks to 64px and already fits in the reserved space. Both numbers were checked against the versions this repo pins (`decentraland-ui2@3.18.0`, `decentraland-dapps@29.3.1`).

## Test plan

- [ ] Check the bar on the Vercel preview: flush under the navbar, dismiss works, call to action opens the Shop in a new tab
- [ ] Check the mobile layout below `992px`
