### PR TITLE
feat: attribute shop announcement bar clicks from the builder

### DIFF
--- a/src/components/AnnouncementBar/AnnouncementBar.spec.tsx
+++ b/src/components/AnnouncementBar/AnnouncementBar.spec.tsx
@@ -1,0 +1,112 @@
+import { MemoryRouter } from 'react-router-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
+import { t } from 'decentraland-dapps/dist/modules/translation/utils'
+import { config } from 'config'
+import AnnouncementBar, { CLICK_SHOP_ANNOUNCEMENT_BAR, DISMISS_SHOP_ANNOUNCEMENT_BAR, isAnnouncementBarDismissed } from './AnnouncementBar'
+
+jest.mock('decentraland-dapps/dist/modules/analytics/utils', () => ({
+  getAnalytics: jest.fn()
+}))
+
+const ANNOUNCEMENT_BAR_KEY = 'shop-announcement-bar'
+const PATH = '/scenes'
+
+const renderComponent = (onDismiss: () => void) =>
+  render(
+    <MemoryRouter initialEntries={[PATH]}>
+      <AnnouncementBar onDismiss={onDismiss} />
+    </MemoryRouter>
+  )
+
+describe('AnnouncementBar', () => {
+  let track: jest.Mock
+  let onDismiss: jest.Mock
+
+  beforeEach(() => {
+    track = jest.fn()
+    onDismiss = jest.fn()
+    ;(getAnalytics as jest.Mock).mockReturnValue({ track })
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    jest.clearAllMocks()
+  })
+
+  describe('when rendering the call to action', () => {
+    let link: HTMLElement
+
+    beforeEach(() => {
+      renderComponent(onDismiss)
+      link = screen.getByRole('link', { name: t('announcement_bar.cta') })
+    })
+
+    it('should point to the shop', () => {
+      expect(link).toHaveAttribute('href', expect.stringContaining(config.get('SHOP_URL')))
+    })
+
+    /**
+     * Untagged, a click from here reached the shop as anonymous traffic: the shop could not tell it apart
+     * from someone arriving on their own, so the bar looked unused while the marketplace one was measurable.
+     * `utm_source=builder` is what separates the two bars once the visitor is on the other side.
+     */
+    it('should tag the link so the shop can attribute the visit to this bar', () => {
+      expect(link.getAttribute('href')).toContain('utm_source=builder&utm_medium=announcement_bar&utm_campaign=shop_launch')
+    })
+
+    it('should open the shop in a new tab so the builder context is not lost', () => {
+      expect(link).toHaveAttribute('target', '_blank')
+    })
+  })
+
+  describe('when the user clicks the call to action', () => {
+    beforeEach(() => {
+      renderComponent(onDismiss)
+      fireEvent.click(screen.getByRole('link', { name: t('announcement_bar.cta') }))
+    })
+
+    it('should track the click with the app and the page it happened on', () => {
+      expect(track).toHaveBeenCalledWith(CLICK_SHOP_ANNOUNCEMENT_BAR, { source: 'builder', path: PATH })
+    })
+  })
+
+  describe('when the user dismisses the bar', () => {
+    beforeEach(() => {
+      renderComponent(onDismiss)
+      fireEvent.click(screen.getByRole('button', { name: t('announcement_bar.dismiss') }))
+    })
+
+    it('should notify the parent so it can reclaim the space', () => {
+      expect(onDismiss).toHaveBeenCalled()
+    })
+
+    it('should remember the dismissal so it stays hidden on the next visit', () => {
+      expect(isAnnouncementBarDismissed()).toBe(true)
+    })
+
+    it('should track the dismissal with the app and the page it happened on', () => {
+      expect(track).toHaveBeenCalledWith(DISMISS_SHOP_ANNOUNCEMENT_BAR, { source: 'builder', path: PATH })
+    })
+  })
+
+  describe('when it has not been dismissed', () => {
+    it('should report the bar as not dismissed', () => {
+      expect(isAnnouncementBarDismissed()).toBe(false)
+    })
+  })
+
+  /**
+   * The key is deliberately shared with the marketplace bar, which runs on the same origin in production,
+   * so a dismissal in either app hides both.
+   */
+  describe('when it was dismissed in a previous visit', () => {
+    beforeEach(() => {
+      localStorage.setItem(ANNOUNCEMENT_BAR_KEY, '1')
+    })
+
+    it('should report the bar as dismissed', () => {
+      expect(isAnnouncementBarDismissed()).toBe(true)
+    })
+  })
+})

--- a/src/components/AnnouncementBar/AnnouncementBar.tsx
+++ b/src/components/AnnouncementBar/AnnouncementBar.tsx
@@ -1,7 +1,8 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
+import { useLocation } from 'react-router-dom'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
 import { t, T } from 'decentraland-dapps/dist/modules/translation/utils'
-import { config } from 'config/index'
+import { config } from 'config'
 import ArrowIcon from './images/arrow.svg'
 import CloseIcon from './images/close.svg'
 import { Props } from './AnnouncementBar.types'
@@ -10,19 +11,38 @@ import styles from './AnnouncementBar.module.css'
 // Shared with the marketplace on purpose: both run on the same origin in
 // production, so dismissing the bar in one of them dismisses it everywhere.
 const ANNOUNCEMENT_BAR_KEY = 'shop-announcement-bar'
+const ANNOUNCEMENT_BAR_SOURCE = 'builder'
+
+export const CLICK_SHOP_ANNOUNCEMENT_BAR = 'Click Shop Announcement Bar'
+export const DISMISS_SHOP_ANNOUNCEMENT_BAR = 'Dismiss Shop Announcement Bar'
 
 export const isAnnouncementBarDismissed = () => localStorage.getItem(ANNOUNCEMENT_BAR_KEY) !== null
 
 const AnnouncementBar = ({ onDismiss }: Props) => {
+  const { pathname } = useLocation()
+
+  // The campaign params let the shop attribute what these visitors do after they
+  // land, which the click event alone cannot tell us. Without them a click from
+  // here arrives at the shop as untagged traffic, indistinguishable from someone
+  // who found it on their own — the marketplace bar tags its link the same way,
+  // and `utm_source` is what tells the two bars apart once they are there.
+  const shopUrl = useMemo(() => {
+    const url = new URL(config.get('SHOP_URL'))
+    url.searchParams.set('utm_source', ANNOUNCEMENT_BAR_SOURCE)
+    url.searchParams.set('utm_medium', 'announcement_bar')
+    url.searchParams.set('utm_campaign', 'shop_launch')
+    return url.toString()
+  }, [])
+
   const handleDismiss = useCallback(() => {
     localStorage.setItem(ANNOUNCEMENT_BAR_KEY, '1')
-    getAnalytics()?.track('Dismiss Shop Announcement Bar')
+    getAnalytics()?.track(DISMISS_SHOP_ANNOUNCEMENT_BAR, { source: ANNOUNCEMENT_BAR_SOURCE, path: pathname })
     onDismiss()
-  }, [onDismiss])
+  }, [onDismiss, pathname])
 
   const handleClick = useCallback(() => {
-    getAnalytics()?.track('Click Shop Announcement Bar')
-  }, [])
+    getAnalytics()?.track(CLICK_SHOP_ANNOUNCEMENT_BAR, { source: ANNOUNCEMENT_BAR_SOURCE, path: pathname })
+  }, [pathname])
 
   return (
     <aside className={styles.bar}>
@@ -32,7 +52,7 @@ const AnnouncementBar = ({ onDismiss }: Props) => {
           values={{ highlight: <span className={styles.highlight}>{t('announcement_bar.highlight')}</span> }}
         />
       </p>
-      <a className={styles.cta} href={config.get('SHOP_URL')} target="_blank" rel="noopener noreferrer" onClick={handleClick}>
+      <a className={styles.cta} href={shopUrl} target="_blank" rel="noopener noreferrer" onClick={handleClick}>
         <span className={styles.ctaLabel}>{t('announcement_bar.cta')}</span>
         <span className={styles.ctaIcon}>
           <img src={ArrowIcon} alt="" />


### PR DESCRIPTION
## Context

The shop announcement bar shipped in the builder and the marketplace within a minute of each other (#3470 here, decentraland/marketplace#2686 there), but only the marketplace one is measurable.

Measured on the warehouse since launch:

| | marketplace | builder |
| --- | --- | --- |
| UTM on the link | `utm_source=marketplace`, `utm_medium=announcement_bar`, `utm_campaign=shop_launch` | **none** |
| event properties | `{ source, path }` | **none** |
| attributed arrivals at the shop | 1 | **0, and unmeasurable** |

Without the campaign params a click from here lands on the shop as untagged traffic — indistinguishable from someone who found it on their own. So the builder half of this experiment is invisible: we cannot tell whether the bar is being ignored or simply not counted. And with no `source` on the events, the two bars cannot be told apart on the event side either, since both emit the same name.

The single attributed arrival on the marketplace side is worth knowing too: the bar looks close to unused on both apps. This PR is about being able to state that with evidence rather than assume it.

## Changes

- The CTA link carries `utm_source=builder`, `utm_medium=announcement_bar`, `utm_campaign=shop_launch`, matching the marketplace so the shop can attribute arrivals and tell the two bars apart.
- Click and dismiss events carry `{ source: 'builder', path }`, via `useLocation` — safe here because `Navbar`, where the bar is mounted, already uses it.
- Event names are exported constants instead of inline strings, so a test can assert on them.
- `config` is imported as `from 'config'` rather than `from 'config/index'`. Both resolve in the build, but only the first is in jest's `moduleNameMapper` (`^config$`), so the old form made the component untestable — and it is what 53 of the 56 imports in this repo already use.

## Test plan

New spec, mirroring the marketplace one — this component had no tests here.

- [x] The link points at the shop and carries the three campaign params.
- [x] It opens in a new tab, so the builder context is not lost.
- [x] Click and dismiss each track with `source: 'builder'` and the current path.
- [x] Dismissing notifies the parent and is remembered across visits, using the key shared with the marketplace bar (same origin in production, so dismissing either hides both).
- [x] `npx jest src/components/AnnouncementBar` — 9 passed. Prettier and eslint clean on both files.