### PR TITLE
fix: repair scene download and sync regressions from the editor sunset

### DIFF
--- a/src/modules/project/sagas.spec.ts
+++ b/src/modules/project/sagas.spec.ts
@@ -3,8 +3,17 @@ import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 import { AuthIdentity } from '@dcl/crypto'
 import { BuilderAPI } from 'lib/api/builder'
 import { loginSuccess } from 'modules/identity/actions'
-import { loadProjectsRequest } from './actions'
+import { toCrdt } from 'modules/inspector/utils'
+import { getSceneByProjectId } from 'modules/scene/utils'
+import { Scene } from 'modules/scene/types'
+import { exportProjectRequest, loadProjectsRequest } from './actions'
 import { projectSaga } from './sagas'
+import { Project } from './types'
+
+jest.mock('modules/scene/utils', () => ({ getSceneByProjectId: jest.fn() }))
+jest.mock('modules/inspector/utils', () => ({ toComposite: jest.fn(), toCrdt: jest.fn(), toMappings: jest.fn() }))
+jest.mock('./export', () => ({ createFiles: jest.fn(), createSDK7Files: jest.fn() }))
+jest.mock('lib/zip', () => ({ downloadZip: jest.fn() }))
 
 const builderAPI = {} as unknown as BuilderAPI
 
@@ -22,5 +31,32 @@ describe('when handling the loginSuccess action', () => {
       .put(loadProjectsRequest())
       .dispatch(loginSuccess(wallet, identity))
       .run({ silenceTimeout: true })
+  })
+})
+
+describe('when handling the exportProjectRequest action', () => {
+  let project: Project
+  let scene: Scene
+
+  beforeEach(() => {
+    project = { id: 'project-id', title: 'Project', layout: { rows: 2, cols: 3 } } as Project
+    scene = { sdk6: { id: 'scene-id', entities: {}, components: {}, assets: {} } } as unknown as Scene
+    ;(getSceneByProjectId as jest.Mock).mockReturnValue(scene)
+    ;(toCrdt as jest.Mock).mockReturnValue(new Uint8Array())
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('and the SDK6 scene is being migrated to SDK7', () => {
+    it('should build the crdt with the project so its layout matches the exported composite', () => {
+      return expectSaga(projectSaga, builderAPI)
+        .dispatch(exportProjectRequest(project, true))
+        .run({ silenceTimeout: true })
+        .then(() => {
+          expect(toCrdt).toHaveBeenCalledWith(scene.sdk6, project)
+        })
+    })
   })
 })

--- a/src/modules/project/sagas.ts
+++ b/src/modules/project/sagas.ts
@@ -91,7 +91,7 @@ export function* projectSaga(builder: BuilderAPI) {
         project,
         scene: sdk7Scene,
         builderAPI: builder,
-        crdt: new Blob([toCrdt(scene.sdk6) as Uint8Array<ArrayBuffer>])
+        crdt: new Blob([toCrdt(scene.sdk6, project) as Uint8Array<ArrayBuffer>])
       })
     } else if (scene.sdk6) {
       const author: string = yield select(getName)

--- a/src/modules/sync/sagas.spec.ts
+++ b/src/modules/sync/sagas.spec.ts
@@ -1,0 +1,54 @@
+import { expectSaga } from 'redux-saga-test-plan'
+import { select } from 'redux-saga/effects'
+import { BuilderAPI } from 'lib/api/builder'
+import { editProjectThumbnail } from 'modules/project/actions'
+import { getData as getProjects } from 'modules/project/selectors'
+import { Project } from 'modules/project/types'
+import { saveProjectSuccess } from './actions'
+import { syncSaga } from './sagas'
+import { saveThumbnail } from './utils'
+
+jest.mock('./utils', () => ({ ...jest.requireActual<object>('./utils'), saveThumbnail: jest.fn() }))
+
+const builderAPI = {} as unknown as BuilderAPI
+
+describe('when handling the saveProjectSuccess action', () => {
+  let project: Project
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('and the project has no thumbnail', () => {
+    beforeEach(() => {
+      project = { id: 'project-id', thumbnail: '' } as Project
+    })
+
+    it('should not save a thumbnail belonging to another project', () => {
+      return expectSaga(syncSaga, builderAPI)
+        .provide([[select(getProjects), { [project.id]: project }]])
+        .dispatch(saveProjectSuccess(project))
+        .dispatch(editProjectThumbnail('another-project-id', 'data:image/png;base64,other'))
+        .run({ silenceTimeout: true })
+        .then(() => {
+          expect(saveThumbnail).not.toHaveBeenCalled()
+        })
+    })
+  })
+
+  describe('and the project has a thumbnail', () => {
+    beforeEach(() => {
+      project = { id: 'project-id', thumbnail: 'https://thumbnail.com/thumb.png' } as Project
+    })
+
+    it('should save the thumbnail of the project', () => {
+      return expectSaga(syncSaga, builderAPI)
+        .provide([[select(getProjects), { [project.id]: project }]])
+        .dispatch(saveProjectSuccess(project))
+        .run({ silenceTimeout: true })
+        .then(() => {
+          expect(saveThumbnail).toHaveBeenCalledWith(project.id, project, builderAPI)
+        })
+    })
+  })
+})

--- a/src/modules/sync/sagas.ts
+++ b/src/modules/sync/sagas.ts
@@ -1,4 +1,4 @@
-import { takeLatest, select, put, call, takeEvery, take } from 'redux-saga/effects'
+import { takeLatest, select, put, call, takeEvery } from 'redux-saga/effects'
 import { isErrorWithMessage } from 'decentraland-dapps/dist/lib/error'
 import type { DataByKey } from 'decentraland-dapps/dist/lib/types'
 import { BuilderAPI } from 'lib/api/builder'
@@ -10,9 +10,7 @@ import {
   SET_PROJECT,
   SetProjectAction,
   DELETE_PROJECT,
-  DeleteProjectAction,
-  EDIT_PROJECT_THUMBNAIL,
-  EditProjectThumbnailAction
+  DeleteProjectAction
 } from 'modules/project/actions'
 import { getData as getProjects, getCurrentProject } from 'modules/project/selectors'
 import type { Project } from 'modules/project/types'
@@ -87,15 +85,8 @@ export function* syncSaga(builder: BuilderAPI) {
 
   function* handleSaveProjectSuccess(action: SaveProjectSuccessAction) {
     const projects: ReturnType<typeof getProjects> = yield select(getProjects)
-    let project = projects[action.payload.project.id]
-    if (!project) return
-    if (!project.thumbnail) {
-      const action: EditProjectThumbnailAction = yield take(EDIT_PROJECT_THUMBNAIL)
-      project = {
-        ...project,
-        thumbnail: action.payload.thumbnail
-      }
-    }
+    const project = projects[action.payload.project.id]
+    if (!project?.thumbnail) return
     try {
       saveThumbnail(project.id, project, builder)
     } catch (e) {


### PR DESCRIPTION
## Description

Fixes two correctness regressions introduced by the scene-editor sunset stack, both surfaced by an xhigh review. Bug fixes only — the related dead code is removed in the follow-up PR.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Refactoring (no functional changes)

## Changes Made

**1. Convert-on-download made a wrong CRDT for multi-parcel scenes** (`modules/project/sagas.ts`).
`handleExportProject` built the SDK7 composite with the project (`toComposite(sdk6, project)`) but the CRDT without it (`toCrdt(sdk6)`), so `getEngine` fell back to a single `[{x:0,y:0}]` parcel. For any SDK6 scene larger than 1×1, the downloaded `main.crdt` encoded a 1-parcel layout that disagreed with `main.composite`/`scene.json`. Fix: pass `project` to `toCrdt`.

**2. Retry-sync could hang on thumbnail-less projects** (`modules/sync/sagas.ts`).
`handleSaveProjectSuccess` waited on `take(EDIT_PROJECT_THUMBNAIL)`, whose only producer was the deleted editor screenshot pipeline — so a thumbnail-less project (reachable via the live `SyncToast` retry) blocked forever and never reached `saveThumbnail`. Fix: drop the dead wait; `if (!project?.thumbnail) return`, otherwise save.

## How to Test

1. Convert-download a 2×N SDK6 scene → the exported `main.crdt` layout matches `main.composite` (test added asserting `toCrdt` receives the project).
2. Retry a failed sync on a project with no thumbnail → `handleSaveProjectSuccess` completes instead of hanging (test added).
3. `npx tsc --noEmit` clean; `npx jest` green (1568/1568).

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code
- [x] Added unit tests for the fixes (both shown failing before, passing after — TDD)
- [x] Existing tests pass locally
- [x] No new warnings or console errors introduced

## Related Issues

Sunset stack, base `sunset/9-review-followups`. Fixes regressions found reviewing PRs #3491 (migrate-on-download) and the editor removal.
