### PR TITLE
feat: update the announcement bar copy

### DIFF
--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -2610,9 +2610,9 @@
     "value": "Credits Value"
   },
   "announcement_bar": {
-    "highlight": "Meet the new Decentraland Shop,",
-    "message": "{highlight} a simpler way to shop with Credits.",
-    "cta": "Try it now",
+    "highlight": "Meet the Decentraland Shop",
+    "message": "{highlight} - New Layout, New Outfits, and Meet the creators.",
+    "cta": "Try it out",
     "dismiss": "Dismiss announcement"
   }
 }

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -2625,9 +2625,9 @@
     }
   },
   "announcement_bar": {
-    "highlight": "Descubre la nueva Decentraland Shop,",
-    "message": "{highlight} una forma más simple de comprar con Créditos.",
-    "cta": "Probar ahora",
+    "highlight": "Conoce la Decentraland Shop",
+    "message": "{highlight} - Nuevo diseño, nuevos looks y conoce a los creadores.",
+    "cta": "Pruébalo",
     "dismiss": "Cerrar anuncio"
   }
 }

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -2609,9 +2609,9 @@
     }
   },
   "announcement_bar": {
-    "highlight": "认识全新的 Decentraland Shop，",
-    "message": "{highlight}用 Credits 购物更简单。",
-    "cta": "立即体验",
+    "highlight": "认识 Decentraland Shop",
+    "message": "{highlight} - 全新布局、全新穿搭，还可以认识创作者。",
+    "cta": "去看看",
     "dismiss": "关闭公告"
   }
 }


### PR DESCRIPTION
## Changes

Updates the announcement bar copy, in the three supported locales. Same change as decentraland/marketplace#2686, so both apps show the same message.

| | Before | After |
|---|---|---|
| Bold | Meet the new Decentraland Shop, | Meet the Decentraland Shop |
| Rest | a simpler way to shop with Credits. | - New Layout, New Outfits, and Meet the creators. |
| Call to action | Try it now | Try it out |

Locale files only — no component or layout changes. Does not overlap with #3468, which only touches the component.

## Test plan

- [ ] Check the bar on the preview at desktop and phone widths. In the Marketplace the line fits on one row down to 768px and wraps to three on a phone
- [ ] Confirm the copy reads as intended before merging
