### PR TITLE
fix: drop the local navbar height compensation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "decentraland-builder-scripts": "^0.24.0",
         "decentraland-connect": "^12.0.0",
         "decentraland-crypto-fetch": "^2.0.1",
-        "decentraland-dapps": "^29.6.1",
+        "decentraland-dapps": "^29.6.2",
         "decentraland-ecs": "6.12.4-7784644013.commit-f770b3e",
         "decentraland-experiments": "^1.0.2",
         "decentraland-transactions": "^3.0.2",
@@ -18582,9 +18582,9 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-29.6.1.tgz",
-      "integrity": "sha512-dXVRKE6OnyOfCcK3Fq8CdDrfYHjDEBec1pW6XGkCuautPhYl0HeKttrwG+DZArQAAN1S4RO5FhXeJI8wweG0Og==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-29.6.2.tgz",
+      "integrity": "sha512-QaXplhNIegQvyHDDU3SaHFPGcJ/dCbezpx0ypgFKYiiXi3DRBTkqvuujd9/hbJpSOZkfHvF5LPtXRRd8C6KlhQ==",
       "dependencies": {
         "@0xsequence/multicall": "0.25.1",
         "@0xsequence/relayer": "0.25.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "decentraland-builder-scripts": "^0.24.0",
     "decentraland-connect": "^12.0.0",
     "decentraland-crypto-fetch": "^2.0.1",
-    "decentraland-dapps": "^29.6.1",
+    "decentraland-dapps": "^29.6.2",
     "decentraland-ecs": "6.12.4-7784644013.commit-f770b3e",
     "decentraland-experiments": "^1.0.2",
     "decentraland-transactions": "^3.0.2",

--- a/src/components/AnnouncementBar/AnnouncementBar.module.css
+++ b/src/components/AnnouncementBar/AnnouncementBar.module.css
@@ -8,11 +8,6 @@
   justify-content: center;
   gap: 8px;
   min-height: 46px;
-  /* The ui2 navbar is fixed and 92px tall on desktop, but the container that
-     wraps it only reserves 66px, so the first 26px of the flow sit behind it.
-     Compensating here keeps the bar flush under the navbar instead of below it.
-     Under 992px the navbar is 64px tall and already fits in those 66px. */
-  margin-top: 26px;
   /* Keeps the centered content from sliding under the absolutely positioned close button */
   padding: 0 56px;
   background-color: var(--announcement-bar-background);

--- a/src/components/AnnouncementBar/AnnouncementBar.module.css
+++ b/src/components/AnnouncementBar/AnnouncementBar.module.css
@@ -98,7 +98,6 @@
 @media (max-width: 991px) {
   .bar {
     justify-content: flex-start;
-    margin-top: 0;
     padding: 8px 0 8px 16px;
   }
 

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -34,10 +34,7 @@ const Navbar: React.FC<Props> = ({ address, ...props }: Props) => {
   }, [])
 
   return (
-    // The fixed navbar is taller than the space its own container reserves, so
-    // this gap is what keeps page content from sliding underneath it. The
-    // announcement bar already provides that separation while it is showing.
-    <div style={{ marginBottom: isAnnouncementBarVisible ? 0 : 36 }}>
+    <div>
       <BaseNavbar
         {...props}
         withChainSelector


### PR DESCRIPTION
Takes `decentraland-dapps` to `^29.6.2` and removes the local margin this repo was carrying to work around a library bug that is now fixed.

### What this removes

`AnnouncementBar.module.css` had:

```css
/* The ui2 navbar is fixed and 92px tall on desktop, but the container that
   wraps it only reserves 66px, so the first 26px of the flow sit behind it.
   Compensating here keeps the bar flush under the navbar instead of below it.
   Under 992px the navbar is 64px tall and already fits in those 66px. */
margin-top: 26px;
```

The comment described the bug exactly, and it is fixed at the source: decentraland/decentraland-dapps#822, shipped in 29.6.2, makes `Navbar2`'s container track the bar's real heights (64px below 992px, 92px above) instead of a flat 66px. Keeping the margin on top of the corrected container would push the bar 26px too far down.

marketplace carried its own version of the same patch, a 36px margin with a rule to cancel it while its announcement bar showed, and it is removed in decentraland/marketplace#2688.

### Measured, at 1200px wide

| | Before | After |
| --- | --- | --- |
| Container reserves | 66px | 92px |
| Announcement bar `margin-top` | 26px | 0 |
| Announcement bar top edge | 92px | 92px |

The bar lands in exactly the same place; the 26px it needed now comes from the container instead of from here. No visual change is expected from this PR, which is the point.

### How to test

`npm ci && npm run check:code && npm run build && npm test`, then in the running app at a desktop width:

```js
const nav = document.querySelector('nav')
nav.closest('div').getBoundingClientRect().height // 92, was 66
document.querySelector('aside[class*=_bar_]').getBoundingClientRect().top // still 92
```

Worth a look below 992px too, where the bar is 64px and the container used to over-reserve by 2px.
