### PR TITLE
fix: run the campaign banner edge to edge without upscaling the art

### DIFF
--- a/src/components/CampaignBanner/CampaignBanner.module.css
+++ b/src/components/CampaignBanner/CampaignBanner.module.css
@@ -18,10 +18,16 @@
    layers pick the URL up from the container with `background-image: inherit`. */
 
 .banner {
-  /* Out to the window edges. Both pages that show a banner sit inside a 24px page gutter - the homepage
-     from `.dcl.page.fullscreen` (index.css), the collections page from `.dcl.page.LoggedInDetailPage` -
-     and unlike the marketplace that gutter stays put on mobile, so this needs no breakpoint. */
-  margin-inline: -24px;
+  /* The gutter of the page hosting the banner: both pages that show one indent their content by 24px - the
+     homepage through `.dcl.page.fullscreen` (index.css), the collections page through
+     `.dcl.page.LoggedInDetailPage.CollectionsPage` - and unlike the marketplace that gutter stays put on
+     mobile, so this needs no breakpoint. It is a variable because the value is needed twice, pulling in
+     opposite directions: out here to reach the window edges, back in below to put the copy on the page's
+     content line. A page with a different gutter only has to override this one declaration. */
+  --page-gutter: 24px;
+
+  /* Out to the window edges. */
+  margin-inline: calc(-1 * var(--page-gutter));
   /* The homepage used to render the banner with no spacing at all, so its title sat right against the
      artwork. */
   margin-bottom: 40px;
@@ -77,11 +83,10 @@
     /* Above both artwork layers. */
     position: relative;
     z-index: 2;
-    /* Back onto the page's content: 24px is the page gutter the tabs, cards and filters start at. Once
-       the window is wide enough that the gutter would leave the copy stranded against the edge, it
-       follows the artwork instead - the same rule the marketplace uses, shifted by the 24px of page
-       padding this app does not have. */
-    padding-inline: max(24px, calc((100% - 1360px) / 2 - 24px));
+    /* Back onto the page's content line, where the tabs, cards and filters start. Once the window is wide
+       enough that the gutter would leave the copy stranded against the edge, it follows the artwork
+       instead - the same rule the marketplace uses, shifted by the gutter this app does not have. */
+    padding-inline: max(var(--page-gutter), calc((100% - 1360px) / 2 - var(--page-gutter)));
   }
 
   /* ui2 gives side aligned copy half of the banner, and now that the banner is as wide as the window that

--- a/src/components/CampaignBanner/CampaignBanner.module.css
+++ b/src/components/CampaignBanner/CampaignBanner.module.css
@@ -1,0 +1,92 @@
+/* Same treatment as the marketplace's CampaignBanner - the two apps show the same campaign artwork, so
+   they are meant to look alike; only the gutter differs, because this app indents its pages by 24px and
+   that one indents them twice.
+
+   The banner itself is Contentful artwork rendered by decentraland-ui2's <Banner>, so its box can only be
+   sized from the outside. Its emotion class names are hashed, so its parts are reached structurally:
+     .banner > div                    ui2's BannerContainer: a grid that paints the artwork as its background
+     .banner > div > div:not(:last-child)  its BackgroundSizer: an empty box carrying the artwork's own
+                                      aspect ratio, which is what gives the banner its height
+     .banner > div > :last-child      its Layout: the title, text and CTA, already padded by 2rem
+
+   The banner runs edge to edge, but the desktop artwork is only 1280px wide (the Shop campaign ships
+   `Web_1280x300.png`), and ui2 stretches it across the whole container: on a 2560px window that came out
+   2512x589, twice its native size, soft avatars and a banner taller than half the viewport. So the artwork
+   is NOT stretched to the full width any more. It is drawn near its native size, pinned to the right where
+   its subject is, and the space left of it is filled with a blurred copy of the same image - the sides read
+   as a continuation of the art instead of as a gap, and no colour has to be hardcoded here, because both
+   layers pick the URL up from the container with `background-image: inherit`. */
+
+.banner {
+  /* Out to the window edges. Both pages that show a banner sit inside a 24px page gutter - the homepage
+     from `.dcl.page.fullscreen` (index.css), the collections page from `.dcl.page.LoggedInDetailPage` -
+     and unlike the marketplace that gutter stays put on mobile, so this needs no breakpoint. */
+  margin-inline: -24px;
+  /* The homepage used to render the banner with no spacing at all, so its title sat right against the
+     artwork. */
+  margin-bottom: 40px;
+}
+
+.banner > div {
+  /* Containing block for the blurred layer below. The container already clips (`overflow: hidden`), which
+     is what keeps both the blur's soft edges and the mask inside the banner. */
+  position: relative;
+}
+
+/* The filler: the same artwork blurred out to fill the strip, so what shows beside the sharp copy is the
+   artwork's own colour and light rather than a flat panel. Two deliberate choices here:
+
+   - `600% 100%` rather than `cover`, which maps the WHOLE frame across the strip: on a very wide window
+     that put the blurred avatars just left of the sharp ones, reading as a ghost of the artwork. Six times
+     the width samples only the empty left sixth of the frame and stretches it across, so the filler
+     carries the art's light with none of its subject. The horizontal distortion that costs is free - the
+     layer is blurred past recognition anyway. The vertical scale stays 100%, so nothing is cropped.
+   - Not darkened: a brightness tweak makes the boundary with the sharp layer visible as a step. */
+.banner > div::before {
+  content: '';
+  position: absolute;
+  /* Overscanned, otherwise the blur fades into transparency at the edges of the strip. */
+  inset: -6%;
+  z-index: 0;
+  background-image: inherit;
+  background-size: 600% 100%;
+  background-position: left center;
+  filter: blur(32px);
+  pointer-events: none;
+}
+
+/* The sharp layer. The sizer's box is already exactly the artwork's aspect ratio, so `cover` fits the
+   image into it without cropping, and capping its width caps the banner's height with it: 1360px keeps
+   the upscale at 1.06x. Pinned right because the avatars and the coins live on that side of the frame;
+   its left edge is faded out so it melts into the blurred layer instead of ending on a seam. */
+.banner > div > div:not(:last-child) {
+  position: relative;
+  z-index: 1;
+  max-width: 1360px;
+  margin-left: auto;
+  margin-right: 0;
+  background-image: inherit;
+  background-size: cover;
+  background-position: center;
+  -webkit-mask-image: linear-gradient(to right, transparent, #000 140px);
+  mask-image: linear-gradient(to right, transparent, #000 140px);
+}
+
+@media (min-width: 768px) {
+  .banner > div > :last-child {
+    /* Above both artwork layers. */
+    position: relative;
+    z-index: 2;
+    /* Back onto the page's content: 24px is the page gutter the tabs, cards and filters start at. Once
+       the window is wide enough that the gutter would leave the copy stranded against the edge, it
+       follows the artwork instead - the same rule the marketplace uses, shifted by the 24px of page
+       padding this app does not have. */
+    padding-inline: max(24px, calc((100% - 1360px) / 2 - 24px));
+  }
+
+  /* ui2 gives side aligned copy half of the banner, and now that the banner is as wide as the window that
+     runs the paragraph across the artwork's subject. 620px is what the two lines need at this font size. */
+  .banner > div > :last-child > :first-child {
+    max-width: min(45%, 620px);
+  }
+}

--- a/src/components/CampaignBanner/CampaignBanner.tsx
+++ b/src/components/CampaignBanner/CampaignBanner.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Banner } from 'decentraland-dapps/dist/containers/Banner'
+import { Props } from './CampaignBanner.types'
+import styles from './CampaignBanner.module.css'
+
+// Layout wrapper for the Contentful driven campaign banner. Every page that shows one goes through here
+// so the artwork gets the same size, gutter and spacing on all of them.
+const CampaignBanner = ({ id }: Props) => (
+  <div className={styles.banner}>
+    <Banner id={id} />
+  </div>
+)
+
+export default React.memo(CampaignBanner)

--- a/src/components/CampaignBanner/CampaignBanner.types.ts
+++ b/src/components/CampaignBanner/CampaignBanner.types.ts
@@ -1,0 +1,4 @@
+export type Props = {
+  /** The admin entry field that holds the banner for this page, e.g. `builderCampaignBanner`. */
+  id: string
+}

--- a/src/components/CampaignBanner/index.ts
+++ b/src/components/CampaignBanner/index.ts
@@ -1,0 +1,2 @@
+import CampaignBanner from './CampaignBanner'
+export default CampaignBanner

--- a/src/components/CollectionsPage/CollectionsPage.css
+++ b/src/components/CollectionsPage/CollectionsPage.css
@@ -215,7 +215,3 @@
   flex-direction: row;
   gap: 8px;
 }
-
-.CollectionsPage .banner-container {
-  margin-bottom: 24px;
-}

--- a/src/components/CollectionsPage/CollectionsPage.tsx
+++ b/src/components/CollectionsPage/CollectionsPage.tsx
@@ -20,8 +20,8 @@ import {
   Icon as UIIcon
 } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
-import { Banner } from 'decentraland-dapps/dist/containers/Banner'
 import { NavigationTab } from 'components/Navigation/Navigation.types'
+import CampaignBanner from 'components/CampaignBanner'
 import LoggedInDetailPage from 'components/LoggedInDetailPage'
 import Icon from 'components/Icon'
 import Chip from 'components/Chip'
@@ -297,9 +297,7 @@ export default function CollectionsPage(props: Props) {
 
     return (
       <>
-        <div className="banner-container">
-          <Banner id={BUILDER_BANNER_ID} />
-        </div>
+        <CampaignBanner id={BUILDER_BANNER_ID} />
         <div className="filters">
           <Container>
             {(hasUserOrphanItems || isThirdPartyManager || isLinkedWearablesPaymentsEnabled) && (

--- a/src/components/HomePage/HomePage.tsx
+++ b/src/components/HomePage/HomePage.tsx
@@ -3,8 +3,8 @@ import { useHistory } from 'react-router-dom'
 import classNames from 'classnames'
 import { Button, Card, Container, Page } from 'decentraland-ui'
 import { getLocalStorage } from 'decentraland-dapps/dist/lib/localStorage'
-import { Banner } from 'decentraland-dapps/dist/containers/Banner'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
+import CampaignBanner from 'components/CampaignBanner'
 import Footer from 'components/Footer'
 import Navbar from 'components/Navbar'
 import LoadingPage from 'components/LoadingPage'
@@ -80,7 +80,7 @@ export const HomePage: React.FC<Props> = props => {
         <Navigation activeTab={NavigationTab.OVERVIEW}>
           <SyncToast />
         </Navigation>
-        <Banner id={BUILDER_BANNER_ID} />
+        <CampaignBanner id={BUILDER_BANNER_ID} />
         <Container>
           <h1 className="title">{t('home_page.title')}</h1>
           <Card.Group itemsPerRow={4} centered>


### PR DESCRIPTION
Same fix the marketplace just got (decentraland/marketplace#2703), applied here so both apps render the
shared campaign artwork the same way.

The banner had no layout of its own on the homepage - `<Banner>` was rendered bare, so the page title sat
right against the artwork - and on both pages ui2 stretched the artwork across the full width of the page
with a `cover` background sized by the asset's aspect ratio. Since the desktop art the Shop campaign ships
is 1280x300, the banner grew with the window and upscaled past the image: **2512x589** on a 2560px window,
twice its native size, and 3.8x on a 4945px one.

The banner now runs edge to edge, but the artwork is no longer stretched to get there.

## Changes

- New `CampaignBanner` component wrapping dapps' `<Banner>`, used by the homepage and the collections page,
  so the layout lives in one place. Replaces `.banner-container` on the collections page and gives the
  homepage the spacing it never had.
- The strip breaks out of the page's 24px gutter with `margin-inline: -24px` (not `100vw`, which would add
  a scrollbar notch on machines that show a classic scrollbar).
- The artwork is drawn on ui2's `BackgroundSizer` - the box that already carries the asset's own aspect
  ratio - capped at 1360px and pinned right, where the subject of the frame is. That keeps the upscale at
  1.06x and caps the banner's height at 319px without writing any of the asset's dimensions into the CSS.
- The space beside it is filled with a blurred copy of the same image. Both layers pick the URL up with
  `background-image: inherit`, so nothing about the current campaign is hardcoded here. The filler samples
  only the empty left sixth of the frame (`600% 100%`) rather than `cover`: mapping the whole frame across
  the strip put the blurred avatars just left of the sharp ones, which read as a ghost of the artwork.
- The sharp layer's left edge is faded with a `mask-image` gradient so it melts into the blurred layer
  instead of ending on a seam.
- The copy sits above both layers, on the 24px page gutter the tabs, cards and filters start at, and
  follows the artwork out once the window is wide enough to leave it stranded against the edge. Capped at
  `min(45%, 620px)` so the paragraph stops running over the avatars.

Worth knowing for whoever picks this up next: the sharpness ceiling is the asset. Even at 1360px, a retina
screen still renders it at roughly twice its pixels - a 2560x600 export would let us grow the artwork and
shrink the filler. And the CSS reaches into ui2's `<Banner>` markup structurally (the emotion class names
are hashed); if that markup changes, the banner degrades to its current look rather than breaking.

## Test plan

- [x] Homepage at 1440 / 2330 / 4945 px: banner spans the window, no horizontal overflow, copy on the page
      gutter at 1440 and following the artwork above it
- [x] Artwork rendered at 1360px (1.06x) instead of 2512px (1.96x) at 2560, height 319px instead of 589px
- [x] No visible seam between the sharp artwork and the blurred filler, and no recognisable ghost of the
      artwork beside it at very wide viewports
- [x] `npm run build:website`, `npx eslint`, `npx prettier -c`, `npx jest` (124/124 suites, 1607 tests)
- [ ] Collections page: same component and the same 24px page gutter (`.dcl.page.LoggedInDetailPage.CollectionsPage`),
      but it is behind sign in, so it was not screenshotted - worth a look on the preview deploy