### PR TITLE
feat: load segment's analytics.js from a first party proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "decentraland-builder-scripts": "^0.24.0",
         "decentraland-connect": "^12.0.0",
         "decentraland-crypto-fetch": "^2.0.1",
-        "decentraland-dapps": "^29.3.1-20260805170817.commit-f4ffa6a",
+        "decentraland-dapps": "^29.4.0",
         "decentraland-ecs": "6.12.4-7784644013.commit-f770b3e",
         "decentraland-experiments": "^1.0.2",
         "decentraland-transactions": "^3.0.2",
@@ -19037,9 +19037,9 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "29.3.1-20260805170817.commit-f4ffa6a",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-29.3.1-20260805170817.commit-f4ffa6a.tgz",
-      "integrity": "sha512-tXPxJJ8X5TRo3x/nftIrBx88msQEsr84hMA6peJs2JdJug1GCvmRna72MgNmvuZeboM0+laxMkTAedcVHltY6w==",
+      "version": "29.4.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-29.4.0.tgz",
+      "integrity": "sha512-AwWUEOkrhq0WufoDacSSY1iLBmY+5Ddli4+H5Vc9iEV3v3o3XcC8ots1tdqKEj75PSKkOKFZkmXnVwYhW/bPJA==",
       "dependencies": {
         "@0xsequence/multicall": "0.25.1",
         "@0xsequence/relayer": "0.25.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "decentraland-builder-scripts": "^0.24.0",
     "decentraland-connect": "^12.0.0",
     "decentraland-crypto-fetch": "^2.0.1",
-    "decentraland-dapps": "^29.3.1-20260805170817.commit-f4ffa6a",
+    "decentraland-dapps": "^29.4.0",
     "decentraland-ecs": "6.12.4-7784644013.commit-f770b3e",
     "decentraland-experiments": "^1.0.2",
     "decentraland-transactions": "^3.0.2",

--- a/src/config/env/dev.json
+++ b/src/config/env/dev.json
@@ -18,6 +18,7 @@
   "SHARE_SCENE_URL": "https://share.decentraland.zone/b",
   "INTERCOM_APP_ID": "z0h94kay",
   "SEGMENT_API_KEY": "H21EgRI4eYwICDZf5uW6ek2BiykIR6wA",
+  "SEGMENT_ANALYTICS_URL": "https://evs.e.decentraland.org/z8jpJNrQbg/PbFpPU15ic.min.js",
   "ROLLBAR_ACCESS_TOKEN": "46e4b7e45c844b9ab81315c8b0919e99",
   "MANA_TOKEN_CONTRACT_ADDRESS": "0xfa04d2e2ba9aec166c93dfeeba7427b2303befa9",
   "LAND_REGISTRY_CONTRACT_ADDRESS": "0x42f4ba48791e2de32f5fbf553441c2672864bb33",

--- a/src/config/env/prod.json
+++ b/src/config/env/prod.json
@@ -18,6 +18,7 @@
   "SHARE_SCENE_URL": "https://share.decentraland.org/b",
   "INTERCOM_APP_ID": "z0h94kay",
   "SEGMENT_API_KEY": "ZxBQcII46wT0TURGQczWYK7tyBq8BEmt",
+  "SEGMENT_ANALYTICS_URL": "https://evs.e.decentraland.org/z8jpJNrQbg/cTZhpqvmud.min.js",
   "ROLLBAR_ACCESS_TOKEN": "46e4b7e45c844b9ab81315c8b0919e99",
   "MANA_TOKEN_CONTRACT_ADDRESS": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
   "LAND_REGISTRY_CONTRACT_ADDRESS": "0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d",

--- a/src/config/env/stg.json
+++ b/src/config/env/stg.json
@@ -18,6 +18,7 @@
   "SHARE_SCENE_URL": "https://share.decentraland.org/b",
   "INTERCOM_APP_ID": "z0h94kay",
   "SEGMENT_API_KEY": "H21EgRI4eYwICDZf5uW6ek2BiykIR6wA",
+  "SEGMENT_ANALYTICS_URL": "https://evs.e.decentraland.org/z8jpJNrQbg/PbFpPU15ic.min.js",
   "ROLLBAR_ACCESS_TOKEN": "46e4b7e45c844b9ab81315c8b0919e99",
   "MANA_TOKEN_CONTRACT_ADDRESS": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
   "LAND_REGISTRY_CONTRACT_ADDRESS": "0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d",

--- a/src/modules/common/store.ts
+++ b/src/modules/common/store.ts
@@ -142,7 +142,10 @@ const { storageMiddleware, loadStorageMiddleware } = createStorageMiddleware({
   }
 })
 const transactionMiddleware = createTransactionMiddleware()
-const analyticsMiddleware = isTestEnv ? null : createAnalyticsMiddleware(config.get('SEGMENT_API_KEY'))
+// analytics.js is served from a first party proxy where configured, ad blockers drop the requests to Segment's CDN
+const analyticsMiddleware = isTestEnv
+  ? null
+  : createAnalyticsMiddleware(config.get('SEGMENT_API_KEY'), { analyticsUrl: config.get('SEGMENT_ANALYTICS_URL', '') || undefined })
 
 const middlewares = [sagasMiddleware, loggerMiddleware, storageMiddleware, analyticsMiddleware, transactionMiddleware].filter(
   mdw => mdw !== null


### PR DESCRIPTION
Ad blockers drop the requests to `cdn.segment.com`, so those sessions load no analytics.js and send no events. `decentraland-dapps` 29.4.0 lets the dapp choose where the bundle comes from, so point every environment at our first party proxy. Same change the marketplace got in decentraland/marketplace#2680.

`dev` and `stg` share a Segment source, so they take the same bundle url; `prod` has its own. The write key each environment sends is unchanged, only the bundle host changes.

How to test: run the app and check the network tab, `analytics.js` loads from `evs.e.decentraland.org` instead of `cdn.segment.com`, and events keep landing in the same Segment source. With an ad blocker on, the bundle now loads where before it was blocked.

Verified against the proxy before wiring it up:

* Both bundles respond 200, and the write key each one embeds in `window.analyticsWriteKey` matches `SEGMENT_API_KEY` for the environments pointing at it (zone and prod resolve to different sources, so there is no cross posting).
* `analytics.load()` still decides the write key, the bundle resolves `_writeKey` before its embedded one.
* The proxy also serves `/v1/projects/<write key>/settings` for both sources, which matters because the snippet resolves `analytics._cdn` from the bundle's origin.

The dapps bump touches only the four `decentraland-dapps` lines in the lockfile. Running `npm install` on macOS also drops the 26 platform specific `@esbuild/*` entries, which would leave CI without its Linux binary, so those were kept as they were.

Not covered here: the inspector has its own Segment source and loads analytics inside the iframe, so `INSPECTOR_SEGMENT_API_KEY` is untouched. Events themselves still post to `api.segment.io`, which is not proxied.
