### PR TITLE
fix: prevent putting sold-out items up for sale

### DIFF
--- a/src/components/CollectionDetailPage/CollectionItem/CollectionItem.tsx
+++ b/src/components/CollectionDetailPage/CollectionItem/CollectionItem.tsx
@@ -4,13 +4,13 @@ import { EmoteDataADR74, Network } from '@dcl/schemas'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { RarityBadge } from 'decentraland-dapps/dist/containers/RarityBadge'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
-import { Dropdown, Icon, Button, Mana, Table } from 'decentraland-ui'
+import { Dropdown, Icon, Button, Mana, Popup, Table } from 'decentraland-ui'
 import { Link, useHistory } from 'react-router-dom'
 import { locations } from 'routing/locations'
 import { preventDefault } from 'lib/event'
 import { formatCredits, formatCreditsFull, usdWeiToCredits } from 'lib/credits'
 import { extractThirdPartyTokenId, extractTokenId, isThirdParty } from 'lib/urn'
-import { isComplete, canManageItem, getMaxSupply, isSmart, isEmote, isFree } from 'modules/item/utils'
+import { isComplete, canManageItem, getMaxSupply, isItemSoldOut, isSmart, isEmote, isFree } from 'modules/item/utils'
 import { isEnableForSaleOffchain, isLocked, isOnSale } from 'modules/collection/utils'
 import { isEmoteData, SyncStatus, VIDEO_PATH, WearableData } from 'modules/item/types'
 import { FromParam } from 'modules/location/types'
@@ -47,6 +47,7 @@ export default function CollectionItem({
   const isUSDPeggedPrice = useTradePriceDenomination(item.tradeId) === PriceDenomination.USD_PEGGED
   const isOnSaleLegacy = wallet && isOnSale(collection, wallet)
   const isEnableForSaleOffchainMarketplace = wallet && isOffchainPublicItemOrdersEnabled && isEnableForSaleOffchain(collection, wallet)
+  const isSoldOut = isItemSoldOut(item)
   const shouldAllowPriceEdition =
     !isOffchainPublicItemOrdersEnabled || (isEnableForSaleOffchainMarketplace && item.tradeId) || isOnSaleLegacy
 
@@ -290,9 +291,18 @@ export default function CollectionItem({
       <Table.Cell>{renderItemStatus()}</Table.Cell>
       {isOffchainPublicItemOrdersEnabled && !isOnSaleLegacy && !item.tradeId && item.isPublished && (
         <Table.Cell>
-          <Button primary size="tiny" disabled={!isEnableForSaleOffchainMarketplace} onClick={handlePutForSale}>
-            {t('collection_item.put_for_sale')}
-          </Button>
+          <Popup
+            content={t('collection_item.sold_out')}
+            position="top center"
+            disabled={!isSoldOut}
+            trigger={
+              <span>
+                <Button primary size="tiny" disabled={!isEnableForSaleOffchainMarketplace || isSoldOut} onClick={handlePutForSale}>
+                  {t('collection_item.put_for_sale')}
+                </Button>
+              </span>
+            }
+          />
         </Table.Cell>
       )}
       {isOffchainPublicItemOrdersEnabled && item.tradeId && (

--- a/src/modules/item/utils.spec.ts
+++ b/src/modules/item/utils.spec.ts
@@ -1,4 +1,4 @@
-import { BodyShape, WearableCategory } from '@dcl/schemas'
+import { BodyShape, Rarity, WearableCategory } from '@dcl/schemas'
 import { Item, ItemMetadataType, ItemType, VIDEO_PATH, WearableRepresentation } from './types'
 import {
   buildItemMetadata,
@@ -24,7 +24,8 @@ import {
   isModelPath,
   stripRepresentationContents,
   stripWrappingFolder,
-  generateImage
+  generateImage,
+  isItemSoldOut
 } from './utils'
 import { compressPngBlob } from 'modules/media/utils'
 
@@ -979,6 +980,40 @@ describe('when generating the catalyst image', () => {
     it('should return the compressed image', async () => {
       const result = await generateImage(item, { thumbnail })
       expect(result).toBe(compressed)
+    })
+  })
+})
+
+describe('when checking if an item is sold out', () => {
+  let item: Item
+
+  describe('and the total supply is lower than the max supply for the rarity', () => {
+    beforeEach(() => {
+      item = { rarity: Rarity.EXOTIC, totalSupply: 10 } as Item
+    })
+
+    it('should return false', () => {
+      expect(isItemSoldOut(item)).toBe(false)
+    })
+  })
+
+  describe('and the total supply reached the max supply for the rarity', () => {
+    beforeEach(() => {
+      item = { rarity: Rarity.UNIQUE, totalSupply: 1 } as Item
+    })
+
+    it('should return true', () => {
+      expect(isItemSoldOut(item)).toBe(true)
+    })
+  })
+
+  describe('and the item has no total supply', () => {
+    beforeEach(() => {
+      item = { rarity: Rarity.UNIQUE } as Item
+    })
+
+    it('should return false', () => {
+      expect(isItemSoldOut(item)).toBe(false)
     })
   })
 })

--- a/src/modules/item/utils.spec.ts
+++ b/src/modules/item/utils.spec.ts
@@ -1007,6 +1007,16 @@ describe('when checking if an item is sold out', () => {
     })
   })
 
+  describe('and the total supply exceeds the max supply for the rarity', () => {
+    beforeEach(() => {
+      item = { rarity: Rarity.UNIQUE, totalSupply: 5 } as Item
+    })
+
+    it('should return true', () => {
+      expect(isItemSoldOut(item)).toBe(true)
+    })
+  })
+
   describe('and the item has no total supply', () => {
     beforeEach(() => {
       item = { rarity: Rarity.UNIQUE } as Item
@@ -1014,6 +1024,16 @@ describe('when checking if an item is sold out', () => {
 
     it('should return false', () => {
       expect(isItemSoldOut(item)).toBe(false)
+    })
+  })
+
+  describe('and the item has no rarity', () => {
+    beforeEach(() => {
+      item = { totalSupply: 0 } as Item
+    })
+
+    it('should return true', () => {
+      expect(isItemSoldOut(item)).toBe(true)
     })
   })
 })

--- a/src/modules/item/utils.ts
+++ b/src/modules/item/utils.ts
@@ -470,6 +470,10 @@ export function canMintItem(collection: Collection, item: Item, address?: string
   )
 }
 
+export function isItemSoldOut(item: Item): boolean {
+  return (item.totalSupply || 0) >= getMaxSupply(item)
+}
+
 export function canManageItem(collection: Collection, item: Item, address?: string): boolean {
   return isOwner(item, address) || canManageCollectionItems(collection, address)
 }
@@ -1044,6 +1048,11 @@ export async function createItemOrderTrade(
 
   if (!item.isPublished) {
     return Promise.reject(new Error('Item is not published'))
+  }
+
+  // A public item order mints on purchase, and the marketplace rejects trades with 0 uses.
+  if (isItemSoldOut(item)) {
+    return Promise.reject(new Error(t('collection_item.sold_out_error')))
   }
 
   const tradeToSign: Omit<TradeCreation, 'signature'> = {

--- a/src/modules/translation/languages/en.json
+++ b/src/modules/translation/languages/en.json
@@ -1819,7 +1819,9 @@
     "put_for_sale": "Put up for sale",
     "remove_from_sale": "Remove from sale",
     "cancel_order_error": "Error when removing order for item",
-    "on_sale_in_shop": "On sale in the shop"
+    "on_sale_in_shop": "On sale in the shop",
+    "sold_out": "This item is sold out, all its supply has already been minted",
+    "sold_out_error": "The item is sold out"
   },
   "collection": {
     "type": {

--- a/src/modules/translation/languages/es.json
+++ b/src/modules/translation/languages/es.json
@@ -1828,7 +1828,9 @@
     "put_for_sale": "Poner en venta",
     "remove_from_sale": "Eliminar de la venta",
     "cancel_order_error": "Error al eliminar el orden para el artículo",
-    "on_sale_in_shop": "En venta en el shop"
+    "on_sale_in_shop": "En venta en el shop",
+    "sold_out": "Este artículo está agotado, ya se acuñó todo su suministro",
+    "sold_out_error": "El artículo está agotado"
   },
   "collection": {
     "type": {

--- a/src/modules/translation/languages/zh.json
+++ b/src/modules/translation/languages/zh.json
@@ -1810,7 +1810,9 @@
     "put_for_sale": "出售",
     "remove_from_sale": "删除出售",
     "cancel_order_error": "删除项目订单时出错",
-    "on_sale_in_shop": "在商店出售"
+    "on_sale_in_shop": "在商店出售",
+    "sold_out": "该物品已售罄，所有供应量均已铸造",
+    "sold_out_error": "该物品已售罄"
   },
   "collection": {
     "type": {


### PR DESCRIPTION
## What

- The "Put up for sale" button is now disabled with a "sold out" tooltip for items whose entire supply has already been minted.
- If a sold-out item still reaches the listing flow, the signing step is rejected upfront with a clear "item is sold out" message instead of the server's generic error.

## Why

Putting a fully-minted item (e.g. a UNIQUE item minted once) up for sale always failed with an opaque "Invalid JSON body" error: a public item order mints on purchase, so the trade was signed with 0 uses, which the marketplace rejects during schema validation.

## How to test

1. In a published collection, find an item with all its supply minted (e.g. a UNIQUE item showing 1/1).
2. The "Put up for sale" button should be disabled, with a tooltip explaining the item is sold out.
3. An item with remaining supply can still be listed normally.

## Screenshots

<img width="1323" height="494" alt="image" src="https://github.com/user-attachments/assets/47aa3ecd-5a5b-4538-bd0d-546acabf8a95" />
