### PR TITLE
fix: infinite render loop in the Intercom component

### DIFF
--- a/src/components/Intercom/Intercom.tsx
+++ b/src/components/Intercom/Intercom.tsx
@@ -13,9 +13,11 @@ export const Intercom: React.FC = () => {
   const analyticsReadyCallback = useCallback(() => {
     const dclAnonymousUserID = getAnonymousId()
     if (dclAnonymousUserID) {
-      setIntercomUserData({ ...intercomUserData, anon_id: dclAnonymousUserID })
+      // Bail out with the same reference when the id didn't change: returning a new object here
+      // re-triggers the effect below and loops render -> ready() -> setState forever.
+      setIntercomUserData(current => (current?.anon_id === dclAnonymousUserID ? current : { ...current, anon_id: dclAnonymousUserID }))
     }
-  }, [intercomUserData])
+  }, [])
 
   useEffect(() => {
     analytics?.ready(analyticsReadyCallback)


### PR DESCRIPTION
## What

- The app no longer re-renders in a permanent loop (~1,300 React commits/sec on every page) driven by the Intercom component.
- `Intercom('update')` is no longer spammed on every cycle, so the launcher stops rewriting its styles continuously and idle CPU usage drops back to zero.

## Why

The analytics-ready callback set a new state object on every invocation and was itself recreated whenever that state changed, so the effect re-registered it with `analytics.ready()` in an endless cycle. The bug was latent until #3475 moved analytics.js behind a first-party proxy: with the script no longer dropped by ad blockers, `ready()` fires reliably and the loop ignited for everyone. The callback is now stable and the state update bails out with the same reference when the anonymous id hasn't changed.

## How to test

1. Run the builder and open any page.
2. Open DevTools and inspect the Intercom launcher element (or watch the Performance or Task Manager panel).
3. Before: its `<style>` tag and attributes flash with updates continuously and React commits nonstop. After: the page is idle — no repeated mutations, no commits.
4. Verify Intercom still receives the Segment anonymous id (the messenger still boots with `anon_id` set).
