### PR TITLE
feat: send the analytics events through the first party proxy behind a kill switch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "decentraland-builder-scripts": "^0.24.0",
         "decentraland-connect": "^12.0.0",
         "decentraland-crypto-fetch": "^3.0.0",
-        "decentraland-dapps": "^29.7.0",
+        "decentraland-dapps": "^29.8.0",
         "decentraland-ecs": "6.12.4-7784644013.commit-f770b3e",
         "decentraland-experiments": "^1.0.2",
         "decentraland-transactions": "^3.1.1",
@@ -18365,9 +18365,9 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-29.7.0.tgz",
-      "integrity": "sha512-pXcr2Wx5aali68tzE1WKCtFIAN1eeh1oaFJUriixZXm3OmXBCcNqkXH+GOE5lwwESSuRho6ddyHrhDulqgf0dg==",
+      "version": "29.8.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-29.8.0.tgz",
+      "integrity": "sha512-bQWS2d4K76skULJpQE/Wc1LDmeJUEqB9pKmx9yTr+HkfcJrTpDSO81R732yM4hali/2+dajUSqeG7oN7FlL5Pg==",
       "dependencies": {
         "@0xsequence/multicall": "0.25.1",
         "@0xsequence/relayer": "0.25.1",
@@ -18377,7 +18377,7 @@
         "date-fns": "1.30.1",
         "dcl-catalyst-client": "^22.0.0",
         "decentraland-crypto-fetch": "^3.0.0",
-        "decentraland-transactions": "^3.0.2",
+        "decentraland-transactions": "^3.1.1",
         "events": "3.3.0",
         "eventsource": "3.0.7",
         "flat": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "decentraland-builder-scripts": "^0.24.0",
     "decentraland-connect": "^12.0.0",
     "decentraland-crypto-fetch": "^3.0.0",
-    "decentraland-dapps": "^29.7.0",
+    "decentraland-dapps": "^29.8.0",
     "decentraland-ecs": "6.12.4-7784644013.commit-f770b3e",
     "decentraland-experiments": "^1.0.2",
     "decentraland-transactions": "^3.1.1",

--- a/src/config/env/dev.json
+++ b/src/config/env/dev.json
@@ -19,6 +19,7 @@
   "INTERCOM_APP_ID": "z0h94kay",
   "SEGMENT_API_KEY": "H21EgRI4eYwICDZf5uW6ek2BiykIR6wA",
   "SEGMENT_ANALYTICS_URL": "https://evs.e.decentraland.org/z8jpJNrQbg/PbFpPU15ic.min.js",
+  "SEGMENT_API_HOST": "api.e.decentraland.org/v1",
   "ROLLBAR_ACCESS_TOKEN": "46e4b7e45c844b9ab81315c8b0919e99",
   "MANA_TOKEN_CONTRACT_ADDRESS": "0xfa04d2e2ba9aec166c93dfeeba7427b2303befa9",
   "LAND_REGISTRY_CONTRACT_ADDRESS": "0x42f4ba48791e2de32f5fbf553441c2672864bb33",

--- a/src/config/env/prod.json
+++ b/src/config/env/prod.json
@@ -19,6 +19,7 @@
   "INTERCOM_APP_ID": "z0h94kay",
   "SEGMENT_API_KEY": "ZxBQcII46wT0TURGQczWYK7tyBq8BEmt",
   "SEGMENT_ANALYTICS_URL": "https://evs.e.decentraland.org/z8jpJNrQbg/cTZhpqvmud.min.js",
+  "SEGMENT_API_HOST": "api.e.decentraland.org/v1",
   "ROLLBAR_ACCESS_TOKEN": "46e4b7e45c844b9ab81315c8b0919e99",
   "MANA_TOKEN_CONTRACT_ADDRESS": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
   "LAND_REGISTRY_CONTRACT_ADDRESS": "0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d",

--- a/src/config/env/stg.json
+++ b/src/config/env/stg.json
@@ -19,6 +19,7 @@
   "INTERCOM_APP_ID": "z0h94kay",
   "SEGMENT_API_KEY": "H21EgRI4eYwICDZf5uW6ek2BiykIR6wA",
   "SEGMENT_ANALYTICS_URL": "https://evs.e.decentraland.org/z8jpJNrQbg/PbFpPU15ic.min.js",
+  "SEGMENT_API_HOST": "api.e.decentraland.org/v1",
   "ROLLBAR_ACCESS_TOKEN": "46e4b7e45c844b9ab81315c8b0919e99",
   "MANA_TOKEN_CONTRACT_ADDRESS": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
   "LAND_REGISTRY_CONTRACT_ADDRESS": "0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d",

--- a/src/modules/analytics/proxy.spec.ts
+++ b/src/modules/analytics/proxy.spec.ts
@@ -1,0 +1,121 @@
+import { SEGMENT_KILL_SWITCH_KEY, getAnalyticsProxyOptions, persistSegmentKillSwitch } from './proxy'
+
+const analyticsUrl = 'https://evs.example.com/bundle.min.js'
+const apiHost = 'api.example.com/v1'
+const proxyOptions = { analyticsUrl, apiHost }
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('when getting the analytics proxy options', () => {
+  describe('and the kill switch was persisted as enabled', () => {
+    beforeEach(() => {
+      localStorage.setItem(SEGMENT_KILL_SWITCH_KEY, '1')
+    })
+
+    it('should return no options so the events go straight to Segment', () => {
+      expect(getAnalyticsProxyOptions(analyticsUrl, apiHost)).toBeUndefined()
+    })
+  })
+
+  describe('and the kill switch was persisted as disabled', () => {
+    beforeEach(() => {
+      localStorage.setItem(SEGMENT_KILL_SWITCH_KEY, '0')
+    })
+
+    it('should return the configured proxy options', () => {
+      expect(getAnalyticsProxyOptions(analyticsUrl, apiHost)).toEqual(proxyOptions)
+    })
+  })
+
+  describe('and nothing was persisted', () => {
+    it('should return the configured proxy options', () => {
+      expect(getAnalyticsProxyOptions(analyticsUrl, apiHost)).toEqual(proxyOptions)
+    })
+  })
+
+  describe('and a value other than the persisted ones is stored', () => {
+    beforeEach(() => {
+      localStorage.setItem(SEGMENT_KILL_SWITCH_KEY, 'true')
+    })
+
+    it('should return the configured proxy options', () => {
+      expect(getAnalyticsProxyOptions(analyticsUrl, apiHost)).toEqual(proxyOptions)
+    })
+  })
+
+  describe('and the proxy is not configured', () => {
+    it('should return no options', () => {
+      expect(getAnalyticsProxyOptions()).toBeUndefined()
+      expect(getAnalyticsProxyOptions('', '')).toBeUndefined()
+    })
+  })
+
+  describe('and only one of the proxy values is configured', () => {
+    it('should return the configured one', () => {
+      expect(getAnalyticsProxyOptions(analyticsUrl)).toEqual({ analyticsUrl })
+      expect(getAnalyticsProxyOptions(undefined, apiHost)).toEqual({ apiHost })
+    })
+  })
+
+  describe('and reading the persisted value throws', () => {
+    let getItem: jest.SpyInstance
+
+    beforeEach(() => {
+      getItem = jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+        throw new Error('Storage is not available')
+      })
+    })
+
+    afterEach(() => {
+      getItem.mockRestore()
+    })
+
+    it('should return the configured proxy options instead of dropping the tracking', () => {
+      expect(getAnalyticsProxyOptions(analyticsUrl, apiHost)).toEqual(proxyOptions)
+    })
+  })
+})
+
+describe('when persisting the kill switch value', () => {
+  describe('and the kill switch is enabled', () => {
+    it('should round trip to no proxy options', () => {
+      persistSegmentKillSwitch(true)
+
+      expect(localStorage.getItem(SEGMENT_KILL_SWITCH_KEY)).toBe('1')
+      expect(getAnalyticsProxyOptions(analyticsUrl, apiHost)).toBeUndefined()
+    })
+  })
+
+  describe('and the kill switch is disabled', () => {
+    beforeEach(() => {
+      localStorage.setItem(SEGMENT_KILL_SWITCH_KEY, '1')
+    })
+
+    it('should round trip to the configured proxy options', () => {
+      persistSegmentKillSwitch(false)
+
+      expect(localStorage.getItem(SEGMENT_KILL_SWITCH_KEY)).toBe('0')
+      expect(getAnalyticsProxyOptions(analyticsUrl, apiHost)).toEqual(proxyOptions)
+    })
+  })
+
+  describe('and writing the value throws', () => {
+    let setItem: jest.SpyInstance
+
+    beforeEach(() => {
+      setItem = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('Storage is not available')
+      })
+    })
+
+    afterEach(() => {
+      setItem.mockRestore()
+    })
+
+    it('should not throw', () => {
+      expect(() => persistSegmentKillSwitch(true)).not.toThrow()
+    })
+  })
+})

--- a/src/modules/analytics/proxy.ts
+++ b/src/modules/analytics/proxy.ts
@@ -1,0 +1,64 @@
+import { AnalyticsSnippetOptions } from 'decentraland-dapps/dist/modules/analytics/snippet'
+
+/**
+ * Last known value of the `dapps-seg-alt` kill switch. The analytics middleware is created while the store is built,
+ * long before the flags are fetched, so the value that arrives from the flag service is persisted here and the next
+ * boot decides with it.
+ *
+ * The key is shared with the other dapps on purpose: they all read the same flag and the switch has to mean the same
+ * thing everywhere.
+ */
+export const SEGMENT_KILL_SWITCH_KEY = 'dcl-analytics-seg-alt'
+
+const ENABLED = '1'
+const DISABLED = '0'
+
+/**
+ * The flag service only publishes enabled flags, so an absent flag and a disabled one are indistinguishable. That is
+ * what makes this a kill switch: anything other than an explicit "on" keeps the configured proxy, and a deploy while
+ * the flag is off changes nothing.
+ */
+function isKillSwitchEnabled(): boolean {
+  try {
+    return localStorage.getItem(SEGMENT_KILL_SWITCH_KEY) === ENABLED
+  } catch (_error) {
+    // Storage can be unavailable (private mode, blocked cookies). Losing the switch must not lose the tracking.
+    return false
+  }
+}
+
+/**
+ * Options the analytics middleware needs to route both the analytics.js bundle and the events through the first party
+ * proxy, or `undefined` when the kill switch is on or the proxy is not configured, which leaves Segment's own CDN and
+ * ingestion endpoint in place.
+ *
+ * @param analyticsUrl URL of the analytics.js bundle served by the proxy.
+ * @param apiHost Host the events are delivered to, without a protocol (`host/basePath`).
+ */
+export function getAnalyticsProxyOptions(analyticsUrl?: string, apiHost?: string): AnalyticsSnippetOptions | undefined {
+  if (isKillSwitchEnabled()) {
+    return undefined
+  }
+
+  const options: AnalyticsSnippetOptions = {}
+  if (analyticsUrl) {
+    options.analyticsUrl = analyticsUrl
+  }
+  if (apiHost) {
+    options.apiHost = apiHost
+  }
+
+  return Object.keys(options).length > 0 ? options : undefined
+}
+
+/**
+ * Stores the kill switch value so the next boot can honour it. Called every time the flags are fetched, never on a
+ * fetch failure: a flag service outage has to leave the last known value alone.
+ */
+export function persistSegmentKillSwitch(isEnabled: boolean): void {
+  try {
+    localStorage.setItem(SEGMENT_KILL_SWITCH_KEY, isEnabled ? ENABLED : DISABLED)
+  } catch (_error) {
+    // Same as above: an unavailable storage only costs the switch its persistence.
+  }
+}

--- a/src/modules/analytics/sagas.spec.ts
+++ b/src/modules/analytics/sagas.spec.ts
@@ -1,10 +1,14 @@
 import { expectSaga } from 'redux-saga-test-plan'
 import { call, select } from 'redux-saga/effects'
 import { getAddress } from 'decentraland-dapps/dist/modules/wallet/selectors'
+import { fetchApplicationFeaturesFailure, fetchApplicationFeaturesSuccess } from 'decentraland-dapps/dist/modules/features/actions'
+import { ApplicationFeatures, ApplicationName } from 'decentraland-dapps/dist/modules/features/types'
 import { Project } from 'modules/project/types'
 import { deployToWorldSuccess } from 'modules/deployment/actions'
 import { Deployment } from 'modules/deployment/types'
 import { getCurrentProject } from 'modules/project/selectors'
+import { getIsSegmentAltIngestionEnabled } from 'modules/features/selectors'
+import { persistSegmentKillSwitch } from './proxy'
 import { analyticsSaga, track } from './sagas'
 
 describe('when handling the deploy to world success action', () => {
@@ -79,5 +83,32 @@ describe('when handling the deploy to world success action', () => {
         .dispatch(deployToWorldSuccess({ world } as Deployment))
         .silentRun()
     })
+  })
+})
+
+describe('when handling the fetch application features success action', () => {
+  const features = {} as Record<ApplicationName, ApplicationFeatures>
+
+  describe.each([true, false])('and the segment alt ingestion flag is %s', isEnabled => {
+    it('should persist the kill switch value so the next boot honours it', () => {
+      return expectSaga(analyticsSaga)
+        .provide([
+          [select(getIsSegmentAltIngestionEnabled), isEnabled],
+          [call(persistSegmentKillSwitch, isEnabled), undefined]
+        ])
+        .call(persistSegmentKillSwitch, isEnabled)
+        .dispatch(fetchApplicationFeaturesSuccess([ApplicationName.DAPPS], features))
+        .silentRun()
+    })
+  })
+})
+
+describe('when handling the fetch application features failure action', () => {
+  it('should leave the persisted kill switch value alone', () => {
+    return expectSaga(analyticsSaga)
+      .provide([[select(getIsSegmentAltIngestionEnabled), false]])
+      .not.call(persistSegmentKillSwitch, false)
+      .dispatch(fetchApplicationFeaturesFailure([ApplicationName.DAPPS], 'anerror'))
+      .silentRun()
   })
 })

--- a/src/modules/analytics/sagas.ts
+++ b/src/modules/analytics/sagas.ts
@@ -2,6 +2,7 @@ import { takeLatest, select, all, call } from 'redux-saga/effects'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
 import { getAddress } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import { createAnalyticsSaga } from 'decentraland-dapps/dist/modules/analytics/sagas'
+import { FETCH_APPLICATION_FEATURES_SUCCESS } from 'decentraland-dapps/dist/modules/features/actions'
 
 import { OPEN_EDITOR, OpenEditorAction, TOGGLE_SNAP_TO_GRID, ToggleSnapToGridAction } from 'modules/editor/actions'
 import { getCurrentProject } from 'modules/project/selectors'
@@ -30,6 +31,8 @@ import {
 import { SEARCH_ASSETS, SearchAssetsAction } from 'modules/ui/sidebar/actions'
 import { getSideBarCategories, getSearch } from 'modules/ui/sidebar/selectors'
 import { Project } from 'modules/project/types'
+import { getIsSegmentAltIngestionEnabled } from 'modules/features/selectors'
+import { persistSegmentKillSwitch } from './proxy'
 import { trimAsset } from './track'
 import { SyncAction, SYNC } from 'modules/sync/actions'
 import { getLocalProjectIds } from 'modules/sync/selectors'
@@ -70,6 +73,7 @@ function* builderAnalyticsSaga() {
   yield takeLatest(DELETE_ASSET_PACK_FAILURE, handleDeleteAssetPackFailure)
   yield takeLatest(PUBLISH_THIRD_PARTY_ITEMS_SUCCESS, handlePublishTPItemSuccess)
   yield takeLatest(DEPLOY_TO_WORLD_SUCCESS, handleDeployToWorldSuccess)
+  yield takeLatest(FETCH_APPLICATION_FEATURES_SUCCESS, handleFetchApplicationFeaturesSuccess)
 }
 
 export function* analyticsSaga() {
@@ -78,6 +82,16 @@ export function* analyticsSaga() {
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-return
 export const track = (event: string, params: any) => getAnalytics()?.track(event, params)
+
+/**
+ * The analytics middleware is created while the store is built, before the flags are fetched, so the kill switch value
+ * is persisted here for the next boot to read. Only the success action is handled: a flag service outage has to leave
+ * the last known value alone instead of falling back to a default.
+ */
+function* handleFetchApplicationFeaturesSuccess() {
+  const isAltIngestionEnabled: boolean = yield select(getIsSegmentAltIngestionEnabled)
+  yield call(persistSegmentKillSwitch, isAltIngestionEnabled)
+}
 
 function handlePublishTPItemSuccess(action: PublishThirdPartyItemsSuccessAction) {
   const { items } = action.payload

--- a/src/modules/common/store.ts
+++ b/src/modules/common/store.ts
@@ -18,6 +18,7 @@ import { ContentfulClient, fetchCampaignRequest } from 'decentraland-dapps/dist/
 import { CreditsClient } from 'decentraland-dapps/dist/modules/credits/CreditsClient'
 import { fetcher } from 'decentraland-dapps/dist/lib/fetcher'
 
+import { getAnalyticsProxyOptions } from 'modules/analytics/proxy'
 import { PROVISION_SCENE, CREATE_SCENE } from 'modules/scene/actions'
 import { DEPLOY_TO_LAND_SUCCESS, CLEAR_DEPLOYMENT_SUCCESS } from 'modules/deployment/actions'
 import { SET_PROJECT, DELETE_PROJECT, CREATE_PROJECT, EDIT_PROJECT_THUMBNAIL } from 'modules/project/actions'
@@ -142,10 +143,14 @@ const { storageMiddleware, loadStorageMiddleware } = createStorageMiddleware({
   }
 })
 const transactionMiddleware = createTransactionMiddleware()
-// analytics.js is served from a first party proxy where configured, ad blockers drop the requests to Segment's CDN
+// Both analytics.js and the events it sends go through a first party proxy where configured, ad blockers drop the
+// requests to Segment's own CDN and ingestion endpoint. The `dapps-seg-alt` kill switch turns the proxy off.
 const analyticsMiddleware = isTestEnv
   ? null
-  : createAnalyticsMiddleware(config.get('SEGMENT_API_KEY'), { analyticsUrl: config.get('SEGMENT_ANALYTICS_URL', '') || undefined })
+  : createAnalyticsMiddleware(
+      config.get('SEGMENT_API_KEY'),
+      getAnalyticsProxyOptions(config.get('SEGMENT_ANALYTICS_URL', ''), config.get('SEGMENT_API_HOST', ''))
+    )
 
 const middlewares = [sagasMiddleware, loggerMiddleware, storageMiddleware, analyticsMiddleware, transactionMiddleware].filter(
   mdw => mdw !== null

--- a/src/modules/features/selectors.spec.ts
+++ b/src/modules/features/selectors.spec.ts
@@ -9,6 +9,7 @@ import {
   getIsMaintenanceEnabled,
   getIsOffchainPublicItemOrdersEnabled,
   getIsPublishCollectionsWertEnabled,
+  getIsSegmentAltIngestionEnabled,
   getIsSocialEmotesEnabled,
   getIsUnityWearablePreviewEnabled,
   getIsCreditsForCollectionsFeeEnabled,
@@ -83,7 +84,8 @@ const ffSelectors = [
   { selector: getIsUnityWearablePreviewEnabled, app: ApplicationName.DAPPS, feature: FeatureName.UNITY_WEARABLE_PREVIEW },
   { selector: getIsCreditsForCollectionsFeeEnabled, app: ApplicationName.BUILDER, feature: FeatureName.CREDITS_FOR_COLLECTIONS_FEE },
   { selector: getIsSocialEmotesEnabled, app: ApplicationName.DAPPS, feature: FeatureName.SOCIAL_EMOTES },
-  { selector: getIsCreditsPrimaryListingsEnabled, app: ApplicationName.BUILDER, feature: FeatureName.CREDITS_PRIMARY_LISTINGS }
+  { selector: getIsCreditsPrimaryListingsEnabled, app: ApplicationName.BUILDER, feature: FeatureName.CREDITS_PRIMARY_LISTINGS },
+  { selector: getIsSegmentAltIngestionEnabled, app: ApplicationName.DAPPS, feature: FeatureName.SEGMENT_ALT_INGESTION }
 ]
 
 ffSelectors.forEach(({ selector, app, feature }) => {

--- a/src/modules/features/selectors.ts
+++ b/src/modules/features/selectors.ts
@@ -108,6 +108,13 @@ export const getIsCreditsPrimaryListingsEnabled = (state: RootState) => {
   return false
 }
 
+export const getIsSegmentAltIngestionEnabled = (state: RootState) => {
+  if (hasLoadedInitialFlags(state)) {
+    return getIsFeatureEnabled(state, ApplicationName.DAPPS, FeatureName.SEGMENT_ALT_INGESTION)
+  }
+  return false
+}
+
 export const getIsSocialEmotesEnabled = (state: RootState) => {
   if (hasLoadedInitialFlags(state)) {
     return getIsFeatureEnabled(state, ApplicationName.DAPPS, FeatureName.SOCIAL_EMOTES)

--- a/src/modules/features/types.ts
+++ b/src/modules/features/types.ts
@@ -15,5 +15,7 @@ export enum FeatureName {
   SHOP_CREDITS_FOR_COLLECTIONS_FEE = 'shop-credits-for-collections-fee',
   UNITY_WEARABLE_PREVIEW = 'unity-wearable-preview',
   SOCIAL_EMOTES = 'social-emotes',
-  CREDITS_PRIMARY_LISTINGS = 'credits-primary-listings'
+  CREDITS_PRIMARY_LISTINGS = 'credits-primary-listings',
+  /** Kill switch for the first party analytics proxy: on means send the events straight to Segment. */
+  SEGMENT_ALT_INGESTION = 'seg-alt'
 }


### PR DESCRIPTION
Builder already loads `analytics.js` and its Segment settings from our first party proxy, but the events it produced still went to `api.segment.io`, which ad blockers drop just like `cdn.segment.com`. For a blocked user nothing was actually recovered: the bundle loaded and every event was then thrown away.

`decentraland-dapps@29.8.0` adds `apiHost` to the analytics snippet options (the ingestion host, no protocol, shaped `host/basePath`; it validates and normalizes the value and falls back to Segment's own ingestion when it is invalid). This passes `SEGMENT_API_HOST` alongside the existing `SEGMENT_ANALYTICS_URL`, so the events reach Segment through the same first party host. The value is `api.e.decentraland.org/v1` in the three environments, the same one decentraland.org has been running in production since Aug 19 without a regression (the client IP still reaches Segment, so `context_ip` is unaffected).

The whole proxy sits behind a kill switch shared with the other dapps: the `dapps-seg-alt` feature flag. On means send the analytics straight to Segment, ignoring both the proxy bundle URL and the proxy api host. Off or unknown means use the configured proxy, so merging this while the flag is off changes nothing about today's behaviour. Because the analytics middleware is created while the store is built and the flags only arrive later, the last known value is persisted in `localStorage` under `dcl-analytics-seg-alt` (`'1'` on, `'0'` off) every time the flags are fetched, and the next boot decides with it. Nothing is persisted on a fetch failure and every storage access is guarded, so a flag service outage or an unavailable storage can never disable the tracking.

How to test:

- With the flag off (its normal state), open the builder and check in the network tab that `analytics.js` is fetched from `evs.e.decentraland.org` and that the events are posted to `api.e.decentraland.org/v1/t`, not to `api.segment.io`. Confirm the events land in Segment.
- Enable `dapps-seg-alt` for the `dapps` application, reload twice (the first load persists the value, the second one applies it) and check the events go to `api.segment.io` again and the bundle to `cdn.segment.com`.
- Repeat the first step with an ad blocker enabled: the events should still be delivered.
- `npm run lint`, `npx tsc --noEmit` and `npm test` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDE5NS3oeKPcJWXbTTqSBx
