### PR TITLE
fix: fetch the third party on the collection detail page only after login

### DIFF
--- a/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.container.tsx
+++ b/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.container.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 import { getData as getWallet } from 'decentraland-dapps/dist/modules/wallet/selectors'
+import { isLoggedIn } from 'modules/identity/selectors'
 import { getData as getAuthorizations } from 'decentraland-dapps/dist/modules/authorization/selectors'
 import { openModal } from 'decentraland-dapps/dist/modules/modal/actions'
 import { RootState } from 'modules/common/types'
@@ -29,6 +30,7 @@ const ThirdPartyCollectionDetailPageContainer: React.FC = () => {
   const items = useSelector((state: RootState) => (collection ? getCollectionItems(state, collection.id) : []))
   const paginatedData = useSelector((state: RootState) => (collection && getPaginationData(state, collection.id)) || null)
   const wallet = useSelector(getWallet)!
+  const isUserLoggedIn = useSelector(isLoggedIn)
   const isThirdPartyV2Enabled = useSelector(getIsLinkedWearablesV2Enabled)
   const isLinkedWearablesPaymentsEnabled = useSelector(getIsLinkedWearablesPaymentsEnabled)
   const thirdParty = useSelector((state: RootState) =>
@@ -62,6 +64,7 @@ const ThirdPartyCollectionDetailPageContainer: React.FC = () => {
       currentPage={currentPage}
       paginatedData={paginatedData}
       wallet={wallet}
+      isLoggedIn={isUserLoggedIn}
       collection={collection}
       isThirdPartyV2Enabled={isThirdPartyV2Enabled}
       isLinkedWearablesPaymentsEnabled={isLinkedWearablesPaymentsEnabled}

--- a/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.tsx
+++ b/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.tsx
@@ -62,6 +62,7 @@ export default function ThirdPartyCollectionDetailPage({
   currentPage,
   lastLocation,
   wallet,
+  isLoggedIn,
   thirdParty,
   items,
   collection,
@@ -90,10 +91,10 @@ export default function ThirdPartyCollectionDetailPage({
   }, [thirdParty, isLoadingAvailableSlots, onFetchAvailableSlots])
 
   useEffect(() => {
-    if (!isLoading && !thirdParty && collection?.urn) {
+    if (isLoggedIn && !isLoading && !thirdParty && collection?.urn) {
       onFetchThirdParty(extractThirdPartyId(collection.urn))
     }
-  }, [collection?.urn, isLoading, thirdParty])
+  }, [collection?.urn, isLoading, thirdParty, isLoggedIn])
 
   useEffect(() => {
     // update the state if the page query param changes

--- a/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.types.ts
+++ b/src/components/ThirdPartyCollectionDetailPage/ThirdPartyCollectionDetailPage.types.ts
@@ -11,6 +11,7 @@ export const PAGE_SIZE = 50
 
 export type Props = {
   wallet: Wallet
+  isLoggedIn: boolean
   collection: Collection | null
   thirdParty: ThirdParty | null
   totalItems: number | null


### PR DESCRIPTION
## Description

Ensures the third-party collection detail page requests its third party only once the user is logged in, so the authenticated `GET /thirdParties/:id` call is not fired before a wallet is connected (which would otherwise produce a spurious unauthenticated request on a direct pre-login page load).

Companion to decentraland/builder-server#811, which requires authentication on `GET /thirdParties/:id`.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Infrastructure / CI/CD
- [ ] Performance improvement

## Changes Made

- Added `isLoggedIn` to the `ThirdPartyCollectionDetailPage` container.
- Gated the `fetchThirdParty` effect on `isLoggedIn` so it only runs once the wallet is connected.

## How to Test

1. `npx tsc --noEmit` — clean.
2. Open a third-party collection detail URL while logged out: no `GET /thirdParties/:id` request is fired; `SignInRequired` renders.
3. After connecting a wallet, the page fetches and renders the third party.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code for obvious errors
- [ ] Added or updated tests where applicable
- [x] Existing tests pass locally
- [ ] Updated documentation if needed
- [x] No new warnings or console errors introduced

## Related Issues

<!-- decentraland/builder-server#811 (companion) -->