### PR TITLE
fix: remove the broken "See in Decentraland" action from item menus

### DIFF
--- a/src/components/CollectionDetailPage/CollectionItem/CollectionItem.tsx
+++ b/src/components/CollectionDetailPage/CollectionItem/CollectionItem.tsx
@@ -76,10 +76,6 @@ export default function CollectionItem({
     onOpenModal('EditPriceAndBeneficiaryModal', { itemId: item.id })
   }, [item, onOpenModal])
 
-  const handleSeeInWorld = useCallback(() => {
-    onOpenModal('SeeInWorldModal', { itemIds: [item.id] })
-  }, [onOpenModal, item])
-
   const handleNavigateToEditor = useCallback(() => {
     onSetItems([item])
     history.push(locations.itemEditor({ itemId: item.id, collectionId: item.collectionId }), { fromParam: FromParam.COLLECTIONS })
@@ -101,7 +97,7 @@ export default function CollectionItem({
 
   const handleCopyURN = useCallback(() => {
     if (item.urn) {
-      navigator.clipboard.writeText(item.urn)
+      void navigator.clipboard.writeText(item.urn)
     }
   }, [item.urn])
 
@@ -219,7 +215,6 @@ export default function CollectionItem({
           <Dropdown.Menu className={styles.contextMenu}>
             <Dropdown.Item text={t('collection_item.see_details')} as={Link} to={locations.itemDetail(item.id)} />
             {item.urn && <Dropdown.Item text={t('collection_item.copy_urn')} onClick={handleCopyURN} />}
-            <Dropdown.Item text={t('collection_context_menu.see_in_decentraland')} onClick={handleSeeInWorld} />
             <Dropdown.Item text={t('collection_item.preview')} onClick={handleNavigateToEditor} />
             {!collection.isPublished && (
               <Dropdown.Item text={t('collection_item.move_to_another_collection')} onClick={handleMoveToAnotherCollection} />
@@ -247,7 +242,6 @@ export default function CollectionItem({
     item,
     ethAddress,
     handleCopyURN,
-    handleSeeInWorld,
     handleNavigateToEditor,
     handleMoveToAnotherCollection,
     handleEditPriceAndBeneficiary,

--- a/src/components/ThirdPartyCollectionDetailPage/CollectionItem/CollectionItem.tsx
+++ b/src/components/ThirdPartyCollectionDetailPage/CollectionItem/CollectionItem.tsx
@@ -24,10 +24,6 @@ export default function CollectionItem({ item, status, selected, onSelect, onOpe
     [item, onSelect]
   )
 
-  const handleSeeInWorld = useCallback(() => {
-    onOpenModal('SeeInWorldModal', { itemIds: [item.id] })
-  }, [item, onOpenModal])
-
   const handleEditURN = useCallback(() => {
     if (!item.isPublished) {
       onOpenModal('EditItemURNModal', { item })
@@ -109,7 +105,6 @@ export default function CollectionItem({ item, status, selected, onSelect, onOpe
             >
               <Dropdown.Menu>
                 <Dropdown.Item text={t('collection_item.see_details')} as={Link} to={locations.itemDetail(item.id)} />
-                <Dropdown.Item text={t('collection_context_menu.see_in_decentraland')} onClick={handleSeeInWorld} />
                 <Dropdown.Item text={t('global.open_in_editor')} onClick={handleNavigateToEditor} />
                 <Popup
                   content={t('collection_item.cannot_edit_urn')}

--- a/src/components/ThirdPartyCollectionDetailPage/CollectionItemV2/CollectionItemV2.tsx
+++ b/src/components/ThirdPartyCollectionDetailPage/CollectionItemV2/CollectionItemV2.tsx
@@ -82,10 +82,6 @@ export default function CollectionItemV2({
     [item, loading, onSelect]
   )
 
-  const handleSeeInWorld = useCallback(() => {
-    onOpenModal('SeeInWorldModal', { itemIds: [item.id] })
-  }, [item, onOpenModal])
-
   const handleEditURN = useCallback(() => {
     if (!item.isPublished) {
       onOpenModal('EditItemURNModal', { item })
@@ -139,7 +135,6 @@ export default function CollectionItemV2({
             >
               <Dropdown.Menu>
                 <Dropdown.Item text={t('collection_item.see_details')} as={Link} to={locations.itemDetail(item.id)} />
-                <Dropdown.Item text={t('collection_context_menu.see_in_decentraland')} onClick={handleSeeInWorld} />
                 <Dropdown.Item text={t('global.open_in_editor')} onClick={handleNavigateToEditor} />
                 <Popup
                   content={t('collection_item.cannot_edit_urn')}


### PR DESCRIPTION
## Why

Since the See in World modal moved to the desktop deep-link (#3412), it can only preview a whole collection. The item-level entry never passed the collection, so clicking "Jump in" closed the modal without launching anything. Removing the dead entry avoids a confusing no-op.

## What

- The per-item "See in Decentraland" entry is gone from the item context menu on the collection detail page and on both third-party collection item lists.
- The collection-level "See in Decentraland" button at the top of the page is unchanged and keeps working.

## How to test

1. Open a collection in the Builder and expand the actions menu of any item.
2. Confirm "See in Decentraland" is no longer listed; the remaining actions (see details, copy URN, preview, edit price, delete, ...) still work.
3. Click the collection-level "See in Decentraland" button at the top and confirm the modal still opens and launches the desktop client.

## Screenshots

https://github.com/user-attachments/assets/dcd8c69a-f7c1-44fe-b167-1d278d897190
