### PR TITLE
chore: bump decentraland-transactions to 3.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "decentraland-dapps": "^29.7.0",
         "decentraland-ecs": "6.12.4-7784644013.commit-f770b3e",
         "decentraland-experiments": "^1.0.2",
-        "decentraland-transactions": "^3.0.2",
+        "decentraland-transactions": "^3.1.1",
         "decentraland-ui": "^7.2.0",
         "decentraland-ui2": "^3.22.1",
         "ethers": "^5.6.8",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "decentraland-dapps": "^29.7.0",
     "decentraland-ecs": "6.12.4-7784644013.commit-f770b3e",
     "decentraland-experiments": "^1.0.2",
-    "decentraland-transactions": "^3.0.2",
+    "decentraland-transactions": "^3.1.1",
     "decentraland-ui": "^7.2.0",
     "decentraland-ui2": "^3.22.1",
     "ethers": "^5.6.8",


### PR DESCRIPTION
## What

Bumps `decentraland-transactions` from 3.0.2 to 3.1.1, which registers the new off-chain marketplace stack deployed to Amoy and Sepolia: `OffChainMarketplaceV3`, `CouponManager` and `CollectionDiscountCoupon`.

## Why this is worth landing on its own

`TradeService` resolves a trade's contract by **address**, via `getContractName(trade.contract)` (`decentraland-dapps/dist/modules/trades/TradeService.js:20` for accept, `:26` for cancel), and `getContractName` throws when the address isn't in the registry. Builder's cancel flow goes straight through it (`src/modules/item/sagas.ts:920`).

So as soon as the backend records a trade against the new marketplace, accepting or cancelling it fails with `Could not get a valid contract name for address 0x36fd…` — with no Builder code change needed to trigger it. This bump alone fixes that, which is why it is split out from the V3 migration proper.

## Scope

Dependency-only: `package.json` and `package-lock.json`, one package changed. The 3.0.2 → 3.1.1 diff is additive — three new contract files, three registry entries, three `ContractName` members — with no existing contract entry, address or ABI touched.

Switching Builder's listing flow to V3 is separate and depends on decentraland/decentraland-dapps#819.

## Why 3.1.1 rather than 3.1.0

3.1.0's root entrypoint re-exported `./crossChain`, which imports `@0xsquid/sdk` — an **optional** peer dependency since 3.0.0. Builder does not install that peer, and `jest.config.ts` has no `@0xsquid` module mapper, so `require('decentraland-transactions')` threw:

```
Cannot find module '@0xsquid/sdk'
```

3.0.2 — what Builder pins today — did not have that root re-export; 3.0.3 reintroduced it. decentraland/decentraland-transactions#134 removed it again in 3.1.1, which is what this pins. I verified the root import resolves here with `@0xsquid` **not** installed, and `src/modules/collection/utils.spec.ts` passes (31 tests).
