### PR TITLE
fix: map curation assignment responses to camelCase to avoid approving undefined collection id

### DIFF
--- a/src/lib/api/builder.spec.ts
+++ b/src/lib/api/builder.spec.ts
@@ -1,6 +1,8 @@
 import { Authorization } from './auth'
-import { BuilderAPI } from './builder'
+import { BuilderAPI, RemoteCollectionCuration } from './builder'
 import { Item } from 'modules/item/types'
+import { CollectionCuration } from 'modules/curations/collectionCuration/types'
+import { CurationStatus } from 'modules/curations/types'
 
 jest.mock('./auth')
 
@@ -121,6 +123,45 @@ describe('when saving item contents', () => {
       await mockBuilder.saveItemContents(item, contents)
       expect(BuilderAPI.prototype.request).toHaveBeenCalledWith('post', `/items/${item.id}/files`, { params: expect.any(FormData) })
       expect(BuilderAPI.prototype.request).toHaveBeenCalledWith('post', `/items/${item.id}/videos`, { params: expect.any(FormData) })
+    })
+  })
+})
+
+describe('when working with collection curations', () => {
+  const remoteCuration: RemoteCollectionCuration = {
+    id: 'curation-id',
+    collection_id: 'collection-id',
+    assignee: '0xassignee',
+    status: CurationStatus.PENDING,
+    created_at: new Date(100),
+    updated_at: new Date(200)
+  }
+  const expectedCuration: CollectionCuration = {
+    id: 'curation-id',
+    collectionId: 'collection-id',
+    assignee: '0xassignee',
+    status: CurationStatus.PENDING,
+    createdAt: 100,
+    updatedAt: 200
+  }
+
+  beforeEach(() => {
+    jest.spyOn(BuilderAPI.prototype, 'request').mockResolvedValue(remoteCuration)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('when pushing a curation', () => {
+    it('should return the curation with its properties mapped from the server response', async () => {
+      await expect(mockBuilder.pushCuration('collection-id', '0xassignee')).resolves.toEqual(expectedCuration)
+    })
+  })
+
+  describe('when updating a curation', () => {
+    it('should return the curation with its properties mapped from the server response', async () => {
+      await expect(mockBuilder.updateCuration('collection-id', { assignee: '0xassignee' })).resolves.toEqual(expectedCuration)
     })
   })
 })

--- a/src/lib/api/builder.ts
+++ b/src/lib/api/builder.ts
@@ -1041,8 +1041,12 @@ export class BuilderAPI extends BaseAPI {
     return fromRemoteCollectionCuration(curation)
   }
 
-  async pushCuration(collectionId: string, assignee?: string | null): Promise<void> {
-    return this.request('post', `/collections/${collectionId}/curation`, { params: { curation: { assignee } } }) as Promise<void>
+  async pushCuration(collectionId: string, assignee?: string | null): Promise<CollectionCuration> {
+    const curation: RemoteCollectionCuration = await this.request('post', `/collections/${collectionId}/curation`, {
+      params: { curation: { assignee } }
+    })
+
+    return fromRemoteCollectionCuration(curation)
   }
 
   async pushItemCuration(itemId: string): Promise<ItemCuration> {
@@ -1105,8 +1109,12 @@ export class BuilderAPI extends BaseAPI {
     return this.request('patch', `/collections/${collectionId}/curation`, { params: { curation: { status } } })
   }
 
-  async updateCuration(collectionId: string, curation: Partial<Pick<CollectionCuration, 'assignee' | 'status'>>) {
-    return this.request('patch', `/collections/${collectionId}/curation`, { params: { curation } })
+  async updateCuration(collectionId: string, curation: Partial<Pick<CollectionCuration, 'assignee' | 'status'>>): Promise<CollectionCuration> {
+    const updatedCuration: RemoteCollectionCuration = await this.request('patch', `/collections/${collectionId}/curation`, {
+      params: { curation }
+    })
+
+    return fromRemoteCollectionCuration(updatedCuration)
   }
 
   async updateItemCurationStatus(itemId: string, status: CurationStatus): Promise<ItemCuration> {

--- a/src/lib/api/builder.ts
+++ b/src/lib/api/builder.ts
@@ -1105,11 +1105,18 @@ export class BuilderAPI extends BaseAPI {
     return this.request('get', `/collections/${collectionId}/approvalData`) as Promise<ItemApprovalData>
   }
 
-  async updateCurationStatus(collectionId: string, status: CurationStatus) {
-    return this.request('patch', `/collections/${collectionId}/curation`, { params: { curation: { status } } })
+  async updateCurationStatus(collectionId: string, status: CurationStatus): Promise<CollectionCuration> {
+    const curation: RemoteCollectionCuration = await this.request('patch', `/collections/${collectionId}/curation`, {
+      params: { curation: { status } }
+    })
+
+    return fromRemoteCollectionCuration(curation)
   }
 
-  async updateCuration(collectionId: string, curation: Partial<Pick<CollectionCuration, 'assignee' | 'status'>>): Promise<CollectionCuration> {
+  async updateCuration(
+    collectionId: string,
+    curation: Partial<Pick<CollectionCuration, 'assignee' | 'status'>>
+  ): Promise<CollectionCuration> {
     const updatedCuration: RemoteCollectionCuration = await this.request('patch', `/collections/${collectionId}/curation`, {
       params: { curation }
     })

--- a/src/modules/collection/sagas.ts
+++ b/src/modules/collection/sagas.ts
@@ -1244,7 +1244,7 @@ export function* collectionSaga(legacyBuilderClient: BuilderAPI, client: Builder
         const curationsByCollectionId: Record<string, CollectionCuration> = yield select(getCurationsByCollectionId)
         const curation = curationsByCollectionId[collection.id]
         if (curation && curation.status === CurationStatus.PENDING) {
-          yield put(approveCollectionCurationRequest(curation.collectionId))
+          yield put(approveCollectionCurationRequest(collection.id))
 
           // wait for actions
           const { failure }: { success: ApproveCollectionCurationSuccessAction; failure: ApproveCollectionCurationFailureAction } =


### PR DESCRIPTION
## What

- Approving a collection no longer fails with `invalid input syntax for type uuid: "undefined"` after the curation was assigned or reassigned during the same session.
- The curation assignment API responses are now returned in the same shape as every other curation fetch, so the state no longer holds a malformed curation after assigning.

## Why

When a curator assigned a collection (e.g. to themselves) and later approved it without reloading the page, the approval flow sent the curation update to `/collections/undefined/curation`, surfacing a Postgres uuid error and aborting the flow — even though the item entities had already deployed successfully.

## How to test

1. As a curator, open the Curation page and assign a pending collection to yourself.
2. Without reloading, open the collection's review page and click Approve, completing the upload step.
3. The flow should reach the success screen and the curation should be approved, with no uuid error modal.