### PR TITLE
feat: sunset scene editor create/edit and redirect editor routes

### DIFF
--- a/src/components/SceneDetailPage/SceneDetailPage.tsx
+++ b/src/components/SceneDetailPage/SceneDetailPage.tsx
@@ -16,7 +16,7 @@ import './SceneDetailPage.css'
 import { useHistory } from 'react-router'
 
 const SceneDetailPage: React.FC<Props> = props => {
-  const { project, scene, isLoading, deployments, onOpenModal, onDelete, onLoadProjectScene } = props
+  const { project, scene, isLoading, deployments, onDelete, onLoadProjectScene } = props
   const [isDeleting, setIsDeleting] = useState(false)
   const history = useHistory()
 
@@ -38,10 +38,6 @@ const SceneDetailPage: React.FC<Props> = props => {
     return <NotFound />
   }
 
-  const handleEditClick = useCallback(() => {
-    onOpenModal('EditProjectModal')
-  }, [onOpenModal])
-
   const handleDeleteClick = useCallback(() => {
     setIsDeleting(true)
   }, [setIsDeleting])
@@ -54,10 +50,6 @@ const SceneDetailPage: React.FC<Props> = props => {
   const handleCancelDeleteProject = useCallback(() => {
     setIsDeleting(false)
   }, [setIsDeleting])
-
-  const handleEditScene = useCallback(() => {
-    history.push(scene?.sdk6 ? locations.sceneEditor(project?.id) : locations.inspector(project?.id))
-  }, [history, project, scene])
 
   const getSceneStatus = () => {
     const { project, isLoading, isLoadingDeployments } = props
@@ -85,10 +77,7 @@ const SceneDetailPage: React.FC<Props> = props => {
             <Column>
               <Row>
                 <Back absolute onClick={() => handleNavigate(locations.scenes())} />
-                <Header className="name">
-                  {project.title}
-                  <Icon name="edit outline" onClick={handleEditClick} />
-                </Header>
+                <Header className="name">{project.title}</Header>
               </Row>
             </Column>
             <Column className="actions" align="right">
@@ -96,10 +85,6 @@ const SceneDetailPage: React.FC<Props> = props => {
                 <Button inverted className="download-button" onClick={() => onOpenModal('ExportModal', { project })}>
                   <Icon name="download" />
                   {t('scene_detail_page.download_scene')}
-                </Button>
-                <Button primary className="edit-button" disabled={!scene} loading={!scene} onClick={handleEditScene}>
-                  <Icon name="edit outline" />
-                  {t('scene_detail_page.edit_scene')}
                 </Button>
                 <Dropdown
                   trigger={

--- a/src/components/ScenesPage/ScenesPage.tsx
+++ b/src/components/ScenesPage/ScenesPage.tsx
@@ -22,7 +22,6 @@ import LoadingPage from 'components/LoadingPage'
 import SyncToast from 'components/SyncToast'
 import { SortBy } from 'modules/ui/dashboard/types'
 import { NavigationTab } from 'components/Navigation/Navigation.types'
-import SceneCreationSelector from 'components/SceneCreationSelector'
 import { locations } from 'routing/locations'
 import { PaginationOptions } from 'routing/utils'
 import { Props, DefaultProps } from './ScenesPage.types'
@@ -80,7 +79,6 @@ const ScenesPage: React.FC<Props> = props => {
             )
           })}
         </span>
-        <SceneCreationSelector />
       </div>
     )
   }

--- a/src/routing/AppRoutes/AppRoutes.spec.tsx
+++ b/src/routing/AppRoutes/AppRoutes.spec.tsx
@@ -1,0 +1,37 @@
+import { createMemoryHistory, MemoryHistory } from 'history'
+import { Router } from 'react-router-dom'
+import { render } from '@testing-library/react'
+import { locations } from 'routing/locations'
+import { AppRoutes } from './AppRoutes'
+
+jest.mock('decentraland-dapps/dist/hooks/usePageTracking', () => ({
+  usePageTracking: jest.fn()
+}))
+jest.mock('components/LoadingPage', () => ({ __esModule: true, default: () => null }))
+jest.mock('components/MobilePage', () => ({ __esModule: true, default: () => null }))
+jest.mock('modules/ProtectedRoute', () => ({ ProtectedRoute: () => null }))
+
+const renderAt = (path: string): MemoryHistory => {
+  const history = createMemoryHistory({ initialEntries: [path] })
+  render(
+    <Router history={history}>
+      <AppRoutes onLocationChange={jest.fn()} />
+    </Router>
+  )
+  return history
+}
+
+describe('when visiting a sunset scene creation route on desktop', () => {
+  beforeEach(() => {
+    window.innerWidth = 1280
+  })
+
+  it.each([
+    locations.sceneEditor('aProjectId'),
+    locations.inspector('aProjectId'),
+    locations.templates(),
+    locations.templateDetail('aTemplateId')
+  ])('should redirect %s to the scenes list', path => {
+    expect(renderAt(path).location.pathname).toBe(locations.scenes())
+  })
+})

--- a/src/routing/AppRoutes/AppRoutes.tsx
+++ b/src/routing/AppRoutes/AppRoutes.tsx
@@ -13,8 +13,6 @@ const ScenesPage = React.lazy(() => import('components/ScenesPage'))
 const HomePage = React.lazy(() => import('components/HomePage'))
 const SignInPage = React.lazy(() => import('components/SignInPage'))
 const NotFoundPage = React.lazy(() => import('components/NotFoundPage'))
-const EditorPage = React.lazy(() => import('components/EditorPage'))
-const InspectorPage = React.lazy(() => import('components/InspectorPage'))
 const SceneListPage = React.lazy(() => import('components/SceneListPage'))
 const SceneViewPage = React.lazy(() => import('components/SceneViewPage'))
 const LandPage = React.lazy(() => import('components/LandPage'))
@@ -37,8 +35,6 @@ const CollectionDetailPage = React.lazy(() => import('components/CollectionDetai
 const ThirdPartyCollectionDetailPage = React.lazy(() => import('components/ThirdPartyCollectionDetailPage'))
 const ItemEditorPage = React.lazy(() => import('components/ItemEditorPage'))
 const CurationPage = React.lazy(() => import('components/CurationPage'))
-const TemplatesPage = React.lazy(() => import('components/TemplatesPage'))
-const TemplateDetailPage = React.lazy(() => import('components/TemplateDetailPage'))
 
 export const AppRoutes: React.FC<Props> = ({ onLocationChange }) => {
   usePageTracking()
@@ -63,8 +59,6 @@ export const AppRoutes: React.FC<Props> = ({ onLocationChange }) => {
         <Switch>
           <Route exact path={locations.root()} component={HomePage} />
           <Route exact path={locations.notFound()} component={NotFoundPage} />
-          <Route exact path={locations.sceneEditor()} component={EditorPage} />
-          <Route exact path={locations.inspector()} component={InspectorPage} />
           <Route exact path={locations.poolSearch()} component={SceneListPage} />
           <Route exact path={locations.sceneView()} component={SceneViewPage} />
           <Route exact path={locations.poolView()} component={SceneViewPage} />
@@ -79,8 +73,6 @@ export const AppRoutes: React.FC<Props> = ({ onLocationChange }) => {
           <Route exact path={locations.settings()} component={SettingsPage} />
           <ProtectedRoute exact path={locations.scenes()} component={ScenesPage} />
           <Route exact path={locations.sceneDetail()} component={SceneDetailPage} />
-          <Route exact path={locations.templates()} component={TemplatesPage} />
-          <Route exact path={locations.templateDetail()} component={TemplateDetailPage} />
           <Route exact key={1} path={locations.ens()} component={ENSListPage} />,
           <Route exact path={locations.ensDetail()} component={ENSDetailPage} />
           <Route exact key={3} path={locations.landSelectENS()} component={LandSelectENSPage} />,
@@ -93,6 +85,10 @@ export const AppRoutes: React.FC<Props> = ({ onLocationChange }) => {
           <Route exact key={4} path={locations.itemEditor()} component={ItemEditorPage} />,
           <Route exact key={5} path={locations.curation()} component={CurationPage} />
           <Route exact key={1} path={locations.thirdPartyCollectionDetail()} component={ThirdPartyCollectionDetailPage} />
+          <Redirect from={locations.sceneEditor()} to={locations.scenes()} />
+          <Redirect from={locations.inspector()} to={locations.scenes()} />
+          <Redirect from={locations.templates()} to={locations.scenes()} />
+          <Redirect from={locations.templateDetail()} to={locations.scenes()} />
           <Redirect to={locations.root()} />
         </Switch>
       </Responsive>


### PR DESCRIPTION
## Feature Description

First layer of the **web scene editor sunset**. The web builder no longer lets users create or edit scenes — creators move to the desktop **Creator Hub** (the in-app `CreatorHubUpgradeModal` already points there). This PR removes the create/edit entry points from the UI and hard-blocks the editor and template routes so bookmarked or pasted URLs can't reach them either. Downloading, deleting, and unpublishing scenes are unaffected.

## User Story

As a Decentraland creator, I can no longer create or edit scenes in the web builder (that capability moves to Creator Hub), but my existing scenes stay visible and their detail pages remain accessible so I can still download, unpublish, or delete them.

## Type of Change

- [x] New feature

## Implementation Details

Bottom of the sunset stack (base: `master`). Purely UI + routing; no data or redux changes.

### Architecture

The editor/template routes are removed from the desktop `<Switch>` in `AppRoutes` and replaced with `<Redirect>`s to `locations.scenes()`, placed before the catch-all so old URLs land on the scene list rather than the home page. The create/edit affordances are removed from the two pages that hosted them.

### Key Files Changed

| File | Change |
|------|--------|
| `src/routing/AppRoutes/AppRoutes.tsx` | Remove `EditorPage`/`InspectorPage`/`TemplatesPage`/`TemplateDetailPage` routes + lazy imports; add redirects for `/scene-editor`, `/inspector`, `/templates`, `/templates/:id` → `/scenes` |
| `src/components/ScenesPage/ScenesPage.tsx` | Remove the create-from-scratch/template selector from the empty state |
| `src/components/SceneDetailPage/SceneDetailPage.tsx` | Remove the "Edit scene" button and the title rename pencil (`EditProjectModal`); keep Download, Delete, Unpublish, deployments |
| `src/routing/AppRoutes/AppRoutes.spec.tsx` | New: assert each sunset route redirects to `/scenes` |

## API Changes

_No API changes._

## Database Changes

- [x] No database changes

## How to Test

1. Go to `/scenes` — the "create from scratch / from template" tiles are gone; the Creator Hub upgrade modal still opens.
2. Open a scene at `/scenes/:id` — no "Edit scene" button and no title pencil; Download, Delete, and Unpublish are still present and work.
3. Navigate directly to `/scene-editor/<id>`, `/inspector/<id>`, `/templates`, `/templates/<id>` — each redirects to `/scenes`.

### Edge Cases Considered

- Bookmarked/pasted editor and template URLs (incl. `:projectId`/`:templateId` params) redirect rather than 404 or fall through to the home page.
- Redirects are ordered before the catch-all so precedence is deterministic.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code
- [x] Added unit tests for new functionality (route redirects)
- [ ] Added integration tests where applicable
- [x] Existing tests pass locally (1588/1588)
- [ ] Updated documentation
- [ ] Tested on mobile (if UI change)
- [x] No new warnings or console errors introduced
- [x] Backwards compatible

## Feature Flag

- [x] No feature flag needed

## Related Issues

Part of the web scene editor sunset stack. Base branch: `master`. Followed by the viewer/Unity removal, inspector removal, migrate-on-download, and dead-code sweep.

## Screenshots / Demo

_UI removals + redirects; no new surface to show._

## Deployment Notes

_None._
