### PR TITLE
fix: install the contentful rich text renderer the ui2 banner needs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@babylonjs/core": "^4.2.0",
         "@babylonjs/loaders": "^4.2.0",
+        "@contentful/rich-text-react-renderer": "16.2.2",
         "@dcl/builder-client": "^6.1.1",
         "@dcl/builder-templates": "^0.2.0",
         "@dcl/content-hash-tree": "^1.1.3",
@@ -925,6 +926,31 @@
         "keccak": "^3.0.3",
         "preact": "^10.16.0",
         "sha.js": "^2.4.11"
+      }
+    },
+    "node_modules/@contentful/rich-text-react-renderer": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-16.2.2.tgz",
+      "integrity": "sha512-3hwKp+tYHRxKyzYTjFpwpI+laczYO1VS0sldSEVqPXfLcQnQabfUmYAL4dGtA35r2ce0+Wp4XVy9u4c7jxH20Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/rich-text-types": "^17.2.7"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@contentful/rich-text-types": {
+      "version": "17.2.7",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.2.7.tgz",
+      "integrity": "sha512-aIdozk8vk5gsYcallOrwEiL6+GSlMXZorDOmiVELfpbVaXMJPJPlf2CBw3LUzviAqCw0UPQcKHHCwG7SdY7u5w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@babylonjs/core": "^4.2.0",
     "@babylonjs/loaders": "^4.2.0",
+    "@contentful/rich-text-react-renderer": "16.2.2",
     "@dcl/builder-client": "^6.1.1",
     "@dcl/builder-templates": "^0.2.0",
     "@dcl/content-hash-tree": "^1.1.3",


### PR DESCRIPTION
The builder crashes with `TypeError: e.documentToReactComponents is not a function` whenever the campaign banner has rich text, taking down the page that renders it (`HomePage` and `CollectionsPage`, both in the `Navigation.container` chunk).

`decentraland-ui2` declares `@contentful/rich-text-react-renderer` as an optional peer dependency and its `Banner` loads it through a dynamic import. The builder never declared it, and Vite does not fail a build over a dynamic import it cannot resolve: it emits an empty module instead. The chunk shipped in the current deploy is literally `const e={};export{e as default};` (33 bytes), so `documentToReactComponents` is undefined at runtime. The marketplace already declares this dependency, which is why its banner renders.

Installing it is the whole fix. Same exact pin the marketplace uses.

How to test: build the app and check the lazy chunk the banner imports. It goes from the 33 byte stub to the real renderer (~10.8 KB, exporting `documentToReactComponents`), and a banner with rich text renders instead of crashing the page.

Worth knowing: the failure predates the deploy that surfaced it. The empty chunk is byte identical in the builds of the last few commits, it only crashes once a campaign with a `text` field is live, so any environment with such a campaign hits it.
